### PR TITLE
Update wvware and pdf2htmlex versions

### DIFF
--- a/conanfile.py
+++ b/conanfile.py
@@ -44,9 +44,9 @@ class OpenDocumentCoreConan(ConanFile):
         self.requires("uchardet/0.0.8")
         self.requires("utfcpp/4.0.4")
         if self.options.get_safe("with_pdf2htmlEX", False):
-            self.requires("pdf2htmlex/0.18.8.rc1-20240905-git-vili")
+            self.requires("pdf2htmlex/0.18.8.rc1-git-6f85c88-odr")
         if self.options.get_safe("with_wvWare", False):
-            self.requires("wvware/1.2.9-vili")
+            self.requires("wvware/1.2.9-odr")
 
     def build_requirements(self):
         self.test_requires("gtest/1.14.0")


### PR DESCRIPTION
After https://github.com/opendocument-app/OpenDocument.core/pull/387 we want to use the "newer" versions of these libraries