### PR TITLE
Fix docx table width

### DIFF
--- a/src/odr/internal/html/document_element.cpp
+++ b/src/odr/internal/html/document_element.cpp
@@ -367,26 +367,28 @@ void html::translate_table(Element element, HtmlWriter &out,
     for (Element cell : table_row.children()) {
       TableCell table_cell = cell.table_cell();
 
-      if (!table_cell.is_covered()) {
-        TableDimensions cell_span = table_cell.span();
-
-        out.write_element_begin(
-            "td",
-            HtmlElementOptions()
-                .set_attributes([&](const HtmlAttributeWriterCallback &clb) {
-                  if (cell_span.columns > 1) {
-                    clb("colspan", std::to_string(cell_span.columns));
-                  }
-                  if (cell_span.rows > 1) {
-                    clb("rowspan", std::to_string(cell_span.rows));
-                  }
-                })
-                .set_style(translate_table_cell_style(table_cell.style())));
-
-        translate_children(cell.children(), out, config);
-
-        out.write_element_end("td");
+      if (table_cell.is_covered()) {
+        continue;
       }
+
+      TableDimensions cell_span = table_cell.span();
+
+      out.write_element_begin(
+          "td",
+          HtmlElementOptions()
+              .set_attributes([&](const HtmlAttributeWriterCallback &clb) {
+                if (cell_span.columns > 1) {
+                  clb("colspan", std::to_string(cell_span.columns));
+                }
+                if (cell_span.rows > 1) {
+                  clb("rowspan", std::to_string(cell_span.rows));
+                }
+              })
+              .set_style(translate_table_cell_style(table_cell.style())));
+
+      translate_children(cell.children(), out, config);
+
+      out.write_element_end("td");
     }
 
     out.write_element_end("tr");

--- a/src/odr/internal/ooxml/ooxml_util.cpp
+++ b/src/odr/internal/ooxml/ooxml_util.cpp
@@ -3,8 +3,8 @@
 #include <odr/internal/abstract/filesystem.hpp>
 #include <odr/internal/common/path.hpp>
 #include <odr/internal/html/common.hpp>
-#include <odr/internal/util/xml_util.hpp>
 #include <odr/internal/util/string_util.hpp>
+#include <odr/internal/util/xml_util.hpp>
 
 #include <cstring>
 

--- a/src/odr/internal/ooxml/ooxml_util.cpp
+++ b/src/odr/internal/ooxml/ooxml_util.cpp
@@ -4,6 +4,7 @@
 #include <odr/internal/common/path.hpp>
 #include <odr/internal/html/common.hpp>
 #include <odr/internal/util/xml_util.hpp>
+#include <odr/internal/util/string_util.hpp>
 
 #include <cstring>
 
@@ -50,7 +51,7 @@ ooxml::read_half_point_attribute(pugi::xml_attribute attribute) {
   if (!attribute) {
     return {};
   }
-  return Measure(attribute.as_float() * 0.5f, DynamicUnit("pt"));
+  return Measure(attribute.as_double() * 0.5, DynamicUnit("pt"));
 }
 
 std::optional<Measure>
@@ -58,7 +59,7 @@ ooxml::read_hundredth_point_attribute(pugi::xml_attribute attribute) {
   if (!attribute) {
     return {};
   }
-  return Measure(attribute.as_float() * 0.01f, DynamicUnit("pt"));
+  return Measure(attribute.as_double() * 0.01, DynamicUnit("pt"));
 }
 
 std::optional<Measure>
@@ -66,7 +67,7 @@ ooxml::read_emus_attribute(pugi::xml_attribute attribute) {
   if (!attribute) {
     return {};
   }
-  return Measure(attribute.as_float() / 914400.0f, DynamicUnit("in"));
+  return Measure(attribute.as_double() / 914400.0, DynamicUnit("in"));
 }
 
 std::optional<Measure>
@@ -74,7 +75,28 @@ ooxml::read_twips_attribute(pugi::xml_attribute attribute) {
   if (!attribute) {
     return {};
   }
-  return Measure(attribute.as_float() / 1440.0f, DynamicUnit("in"));
+  return Measure(attribute.as_double() / 1440.0, DynamicUnit("in"));
+}
+
+std::optional<Measure>
+ooxml::read_pct_attribute(pugi::xml_attribute attribute) {
+  if (!attribute) {
+    return {};
+  }
+
+  // handle percentage which is not always a percentage for tables
+  // http://officeopenxml.com/WPtableWidth.php
+  // potentially this should be moved to a table parser
+
+  std::string val = attribute.value();
+  util::string::trim(val);
+
+  if (val.find('%') != std::string::npos) {
+    util::string::replace_all(val, "%", "");
+    return Measure(std::stod(val), DynamicUnit("%"));
+  }
+
+  return Measure(attribute.as_double() / 50.0, DynamicUnit("%"));
 }
 
 std::optional<Measure> ooxml::read_width_attribute(pugi::xml_node node) {
@@ -92,7 +114,7 @@ std::optional<Measure> ooxml::read_width_attribute(pugi::xml_node node) {
     return Measure(0, DynamicUnit(""));
   }
   if (std::strcmp("pct", type) == 0) {
-    return Measure(node.attribute("w:w").as_float(), DynamicUnit("%"));
+    return read_pct_attribute(node.attribute("w:w"));
   }
   return {};
 }

--- a/src/odr/internal/ooxml/ooxml_util.hpp
+++ b/src/odr/internal/ooxml/ooxml_util.hpp
@@ -33,6 +33,7 @@ std::optional<Measure> read_half_point_attribute(pugi::xml_attribute);
 std::optional<Measure> read_hundredth_point_attribute(pugi::xml_attribute);
 std::optional<Measure> read_emus_attribute(pugi::xml_attribute);
 std::optional<Measure> read_twips_attribute(pugi::xml_attribute);
+std::optional<Measure> read_pct_attribute(pugi::xml_attribute);
 std::optional<Measure> read_width_attribute(pugi::xml_node);
 bool read_line_attribute(pugi::xml_attribute);
 bool read_line_attribute(pugi::xml_node);

--- a/src/odr/internal/util/string_util.cpp
+++ b/src/odr/internal/util/string_util.cpp
@@ -1,5 +1,7 @@
 #include <odr/internal/util/string_util.hpp>
 
+#include <algorithm>
+#include <cctype>
 #include <codecvt>
 #include <iomanip>
 #include <locale>
@@ -15,6 +17,24 @@ bool string::ends_with(const std::string &string, const std::string &with) {
   return (string.length() >= with.length()) &&
          (string.compare(string.length() - with.length(), with.length(),
                          with) == 0);
+}
+
+void string::ltrim(std::string &s) {
+  s.erase(s.begin(), std::find_if(s.begin(), s.end(), [](unsigned char ch) {
+            return !std::isspace(ch);
+          }));
+}
+
+void string::rtrim(std::string &s) {
+  s.erase(std::find_if(s.rbegin(), s.rend(),
+                       [](unsigned char ch) { return !std::isspace(ch); })
+              .base(),
+          s.end());
+}
+
+void string::trim(std::string &s) {
+  rtrim(s);
+  ltrim(s);
 }
 
 void string::replace_all(std::string &string, const std::string &search,

--- a/src/odr/internal/util/string_util.hpp
+++ b/src/odr/internal/util/string_util.hpp
@@ -9,8 +9,14 @@
 namespace odr::internal::util::string {
 bool starts_with(const std::string &string, const std::string &with);
 bool ends_with(const std::string &string, const std::string &with);
+
+void ltrim(std::string &s);
+void rtrim(std::string &s);
+void trim(std::string &s);
+
 void replace_all(std::string &string, const std::string &search,
                  const std::string &replace);
+
 void split(const std::string &string, const std::string &delimiter,
            std::function<void(const std::string &)> callback);
 std::vector<std::string> split(const std::string &string,


### PR DESCRIPTION
Apparently percent does not always mean percent but rather 1/50 percent as described here http://officeopenxml.com/WPtableWidth.php. I changed this for all `pct` parsing which might not generalize and has to be changed in the future. This was the easiest solution for now and a 50:50 shot that it might generalize.

fixes
- https://github.com/opendocument-app/OpenDocument.droid/issues/354