### PR TITLE
feat: html service

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -60,6 +60,7 @@ set(ODR_SOURCE_FILES
         "src/odr/file.cpp"
         "src/odr/filesystem.cpp"
         "src/odr/html.cpp"
+        "src/odr/html_service.cpp"
         "src/odr/open_document_reader.cpp"
         "src/odr/quantity.cpp"
         "src/odr/style.cpp"

--- a/src/odr/html_service.cpp
+++ b/src/odr/html_service.cpp
@@ -1,0 +1,30 @@
+#include <odr/html_service.hpp>
+
+#include <odr/internal/abstract/html_service.hpp>
+
+namespace odr {
+
+HtmlService::HtmlService(std::shared_ptr<internal::abstract::HtmlService> impl)
+    : m_impl{std::move(impl)} {}
+
+std::vector<HtmlFragment> HtmlService::fragments() const {
+  std::vector<HtmlFragment> result;
+  for (const auto &fragment : m_impl->fragments()) {
+    result.emplace_back(fragment);
+  }
+  return result;
+}
+
+HtmlFragment::HtmlFragment(
+    std::shared_ptr<internal::abstract::HtmlFragment> impl)
+    : m_impl{std::move(impl)} {}
+
+std::string HtmlFragment::name() const { return m_impl->name(); }
+
+void HtmlFragment::write_html_fragment(
+    std::ostream &os, const odr::HtmlConfig &config,
+    const odr::HtmlResourceLocator &resourceLocator) const {
+  m_impl->write_html_fragment(os, config, resourceLocator);
+}
+
+} // namespace odr

--- a/src/odr/html_service.cpp
+++ b/src/odr/html_service.cpp
@@ -1,6 +1,7 @@
 #include <odr/html_service.hpp>
 
 #include <odr/internal/abstract/html_service.hpp>
+#include <odr/internal/html/html_writer.hpp>
 
 #include <iostream>
 
@@ -26,7 +27,9 @@ std::string HtmlFragment::name() const { return m_impl->name(); }
 void HtmlFragment::write_html_fragment(
     std::ostream &os, const odr::HtmlConfig &config,
     const odr::HtmlResourceLocator &resourceLocator) const {
-  m_impl->write_html_fragment(os, config, resourceLocator);
+  internal::html::HtmlWriter out(os, config);
+
+  m_impl->write_html_fragment(out, config, resourceLocator);
 }
 
 } // namespace odr

--- a/src/odr/html_service.cpp
+++ b/src/odr/html_service.cpp
@@ -2,6 +2,8 @@
 
 #include <odr/internal/abstract/html_service.hpp>
 
+#include <iostream>
+
 namespace odr {
 
 HtmlService::HtmlService(std::shared_ptr<internal::abstract::HtmlService> impl)

--- a/src/odr/html_service.hpp
+++ b/src/odr/html_service.hpp
@@ -2,6 +2,10 @@
 #define ODR_HTML_SERVICE_HPP
 
 #include <functional>
+#include <iosfwd>
+#include <memory>
+#include <optional>
+#include <string>
 #include <vector>
 
 namespace odr::internal::abstract {

--- a/src/odr/html_service.hpp
+++ b/src/odr/html_service.hpp
@@ -1,0 +1,55 @@
+#ifndef ODR_HTML_SERVICE_HPP
+#define ODR_HTML_SERVICE_HPP
+
+#include <functional>
+#include <vector>
+
+namespace odr::internal::abstract {
+class HtmlService;
+class HtmlFragment;
+} // namespace odr::internal::abstract
+
+namespace odr {
+enum class FileType;
+class File;
+struct HtmlConfig;
+
+class HtmlFragment;
+
+enum class HtmlResourceType {
+  css,
+  js,
+  image,
+};
+
+using HtmlResourceLocation = std::optional<std::string>;
+using HtmlResourceLocator = std::function<HtmlResourceLocation(
+    HtmlResourceType type, const std::string &name, const std::string &path,
+    const File &resource, bool is_core_resource)>;
+
+class HtmlService final {
+public:
+  explicit HtmlService(std::shared_ptr<internal::abstract::HtmlService> impl);
+
+  [[nodiscard]] std::vector<HtmlFragment> fragments() const;
+
+private:
+  std::shared_ptr<internal::abstract::HtmlService> m_impl;
+};
+
+class HtmlFragment final {
+public:
+  explicit HtmlFragment(std::shared_ptr<internal::abstract::HtmlFragment> impl);
+
+  [[nodiscard]] std::string name() const;
+
+  void write_html_fragment(std::ostream &os, const HtmlConfig &config,
+                           const HtmlResourceLocator &resourceLocator) const;
+
+private:
+  std::shared_ptr<internal::abstract::HtmlFragment> m_impl;
+};
+
+} // namespace odr
+
+#endif // ODR_HTML_SERVICE_HPP

--- a/src/odr/internal/abstract/html_service.hpp
+++ b/src/odr/internal/abstract/html_service.hpp
@@ -6,6 +6,10 @@
 #include <iosfwd>
 #include <memory>
 
+namespace odr::internal::html {
+class HtmlWriter;
+}
+
 namespace odr::internal::abstract {
 class File;
 class HtmlFragment;
@@ -25,7 +29,7 @@ public:
   [[nodiscard]] virtual std::string name() const = 0;
 
   virtual void
-  write_html_fragment(std::ostream &os, const HtmlConfig &config,
+  write_html_fragment(html::HtmlWriter &out, const HtmlConfig &config,
                       const HtmlResourceLocator &resourceLocator) const = 0;
 };
 

--- a/src/odr/internal/abstract/html_service.hpp
+++ b/src/odr/internal/abstract/html_service.hpp
@@ -1,0 +1,34 @@
+#ifndef ODR_INTERNAL_ABSTRACT_HTML_SERVICE_HPP
+#define ODR_INTERNAL_ABSTRACT_HTML_SERVICE_HPP
+
+#include <odr/html_service.hpp>
+
+#include <iosfwd>
+#include <memory>
+
+namespace odr::internal::abstract {
+class File;
+class HtmlFragment;
+
+class HtmlService {
+public:
+  virtual ~HtmlService() = default;
+
+  [[nodiscard]] virtual const std::vector<std::shared_ptr<HtmlFragment>> &
+  fragments() const = 0;
+};
+
+class HtmlFragment {
+public:
+  virtual ~HtmlFragment() = default;
+
+  [[nodiscard]] virtual std::string name() const = 0;
+
+  virtual void
+  write_html_fragment(std::ostream &os, const HtmlConfig &config,
+                      const HtmlResourceLocator &resourceLocator) const = 0;
+};
+
+} // namespace odr::internal::abstract
+
+#endif // ODR_INTERNAL_ABSTRACT_HTML_SERVICE_HPP

--- a/src/odr/internal/cfb/cfb_archive.cpp
+++ b/src/odr/internal/cfb/cfb_archive.cpp
@@ -32,6 +32,10 @@ std::shared_ptr<abstract::Filesystem> CfbArchive::filesystem() const {
   return filesystem;
 }
 
-void CfbArchive::save(std::ostream &out) const { throw UnsupportedOperation(); }
+void CfbArchive::save(std::ostream &out) const {
+  (void)out;
+
+  throw UnsupportedOperation();
+}
 
 } // namespace odr::internal::cfb

--- a/src/odr/internal/html/common.cpp
+++ b/src/odr/internal/html/common.cpp
@@ -67,7 +67,8 @@ HtmlResourceLocator html::local_resource_locator(const std::string &output_path,
     (void)type;
     (void)name;
 
-    if (config.embed_resources) {
+    // TODO remove `!is_core_resource` check after supporting external resources
+    if (config.embed_resources || !is_core_resource) {
       return std::nullopt;
     }
 

--- a/src/odr/internal/html/common.cpp
+++ b/src/odr/internal/html/common.cpp
@@ -1,12 +1,14 @@
 #include <odr/internal/html/common.hpp>
 
 #include <odr/internal/abstract/file.hpp>
+#include <odr/internal/common/path.hpp>
 #include <odr/internal/crypto/crypto_util.hpp>
 #include <odr/internal/util/stream_util.hpp>
 #include <odr/internal/util/string_util.hpp>
 
 #include <odr/html.hpp>
 
+#include <fstream>
 #include <iomanip>
 #include <iostream>
 #include <sstream>
@@ -55,6 +57,34 @@ std::string html::file_to_url(std::istream &file, const std::string &mimeType) {
 std::string html::file_to_url(const abstract::File &file,
                               const std::string &mimeType) {
   return file_to_url(*file.stream(), mimeType);
+}
+
+HtmlResourceLocator html::local_resource_locator(const std::string &output_path,
+                                                 const HtmlConfig &config) {
+  return [&](HtmlResourceType type, const std::string &name,
+             const std::string &path, const File &resource,
+             bool is_core_resource) -> HtmlResourceLocation {
+    if (config.embed_resources) {
+      return std::nullopt;
+    }
+
+    if (is_core_resource && !config.external_resource_path.empty()) {
+      auto resource_path =
+          common::Path(config.external_resource_path).join(path);
+      if (config.relative_resource_paths) {
+        resource_path = resource_path.rebase(output_path);
+      }
+      return resource_path.string();
+    }
+
+    // TODO relocate file if necessary
+
+    auto resource_path = common::Path(output_path).join(path);
+    std::filesystem::create_directories(resource_path.parent().path());
+    std::ofstream os(resource_path.path());
+    util::stream::pipe(*resource.stream(), os);
+    return path;
+  };
 }
 
 } // namespace odr::internal

--- a/src/odr/internal/html/common.cpp
+++ b/src/odr/internal/html/common.cpp
@@ -64,6 +64,9 @@ HtmlResourceLocator html::local_resource_locator(const std::string &output_path,
   return [&](HtmlResourceType type, const std::string &name,
              const std::string &path, const File &resource,
              bool is_core_resource) -> HtmlResourceLocation {
+    (void)type;
+    (void)name;
+
     if (config.embed_resources) {
       return std::nullopt;
     }

--- a/src/odr/internal/html/common.hpp
+++ b/src/odr/internal/html/common.hpp
@@ -4,9 +4,13 @@
 #include <iosfwd>
 #include <string>
 
+#include <odr/html_service.hpp>
+#include <odr/internal/abstract/html_service.hpp>
+
 namespace odr {
 struct Color;
 struct HtmlConfig;
+class Html;
 } // namespace odr
 
 namespace odr::internal::abstract {
@@ -23,6 +27,24 @@ std::string file_to_url(const std::string &file, const std::string &mimeType);
 std::string file_to_url(std::istream &file, const std::string &mimeType);
 std::string file_to_url(const abstract::File &file,
                         const std::string &mimeType);
+
+HtmlResourceLocator local_resource_locator(const std::string &output_path,
+                                           const HtmlConfig &config);
+
+class StaticHtmlService : public abstract::HtmlService {
+public:
+  explicit StaticHtmlService(
+      std::vector<std::shared_ptr<abstract::HtmlFragment>> fragments)
+      : m_fragments(std::move(fragments)) {}
+
+  [[nodiscard]] const std::vector<std::shared_ptr<abstract::HtmlFragment>> &
+  fragments() const override {
+    return m_fragments;
+  }
+
+private:
+  const std::vector<std::shared_ptr<abstract::HtmlFragment>> m_fragments;
+};
 
 } // namespace odr::internal::html
 

--- a/src/odr/internal/html/document.cpp
+++ b/src/odr/internal/html/document.cpp
@@ -30,10 +30,8 @@ public:
   [[nodiscard]] std::string name() const final { return "document"; }
 
   void
-  write_html_fragment(std::ostream &os, const HtmlConfig &config,
+  write_html_fragment(HtmlWriter &out, const HtmlConfig &config,
                       const HtmlResourceLocator &resourceLocator) const final {
-    HtmlWriter out(os, config);
-
     auto root = m_document.root_element();
     auto element = root.text_root();
 
@@ -71,10 +69,8 @@ public:
   [[nodiscard]] std::string name() const final { return m_slide.name(); }
 
   void
-  write_html_fragment(std::ostream &os, const HtmlConfig &config,
+  write_html_fragment(HtmlWriter &out, const HtmlConfig &config,
                       const HtmlResourceLocator &resourceLocator) const final {
-    HtmlWriter out(os, config);
-
     internal::html::translate_slide(m_slide, out, config);
   }
 
@@ -91,10 +87,8 @@ public:
   [[nodiscard]] std::string name() const final { return m_sheet.name(); }
 
   void
-  write_html_fragment(std::ostream &os, const HtmlConfig &config,
+  write_html_fragment(HtmlWriter &out, const HtmlConfig &config,
                       const HtmlResourceLocator &resourceLocator) const final {
-    HtmlWriter out(os, config);
-
     translate_sheet(m_sheet, out, config);
   }
 
@@ -111,10 +105,8 @@ public:
   [[nodiscard]] std::string name() const final { return m_page.name(); }
 
   void
-  write_html_fragment(std::ostream &os, const HtmlConfig &config,
+  write_html_fragment(HtmlWriter &out, const HtmlConfig &config,
                       const HtmlResourceLocator &resourceLocator) const final {
-    HtmlWriter out(os, config);
-
     internal::html::translate_page(m_page, out, config);
   }
 

--- a/src/odr/internal/html/document.cpp
+++ b/src/odr/internal/html/document.cpp
@@ -46,13 +46,13 @@ public:
                               HtmlElementOptions().set_style(
                                   translate_inner_page_style(page_layout)));
 
-      translate_children(element.children(), out, config);
+      translate_children(element.children(), out, config, resourceLocator);
 
       out.write_element_end("div");
       out.write_element_end("div");
     } else {
       out.write_element_begin("div");
-      translate_children(element.children(), out, config);
+      translate_children(element.children(), out, config, resourceLocator);
       out.write_element_end("div");
     }
   }
@@ -71,7 +71,7 @@ public:
   void
   write_html_fragment(HtmlWriter &out, const HtmlConfig &config,
                       const HtmlResourceLocator &resourceLocator) const final {
-    internal::html::translate_slide(m_slide, out, config);
+    internal::html::translate_slide(m_slide, out, config, resourceLocator);
   }
 
 private:
@@ -89,7 +89,7 @@ public:
   void
   write_html_fragment(HtmlWriter &out, const HtmlConfig &config,
                       const HtmlResourceLocator &resourceLocator) const final {
-    translate_sheet(m_sheet, out, config);
+    translate_sheet(m_sheet, out, config, resourceLocator);
   }
 
 private:
@@ -107,7 +107,7 @@ public:
   void
   write_html_fragment(HtmlWriter &out, const HtmlConfig &config,
                       const HtmlResourceLocator &resourceLocator) const final {
-    internal::html::translate_page(m_page, out, config);
+    internal::html::translate_page(m_page, out, config, resourceLocator);
   }
 
 private:

--- a/src/odr/internal/html/document.hpp
+++ b/src/odr/internal/html/document.hpp
@@ -5,28 +5,18 @@
 
 namespace odr {
 class Document;
-
 struct HtmlConfig;
 class Html;
+class HtmlService;
 } // namespace odr
 
 namespace odr::internal::html {
 
+HtmlService translate_document(const Document &document);
+
 Html translate_document(const Document &document,
                         const std::string &output_path,
                         const HtmlConfig &config);
-
-Html translate_text_document(const Document &document,
-                             const std::string &output_path,
-                             const HtmlConfig &config);
-Html translate_presentation(const Document &document,
-                            const std::string &output_path,
-                            const HtmlConfig &config);
-Html translate_spreadsheet(const Document &document,
-                           const std::string &output_path,
-                           const HtmlConfig &config);
-Html translate_drawing(const Document &document, const std::string &output_path,
-                       const HtmlConfig &config);
 
 } // namespace odr::internal::html
 

--- a/src/odr/internal/html/document_element.cpp
+++ b/src/odr/internal/html/document_element.cpp
@@ -58,10 +58,8 @@ void html::translate_element(Element element, HtmlWriter &out,
   }
 }
 
-void html::translate_sheet(Element element, HtmlWriter &out,
+void html::translate_sheet(Sheet sheet, HtmlWriter &out,
                            const HtmlConfig &config) {
-  Sheet sheet = element.sheet();
-
   out.write_element_begin(
       "table",
       HtmlElementOptions().set_attributes(HtmlAttributesVector{
@@ -188,10 +186,8 @@ void html::translate_sheet(Element element, HtmlWriter &out,
   out.write_element_end("table");
 }
 
-void html::translate_slide(Element element, HtmlWriter &out,
+void html::translate_slide(Slide slide, HtmlWriter &out,
                            const HtmlConfig &config) {
-  Slide slide = element.slide();
-
   out.write_element_begin("div",
                           HtmlElementOptions().set_style(
                               translate_outer_page_style(slide.page_layout())));
@@ -206,10 +202,8 @@ void html::translate_slide(Element element, HtmlWriter &out,
   out.write_element_end("div");
 }
 
-void html::translate_page(Element element, HtmlWriter &out,
+void html::translate_page(Page page, HtmlWriter &out,
                           const HtmlConfig &config) {
-  Page page = element.page();
-
   out.write_element_begin("div",
                           HtmlElementOptions().set_style(
                               translate_outer_page_style(page.page_layout())));
@@ -222,9 +216,9 @@ void html::translate_page(Element element, HtmlWriter &out,
   out.write_element_end("div");
 }
 
-void html::translate_master_page(MasterPage element, HtmlWriter &out,
+void html::translate_master_page(MasterPage masterPage, HtmlWriter &out,
                                  const HtmlConfig &config) {
-  for (Element child : element.children()) {
+  for (Element child : masterPage.children()) {
     // TODO filter placeholders
     translate_element(child, out, config);
   }

--- a/src/odr/internal/html/document_element.cpp
+++ b/src/odr/internal/html/document_element.cpp
@@ -427,7 +427,7 @@ void html::translate_image(Element element, HtmlWriter &out,
           .set_attributes([&](const HtmlAttributeWriterCallback &clb) {
             clb("alt", "Error: image not found or unsupported");
             if (resourceLocation.has_value()) {
-              clb("src", image.href());
+              clb("src", resourceLocation.value());
             } else {
               clb("src", [&](std::ostream &o) {
                 translate_image_src(image.file().value(), o, config);

--- a/src/odr/internal/html/document_element.cpp
+++ b/src/odr/internal/html/document_element.cpp
@@ -13,53 +13,56 @@
 namespace odr::internal {
 
 void html::translate_children(ElementRange range, HtmlWriter &out,
-                              const HtmlConfig &config) {
+                              const HtmlConfig &config,
+                              const HtmlResourceLocator &resourceLocator) {
   for (Element child : range) {
-    translate_element(child, out, config);
+    translate_element(child, out, config, resourceLocator);
   }
 }
 
 void html::translate_element(Element element, HtmlWriter &out,
-                             const HtmlConfig &config) {
+                             const HtmlConfig &config,
+                             const HtmlResourceLocator &resourceLocator) {
   if (element.type() == ElementType::text) {
-    translate_text(element, out, config);
+    translate_text(element, out, config, resourceLocator);
   } else if (element.type() == ElementType::line_break) {
-    translate_line_break(element, out, config);
+    translate_line_break(element, out, config, resourceLocator);
   } else if (element.type() == ElementType::paragraph) {
-    translate_paragraph(element, out, config);
+    translate_paragraph(element, out, config, resourceLocator);
   } else if (element.type() == ElementType::span) {
-    translate_span(element, out, config);
+    translate_span(element, out, config, resourceLocator);
   } else if (element.type() == ElementType::link) {
-    translate_link(element, out, config);
+    translate_link(element, out, config, resourceLocator);
   } else if (element.type() == ElementType::bookmark) {
-    translate_bookmark(element, out, config);
+    translate_bookmark(element, out, config, resourceLocator);
   } else if (element.type() == ElementType::list) {
-    translate_list(element, out, config);
+    translate_list(element, out, config, resourceLocator);
   } else if (element.type() == ElementType::list_item) {
-    translate_list_item(element, out, config);
+    translate_list_item(element, out, config, resourceLocator);
   } else if (element.type() == ElementType::table) {
-    translate_table(element, out, config);
+    translate_table(element, out, config, resourceLocator);
   } else if (element.type() == ElementType::frame) {
-    translate_frame(element, out, config);
+    translate_frame(element, out, config, resourceLocator);
   } else if (element.type() == ElementType::image) {
-    translate_image(element, out, config);
+    translate_image(element, out, config, resourceLocator);
   } else if (element.type() == ElementType::rect) {
-    translate_rect(element, out, config);
+    translate_rect(element, out, config, resourceLocator);
   } else if (element.type() == ElementType::line) {
-    translate_line(element, out, config);
+    translate_line(element, out, config, resourceLocator);
   } else if (element.type() == ElementType::circle) {
-    translate_circle(element, out, config);
+    translate_circle(element, out, config, resourceLocator);
   } else if (element.type() == ElementType::custom_shape) {
-    translate_custom_shape(element, out, config);
+    translate_custom_shape(element, out, config, resourceLocator);
   } else if (element.type() == ElementType::group) {
-    translate_children(element.children(), out, config);
+    translate_children(element.children(), out, config, resourceLocator);
   } else {
     // TODO log
   }
 }
 
 void html::translate_sheet(Sheet sheet, HtmlWriter &out,
-                           const HtmlConfig &config) {
+                           const HtmlConfig &config,
+                           const HtmlResourceLocator &resourceLocator) {
   out.write_element_begin(
       "table",
       HtmlElementOptions().set_attributes(HtmlAttributesVector{
@@ -169,10 +172,10 @@ void html::translate_sheet(Sheet sheet, HtmlWriter &out,
               }()));
       if ((column_index == 0) && (row_index == 0)) {
         for (Element shape : sheet.shapes()) {
-          translate_element(shape, out, config);
+          translate_element(shape, out, config, resourceLocator);
         }
       }
-      translate_children(cell.children(), out, config);
+      translate_children(cell.children(), out, config, resourceLocator);
       out.write_element_end("td");
 
       cursor.add_cell(cell_span.columns, cell_span.rows);
@@ -187,7 +190,8 @@ void html::translate_sheet(Sheet sheet, HtmlWriter &out,
 }
 
 void html::translate_slide(Slide slide, HtmlWriter &out,
-                           const HtmlConfig &config) {
+                           const HtmlConfig &config,
+                           const HtmlResourceLocator &resourceLocator) {
   out.write_element_begin("div",
                           HtmlElementOptions().set_style(
                               translate_outer_page_style(slide.page_layout())));
@@ -195,37 +199,39 @@ void html::translate_slide(Slide slide, HtmlWriter &out,
                           HtmlElementOptions().set_style(
                               translate_inner_page_style(slide.page_layout())));
 
-  translate_master_page(slide.master_page(), out, config);
-  translate_children(slide.children(), out, config);
+  translate_master_page(slide.master_page(), out, config, resourceLocator);
+  translate_children(slide.children(), out, config, resourceLocator);
 
   out.write_element_end("div");
   out.write_element_end("div");
 }
 
-void html::translate_page(Page page, HtmlWriter &out,
-                          const HtmlConfig &config) {
+void html::translate_page(Page page, HtmlWriter &out, const HtmlConfig &config,
+                          const HtmlResourceLocator &resourceLocator) {
   out.write_element_begin("div",
                           HtmlElementOptions().set_style(
                               translate_outer_page_style(page.page_layout())));
   out.write_element_begin("div",
                           HtmlElementOptions().set_style(
                               translate_inner_page_style(page.page_layout())));
-  translate_master_page(page.master_page(), out, config);
-  translate_children(page.children(), out, config);
+  translate_master_page(page.master_page(), out, config, resourceLocator);
+  translate_children(page.children(), out, config, resourceLocator);
   out.write_element_end("div");
   out.write_element_end("div");
 }
 
 void html::translate_master_page(MasterPage masterPage, HtmlWriter &out,
-                                 const HtmlConfig &config) {
+                                 const HtmlConfig &config,
+                                 const HtmlResourceLocator &resourceLocator) {
   for (Element child : masterPage.children()) {
     // TODO filter placeholders
-    translate_element(child, out, config);
+    translate_element(child, out, config, resourceLocator);
   }
 }
 
 void html::translate_text(const Element element, HtmlWriter &out,
-                          const HtmlConfig &config) {
+                          const HtmlConfig &config,
+                          const HtmlResourceLocator &resourceLocator) {
   Text text = element.text();
 
   out.write_element_begin(
@@ -244,7 +250,10 @@ void html::translate_text(const Element element, HtmlWriter &out,
 }
 
 void html::translate_line_break(Element element, HtmlWriter &out,
-                                const HtmlConfig &) {
+                                const HtmlConfig &config,
+                                const HtmlResourceLocator &resourceLocator) {
+  (void)config;
+
   LineBreak line_break = element.line_break();
 
   out.write_element_begin(
@@ -256,14 +265,15 @@ void html::translate_line_break(Element element, HtmlWriter &out,
 }
 
 void html::translate_paragraph(Element element, HtmlWriter &out,
-                               const HtmlConfig &config) {
+                               const HtmlConfig &config,
+                               const HtmlResourceLocator &resourceLocator) {
   Paragraph paragraph = element.paragraph();
 
   out.write_element_begin(
       "x-p",
       HtmlElementOptions().set_inline(true).set_style(
           "display:block;" + translate_paragraph_style(paragraph.style())));
-  translate_children(paragraph.children(), out, config);
+  translate_children(paragraph.children(), out, config, resourceLocator);
   if (paragraph.first_child()) {
     // TODO if element is content (e.g. bookmark does not count)
 
@@ -283,29 +293,32 @@ void html::translate_paragraph(Element element, HtmlWriter &out,
 }
 
 void html::translate_span(Element element, HtmlWriter &out,
-                          const HtmlConfig &config) {
+                          const HtmlConfig &config,
+                          const HtmlResourceLocator &resourceLocator) {
   Span span = element.span();
 
   out.write_element_begin("x-s",
                           HtmlElementOptions().set_inline(true).set_style(
                               translate_text_style(span.style())));
-  translate_children(span.children(), out, config);
+  translate_children(span.children(), out, config, resourceLocator);
   out.write_element_end("x-s");
 }
 
 void html::translate_link(Element element, HtmlWriter &out,
-                          const HtmlConfig &config) {
+                          const HtmlConfig &config,
+                          const HtmlResourceLocator &resourceLocator) {
   Link link = element.link();
 
   out.write_element_begin("a",
                           HtmlElementOptions().set_inline(true).set_attributes(
                               HtmlAttributesVector{{"href", link.href()}}));
-  translate_children(link.children(), out, config);
+  translate_children(link.children(), out, config, resourceLocator);
   out.write_element_end("a");
 }
 
 void html::translate_bookmark(Element element, HtmlWriter &out,
-                              const HtmlConfig & /*config*/) {
+                              const HtmlConfig &config,
+                              const HtmlResourceLocator &resourceLocator) {
   Bookmark bookmark = element.bookmark();
 
   out.write_element_begin("a",
@@ -315,24 +328,27 @@ void html::translate_bookmark(Element element, HtmlWriter &out,
 }
 
 void html::translate_list(Element element, HtmlWriter &out,
-                          const HtmlConfig &config) {
+                          const HtmlConfig &config,
+                          const HtmlResourceLocator &resourceLocator) {
   out.write_element_begin("ul");
-  translate_children(element.children(), out, config);
+  translate_children(element.children(), out, config, resourceLocator);
   out.write_element_end("ul");
 }
 
 void html::translate_list_item(Element element, HtmlWriter &out,
-                               const HtmlConfig &config) {
+                               const HtmlConfig &config,
+                               const HtmlResourceLocator &resourceLocator) {
   ListItem list_item = element.list_item();
 
   out.write_element_begin("li", HtmlElementOptions().set_style(
                                     translate_text_style(list_item.style())));
-  translate_children(list_item.children(), out, config);
+  translate_children(list_item.children(), out, config, resourceLocator);
   out.write_element_end("li");
 }
 
 void html::translate_table(Element element, HtmlWriter &out,
-                           const HtmlConfig &config) {
+                           const HtmlConfig &config,
+                           const HtmlResourceLocator &resourceLocator) {
   Table table = element.table();
 
   out.write_element_begin(
@@ -380,7 +396,7 @@ void html::translate_table(Element element, HtmlWriter &out,
               })
               .set_style(translate_table_cell_style(table_cell.style())));
 
-      translate_children(cell.children(), out, config);
+      translate_children(cell.children(), out, config, resourceLocator);
 
       out.write_element_end("td");
     }
@@ -392,8 +408,17 @@ void html::translate_table(Element element, HtmlWriter &out,
 }
 
 void html::translate_image(Element element, HtmlWriter &out,
-                           const HtmlConfig &config) {
+                           const HtmlConfig &config,
+                           const HtmlResourceLocator &resourceLocator) {
   Image image = element.image();
+
+  HtmlResourceLocation resourceLocation;
+  if (image.is_internal()) {
+    resourceLocation = resourceLocator(HtmlResourceType::image, "image",
+                                       "image", image.file().value(), false);
+  } else {
+    resourceLocation = image.href();
+  }
 
   out.write_element_begin(
       "img",
@@ -401,38 +426,40 @@ void html::translate_image(Element element, HtmlWriter &out,
           .set_close_type(HtmlCloseType::trailing)
           .set_attributes([&](const HtmlAttributeWriterCallback &clb) {
             clb("alt", "Error: image not found or unsupported");
-            if (image.is_internal()) {
+            if (resourceLocation.has_value()) {
+              clb("src", image.href());
+            } else {
               clb("src", [&](std::ostream &o) {
                 translate_image_src(image.file().value(), o, config);
               });
-            } else {
-              clb("src", image.href());
             }
           })
           .set_style("position:absolute;left:0;top:0;width:100%;height:100%"));
 }
 
 void html::translate_frame(Element element, HtmlWriter &out,
-                           const HtmlConfig &config) {
+                           const HtmlConfig &config,
+                           const HtmlResourceLocator &resourceLocator) {
   Frame frame = element.frame();
   GraphicStyle style = frame.style();
 
   out.write_element_begin(
       "div", HtmlElementOptions().set_style(translate_frame_properties(frame) +
                                             translate_drawing_style(style)));
-  translate_children(frame.children(), out, config);
+  translate_children(frame.children(), out, config, resourceLocator);
   out.write_element_end("div");
 }
 
 void html::translate_rect(Element element, HtmlWriter &out,
-                          const HtmlConfig &config) {
+                          const HtmlConfig &config,
+                          const HtmlResourceLocator &resourceLocator) {
   Rect rect = element.rect();
   GraphicStyle style = rect.style();
 
   out.write_element_begin(
       "div", HtmlElementOptions().set_style(translate_rect_properties(rect) +
                                             translate_drawing_style(style)));
-  translate_children(rect.children(), out, config);
+  translate_children(rect.children(), out, config, resourceLocator);
   out.write_new_line();
   out.write_raw(
       R"(<svg xmlns="http://www.w3.org/2000/svg" version="1.1" overflow="visible" preserveAspectRatio="none" style="z-index:-1;width:inherit;height:inherit;position:absolute;top:0;left:0;padding:inherit;"><rect x="0" y="0" width="100%" height="100%" /></svg>)");
@@ -440,7 +467,11 @@ void html::translate_rect(Element element, HtmlWriter &out,
 }
 
 void html::translate_line(Element element, HtmlWriter &out,
-                          const HtmlConfig & /*config*/) {
+                          const HtmlConfig &config,
+                          const HtmlResourceLocator &resourceLocator) {
+  (void)config;
+  (void)resourceLocator;
+
   Line line = element.line();
   GraphicStyle style = line.style();
 
@@ -465,7 +496,8 @@ void html::translate_line(Element element, HtmlWriter &out,
 }
 
 void html::translate_circle(Element element, HtmlWriter &out,
-                            const HtmlConfig &config) {
+                            const HtmlConfig &config,
+                            const HtmlResourceLocator &resourceLocator) {
   Circle circle = element.circle();
   GraphicStyle style = circle.style();
 
@@ -473,14 +505,15 @@ void html::translate_circle(Element element, HtmlWriter &out,
                                      translate_circle_properties(circle) +
                                      translate_drawing_style(style)));
   out.write_new_line();
-  translate_children(circle.children(), out, config);
+  translate_children(circle.children(), out, config, resourceLocator);
   out.write_raw(
       R"(<svg xmlns="http://www.w3.org/2000/svg" version="1.1" overflow="visible" preserveAspectRatio="none" style="z-index:-1;width:inherit;height:inherit;position:absolute;top:0;left:0;padding:inherit;"><circle cx="50%" cy="50%" r="50%" /></svg>)");
   out.write_element_end("div");
 }
 
 void html::translate_custom_shape(Element element, HtmlWriter &out,
-                                  const HtmlConfig &config) {
+                                  const HtmlConfig &config,
+                                  const HtmlResourceLocator &resourceLocator) {
   CustomShape custom_shape = element.custom_shape();
   GraphicStyle style = custom_shape.style();
 
@@ -488,7 +521,7 @@ void html::translate_custom_shape(Element element, HtmlWriter &out,
                           HtmlElementOptions().set_style(
                               translate_custom_shape_properties(custom_shape) +
                               translate_drawing_style(style)));
-  translate_children(custom_shape.children(), out, config);
+  translate_children(custom_shape.children(), out, config, resourceLocator);
   // TODO draw shape in svg
   out.write_element_end("div");
 }

--- a/src/odr/internal/html/document_element.hpp
+++ b/src/odr/internal/html/document_element.hpp
@@ -1,6 +1,8 @@
 #ifndef ODR_INTERNAL_HTML_DOCUMENT_ELEMENT_HPP
 #define ODR_INTERNAL_HTML_DOCUMENT_ELEMENT_HPP
 
+#include <odr/html_service.hpp>
+
 namespace odr {
 class Element;
 class ElementRange;
@@ -8,48 +10,65 @@ class MasterPage;
 class Slide;
 class Sheet;
 class Page;
-
-struct HtmlConfig;
 } // namespace odr
 
 namespace odr::internal::html {
 class HtmlWriter;
 
 void translate_children(ElementRange range, HtmlWriter &out,
-                        const HtmlConfig &config);
+                        const HtmlConfig &config,
+                        const HtmlResourceLocator &resourceLocator);
 void translate_element(Element element, HtmlWriter &out,
-                       const HtmlConfig &config);
+                       const HtmlConfig &config,
+                       const HtmlResourceLocator &resourceLocator);
 
-void translate_slide(Slide slide, HtmlWriter &out, const HtmlConfig &config);
-void translate_sheet(Sheet sheet, HtmlWriter &out, const HtmlConfig &config);
-void translate_page(Page page, HtmlWriter &out, const HtmlConfig &config);
+void translate_slide(Slide slide, HtmlWriter &out, const HtmlConfig &config,
+                     const HtmlResourceLocator &resourceLocator);
+void translate_sheet(Sheet sheet, HtmlWriter &out, const HtmlConfig &config,
+                     const HtmlResourceLocator &resourceLocator);
+void translate_page(Page page, HtmlWriter &out, const HtmlConfig &config,
+                    const HtmlResourceLocator &resourceLocator);
 
 void translate_master_page(MasterPage masterPage, HtmlWriter &out,
-                           const HtmlConfig &config);
+                           const HtmlConfig &config,
+                           const HtmlResourceLocator &resourceLocator);
 
-void translate_text(Element element, HtmlWriter &out, const HtmlConfig &config);
-void translate_line_break(Element element, HtmlWriter &out, const HtmlConfig &);
+void translate_text(Element element, HtmlWriter &out, const HtmlConfig &config,
+                    const HtmlResourceLocator &resourceLocator);
+void translate_line_break(Element element, HtmlWriter &out,
+                          const HtmlConfig &config,
+                          const HtmlResourceLocator &resourceLocator);
 void translate_paragraph(Element element, HtmlWriter &out,
-                         const HtmlConfig &config);
-void translate_span(Element element, HtmlWriter &out, const HtmlConfig &config);
-void translate_link(Element element, HtmlWriter &out, const HtmlConfig &config);
+                         const HtmlConfig &config,
+                         const HtmlResourceLocator &resourceLocator);
+void translate_span(Element element, HtmlWriter &out, const HtmlConfig &config,
+                    const HtmlResourceLocator &resourceLocator);
+void translate_link(Element element, HtmlWriter &out, const HtmlConfig &config,
+                    const HtmlResourceLocator &resourceLocator);
 void translate_bookmark(Element element, HtmlWriter &out,
-                        const HtmlConfig &config);
-void translate_list(Element element, HtmlWriter &out, const HtmlConfig &config);
+                        const HtmlConfig &config,
+                        const HtmlResourceLocator &resourceLocator);
+void translate_list(Element element, HtmlWriter &out, const HtmlConfig &config,
+                    const HtmlResourceLocator &resourceLocator);
 void translate_list_item(Element element, HtmlWriter &out,
-                         const HtmlConfig &config);
-void translate_table(Element element, HtmlWriter &out,
-                     const HtmlConfig &config);
-void translate_image(Element element, HtmlWriter &out,
-                     const HtmlConfig &config);
-void translate_frame(Element element, HtmlWriter &out,
-                     const HtmlConfig &config);
-void translate_rect(Element element, HtmlWriter &out, const HtmlConfig &config);
-void translate_line(Element element, HtmlWriter &out, const HtmlConfig &config);
+                         const HtmlConfig &config,
+                         const HtmlResourceLocator &resourceLocator);
+void translate_table(Element element, HtmlWriter &out, const HtmlConfig &config,
+                     const HtmlResourceLocator &resourceLocator);
+void translate_image(Element element, HtmlWriter &out, const HtmlConfig &config,
+                     const HtmlResourceLocator &resourceLocator);
+void translate_frame(Element element, HtmlWriter &out, const HtmlConfig &config,
+                     const HtmlResourceLocator &resourceLocator);
+void translate_rect(Element element, HtmlWriter &out, const HtmlConfig &config,
+                    const HtmlResourceLocator &resourceLocator);
+void translate_line(Element element, HtmlWriter &out, const HtmlConfig &config,
+                    const HtmlResourceLocator &resourceLocator);
 void translate_circle(Element element, HtmlWriter &out,
-                      const HtmlConfig &config);
+                      const HtmlConfig &config,
+                      const HtmlResourceLocator &resourceLocator);
 void translate_custom_shape(Element element, HtmlWriter &out,
-                            const HtmlConfig &config);
+                            const HtmlConfig &config,
+                            const HtmlResourceLocator &resourceLocator);
 
 } // namespace odr::internal::html
 

--- a/src/odr/internal/html/document_element.hpp
+++ b/src/odr/internal/html/document_element.hpp
@@ -5,6 +5,9 @@ namespace odr {
 class Element;
 class ElementRange;
 class MasterPage;
+class Slide;
+class Sheet;
+class Page;
 
 struct HtmlConfig;
 } // namespace odr
@@ -17,17 +20,14 @@ void translate_children(ElementRange range, HtmlWriter &out,
 void translate_element(Element element, HtmlWriter &out,
                        const HtmlConfig &config);
 
-void translate_slide(Element element, HtmlWriter &out,
-                     const HtmlConfig &config);
-void translate_sheet(Element element, HtmlWriter &out,
-                     const HtmlConfig &config);
-void translate_page(Element element, HtmlWriter &out, const HtmlConfig &config);
+void translate_slide(Slide slide, HtmlWriter &out, const HtmlConfig &config);
+void translate_sheet(Sheet sheet, HtmlWriter &out, const HtmlConfig &config);
+void translate_page(Page page, HtmlWriter &out, const HtmlConfig &config);
 
-void translate_master_page(MasterPage element, HtmlWriter &out,
+void translate_master_page(MasterPage masterPage, HtmlWriter &out,
                            const HtmlConfig &config);
 
-void translate_text(const Element element, HtmlWriter &out,
-                    const HtmlConfig &config);
+void translate_text(Element element, HtmlWriter &out, const HtmlConfig &config);
 void translate_line_break(Element element, HtmlWriter &out, const HtmlConfig &);
 void translate_paragraph(Element element, HtmlWriter &out,
                          const HtmlConfig &config);

--- a/src/odr/internal/html/html_writer.cpp
+++ b/src/odr/internal/html/html_writer.cpp
@@ -121,6 +121,9 @@ HtmlElementOptions::set_extra(std::optional<HtmlWritable> _extra) {
 HtmlWriter::HtmlWriter(std::ostream &out, bool format, std::uint8_t indent)
     : m_out{out}, m_format{format}, m_indent(indent, ' ') {}
 
+HtmlWriter::HtmlWriter(std::ostream &out, const HtmlConfig &config)
+    : HtmlWriter{out, config.format_html, config.html_indent} {}
+
 void HtmlWriter::write_begin() {
   m_out << "<!DOCTYPE html>\n";
   m_out << "<html>";

--- a/src/odr/internal/html/html_writer.cpp
+++ b/src/odr/internal/html/html_writer.cpp
@@ -4,6 +4,7 @@
 
 #include <cstring>
 #include <iostream>
+#include <ranges>
 #include <stdexcept>
 
 namespace odr::internal::html {

--- a/src/odr/internal/html/html_writer.cpp
+++ b/src/odr/internal/html/html_writer.cpp
@@ -2,9 +2,9 @@
 
 #include <odr/internal/html/common.hpp>
 
+#include <algorithm>
 #include <cstring>
 #include <iostream>
-#include <ranges>
 #include <stdexcept>
 
 namespace odr::internal::html {
@@ -273,7 +273,7 @@ void HtmlWriter::write_element_end(const std::string &name) {
 }
 
 bool HtmlWriter::is_inline_mode() const {
-  return std::ranges::all_of(m_stack, [](const StackElement &element) {
+  return std::ranges::any_of(m_stack, [](const StackElement &element) {
     return element.inline_element;
   });
 }

--- a/src/odr/internal/html/html_writer.cpp
+++ b/src/odr/internal/html/html_writer.cpp
@@ -118,8 +118,10 @@ HtmlElementOptions::set_extra(std::optional<HtmlWritable> _extra) {
   return *this;
 }
 
-HtmlWriter::HtmlWriter(std::ostream &out, bool format, std::uint8_t indent)
-    : m_out{out}, m_format{format}, m_indent(indent, ' ') {}
+HtmlWriter::HtmlWriter(std::ostream &out, bool format, std::uint8_t indent,
+                       std::uint32_t current_indent)
+    : m_out{out}, m_format{format}, m_indent(indent, ' '),
+      m_current_indent{current_indent} {}
 
 HtmlWriter::HtmlWriter(std::ostream &out, const HtmlConfig &config)
     : HtmlWriter{out, config.format_html, config.html_indent} {}
@@ -158,7 +160,7 @@ void HtmlWriter::write_header_title(const std::string &title) {
 void HtmlWriter::write_header_viewport(const std::string &viewport) {
   write_new_line();
 
-  m_out << "<meta name=\"viewport\" content=\"";
+  m_out << R"(<meta name="viewport" content=")";
   m_out << viewport;
   m_out << "\"/>";
 }
@@ -182,7 +184,7 @@ void HtmlWriter::write_header_charset(const std::string &charset) {
 void HtmlWriter::write_header_style(const std::string &href) {
   write_new_line();
 
-  m_out << "<link rel=\"stylesheet\" href=\"";
+  m_out << R"(<link rel="stylesheet" href=")";
   m_out << href;
   m_out << "\"/>";
 }
@@ -204,7 +206,7 @@ void HtmlWriter::write_header_style_end() {
 void HtmlWriter::write_script(const std::string &src) {
   write_new_line();
 
-  m_out << "<script type=\"text/javascript\" src=\"" << src << "\"></script>";
+  m_out << R"(<script type="text/javascript" src=")" << src << "\"></script>";
 }
 
 void HtmlWriter::write_script_begin() {
@@ -221,7 +223,7 @@ void HtmlWriter::write_script_end() {
   m_out << "</script>";
 }
 
-void HtmlWriter::write_body_begin(HtmlElementOptions options) {
+void HtmlWriter::write_body_begin(const HtmlElementOptions &options) {
   write_new_line();
   ++m_current_indent;
 
@@ -238,7 +240,7 @@ void HtmlWriter::write_body_end() {
 }
 
 void HtmlWriter::write_element_begin(const std::string &name,
-                                     HtmlElementOptions options) {
+                                     const HtmlElementOptions &options) {
   write_new_line();
   if (options.close_type == HtmlCloseType::standard) {
     ++m_current_indent;
@@ -270,12 +272,9 @@ void HtmlWriter::write_element_end(const std::string &name) {
 }
 
 bool HtmlWriter::is_inline_mode() const {
-  for (const auto &element : m_stack) {
-    if (element.inline_element) {
-      return true;
-    }
-  }
-  return false;
+  return std::ranges::all_of(m_stack, [](const StackElement &element) {
+    return element.inline_element;
+  });
 }
 
 void HtmlWriter::write_new_line() {

--- a/src/odr/internal/html/html_writer.hpp
+++ b/src/odr/internal/html/html_writer.hpp
@@ -48,7 +48,8 @@ struct HtmlElementOptions {
 
 class HtmlWriter {
 public:
-  explicit HtmlWriter(std::ostream &out, bool format, std::uint8_t indent);
+  HtmlWriter(std::ostream &out, bool format, std::uint8_t indent);
+  HtmlWriter(std::ostream &out, const HtmlConfig &config);
 
   void write_begin();
   void write_end();

--- a/src/odr/internal/html/html_writer.hpp
+++ b/src/odr/internal/html/html_writer.hpp
@@ -48,7 +48,8 @@ struct HtmlElementOptions {
 
 class HtmlWriter {
 public:
-  HtmlWriter(std::ostream &out, bool format, std::uint8_t indent);
+  HtmlWriter(std::ostream &out, bool format, std::uint8_t indent,
+             std::uint32_t current_indent = 0);
   HtmlWriter(std::ostream &out, const HtmlConfig &config);
 
   void write_begin();
@@ -68,14 +69,14 @@ public:
   void write_script_begin();
   void write_script_end();
 
-  void write_body_begin(HtmlElementOptions options = {});
+  void write_body_begin(const HtmlElementOptions &options = {});
   void write_body_end();
 
   void write_element_begin(const std::string &name,
-                           HtmlElementOptions options = {});
+                           const HtmlElementOptions &options = {});
   void write_element_end(const std::string &name);
 
-  bool is_inline_mode() const;
+  [[nodiscard]] bool is_inline_mode() const;
   void write_new_line();
   void write_raw(const HtmlWritable &writable, bool new_line = true);
 


### PR DESCRIPTION
- Generalize HTML generation to "fragments" which can be written to output streams individually
- This allows the user to control the HTML output as only the crucial content will be generated but not the surrounding HTML header / footer
- This abstraction can be used by a HTTP server to access parts of documents individually
- It also allows us to push UI/UX out of the core and into the platform