### PR TITLE
refactor html service

### DIFF
--- a/cli/src/server.cpp
+++ b/cli/src/server.cpp
@@ -1,4 +1,5 @@
 #include <odr/file.hpp>
+#include <odr/html.hpp>
 #include <odr/http_server.hpp>
 
 #include <iostream>
@@ -33,19 +34,16 @@ int main(int argc, char **argv) {
     }
   }
 
-  HttpServer::Config config;
-  HttpServer server(config);
+  HttpServer::Config server_config;
+  HttpServer server(server_config);
+
+  HtmlConfig html_config;
 
   {
-    std::string id = server.host_file(File(input));
-    std::cout << "hosted file with id: " << id << std::endl;
-    std::cout << "http://localhost:8080/" << id << std::endl;
-  }
-
-  {
-    std::string id = server.host_file(decoded_file);
-    std::cout << "hosted decoded file with id: " << id << std::endl;
-    std::cout << "http://localhost:8080/" << id << std::endl;
+    std::string prefix = "one_file";
+    server.serve_file(decoded_file, prefix, html_config);
+    std::cout << "hosted decoded file with id: " << prefix << std::endl;
+    std::cout << "http://localhost:8080/" << prefix << std::endl;
   }
 
   server.listen("localhost", 8080);

--- a/src/odr/html_service.cpp
+++ b/src/odr/html_service.cpp
@@ -20,6 +20,10 @@ const HtmlResourceLocator &HtmlService::resource_locator() const {
 
 void HtmlService::warmup() const { m_impl->warmup(); }
 
+std::string HtmlService::mimetype(const std::string &path) const {
+  return m_impl->mimetype(path);
+}
+
 void HtmlService::write(const std::string &path, std::ostream &out) const {
   m_impl->write(path, out);
 }

--- a/src/odr/html_service.cpp
+++ b/src/odr/html_service.cpp
@@ -20,10 +20,14 @@ const HtmlResourceLocator &HtmlService::resource_locator() const {
 
 void HtmlService::warmup() const { m_impl->warmup(); }
 
-HtmlResources HtmlService::resources() const { return m_impl->resources(); }
-
 void HtmlService::write(const std::string &path, std::ostream &out) const {
   m_impl->write(path, out);
+}
+
+HtmlResources HtmlService::write_html(const std::string &path,
+                                      std::ostream &out) const {
+  internal::html::HtmlWriter writer(out, config());
+  return m_impl->write_html(path, writer);
 }
 
 const std::shared_ptr<internal::abstract::HtmlService> &

--- a/src/odr/html_service.cpp
+++ b/src/odr/html_service.cpp
@@ -7,52 +7,27 @@
 
 namespace odr {
 
-HtmlDocumentService::HtmlDocumentService() = default;
+HtmlService::HtmlService() = default;
 
-HtmlDocumentService::HtmlDocumentService(
-    std::shared_ptr<internal::abstract::HtmlDocumentService> impl)
+HtmlService::HtmlService(std::shared_ptr<internal::abstract::HtmlService> impl)
     : m_impl{std::move(impl)} {}
 
-const HtmlConfig &HtmlDocumentService::config() const {
-  return m_impl->config();
-}
+const HtmlConfig &HtmlService::config() const { return m_impl->config(); }
 
-const HtmlResourceLocator &HtmlDocumentService::resource_locator() const {
+const HtmlResourceLocator &HtmlService::resource_locator() const {
   return m_impl->resource_locator();
 }
 
-HtmlResources HtmlDocumentService::write_document(std::ostream &os) const {
-  internal::html::HtmlWriter out(os, config());
+void HtmlService::warmup() const { m_impl->warmup(); }
 
-  return m_impl->write_document(out);
+HtmlResources HtmlService::resources() const { return m_impl->resources(); }
+
+void HtmlService::write(const std::string &path, std::ostream &out) const {
+  m_impl->write(path, out);
 }
 
-const std::shared_ptr<internal::abstract::HtmlDocumentService> &
-HtmlDocumentService::impl() const {
-  return m_impl;
-}
-
-HtmlFragmentService::HtmlFragmentService(
-    std::shared_ptr<internal::abstract::HtmlFragmentService> impl)
-    : m_impl{std::move(impl)} {}
-
-const HtmlConfig &HtmlFragmentService::config() const {
-  return m_impl->config();
-}
-
-const HtmlResourceLocator &HtmlFragmentService::resource_locator() const {
-  return m_impl->resource_locator();
-}
-
-void HtmlFragmentService::write_fragment(std::ostream &os,
-                                         HtmlResources &resources) const {
-  internal::html::HtmlWriter out(os, config());
-
-  m_impl->write_fragment(out, resources);
-}
-
-const std::shared_ptr<internal::abstract::HtmlFragmentService> &
-HtmlFragmentService::impl() const {
+const std::shared_ptr<internal::abstract::HtmlService> &
+HtmlService::impl() const {
   return m_impl;
 }
 

--- a/src/odr/html_service.hpp
+++ b/src/odr/html_service.hpp
@@ -8,8 +8,7 @@
 #include <vector>
 
 namespace odr::internal::abstract {
-class HtmlDocumentService;
-class HtmlFragmentService;
+class HtmlService;
 class HtmlResource;
 } // namespace odr::internal::abstract
 
@@ -34,39 +33,25 @@ using HtmlResourceLocator =
 using HtmlResources =
     std::vector<std::pair<HtmlResource, HtmlResourceLocation>>;
 
-class HtmlDocumentService final {
+class HtmlService final {
 public:
-  HtmlDocumentService();
-  explicit HtmlDocumentService(
-      std::shared_ptr<internal::abstract::HtmlDocumentService> impl);
+  HtmlService();
+  explicit HtmlService(std::shared_ptr<internal::abstract::HtmlService> impl);
 
   [[nodiscard]] const HtmlConfig &config() const;
   [[nodiscard]] const HtmlResourceLocator &resource_locator() const;
 
-  HtmlResources write_document(std::ostream &os) const;
+  void warmup() const;
 
-  [[nodiscard]] const std::shared_ptr<internal::abstract::HtmlDocumentService> &
+  [[nodiscard]] HtmlResources resources() const;
+
+  void write(const std::string &path, std::ostream &out) const;
+
+  [[nodiscard]] const std::shared_ptr<internal::abstract::HtmlService> &
   impl() const;
 
 private:
-  std::shared_ptr<internal::abstract::HtmlDocumentService> m_impl;
-};
-
-class HtmlFragmentService final {
-public:
-  explicit HtmlFragmentService(
-      std::shared_ptr<internal::abstract::HtmlFragmentService> impl);
-
-  [[nodiscard]] const HtmlConfig &config() const;
-  [[nodiscard]] const HtmlResourceLocator &resource_locator() const;
-
-  void write_fragment(std::ostream &os, HtmlResources &resources) const;
-
-  [[nodiscard]] const std::shared_ptr<internal::abstract::HtmlFragmentService> &
-  impl() const;
-
-private:
-  std::shared_ptr<internal::abstract::HtmlFragmentService> m_impl;
+  std::shared_ptr<internal::abstract::HtmlService> m_impl;
 };
 
 class HtmlResource final {

--- a/src/odr/html_service.hpp
+++ b/src/odr/html_service.hpp
@@ -43,6 +43,8 @@ public:
 
   void warmup() const;
 
+  [[nodiscard]] std::string mimetype(const std::string &path) const;
+
   void write(const std::string &path, std::ostream &out) const;
   HtmlResources write_html(const std::string &path, std::ostream &out) const;
 

--- a/src/odr/html_service.hpp
+++ b/src/odr/html_service.hpp
@@ -43,9 +43,8 @@ public:
 
   void warmup() const;
 
-  [[nodiscard]] HtmlResources resources() const;
-
   void write(const std::string &path, std::ostream &out) const;
+  HtmlResources write_html(const std::string &path, std::ostream &out) const;
 
   [[nodiscard]] const std::shared_ptr<internal::abstract::HtmlService> &
   impl() const;

--- a/src/odr/http_server.cpp
+++ b/src/odr/http_server.cpp
@@ -4,12 +4,11 @@
 #include <odr/filesystem.hpp>
 #include <odr/html.hpp>
 #include <odr/html_service.hpp>
-#include <odr/internal/common/null_stream.hpp>
 #include <odr/internal/html/document.hpp>
 #include <odr/internal/html/pdf2htmlex_wrapper.hpp>
 #include <odr/internal/pdf_poppler/poppler_pdf_file.hpp>
 
-#include <random>
+#include <utility>
 
 #include <httplib/httplib.h>
 
@@ -17,137 +16,51 @@ namespace odr {
 
 class HttpServer::Impl {
 public:
-  explicit Impl(const HttpServer::Config &config) : m_config{config} {
+  explicit Impl(HttpServer::Config config) : m_config{std::move(config)} {
     m_server.Get("/",
                  [](const httplib::Request & /*req*/, httplib::Response &res) {
                    res.set_content("Hello World!", "text/plain");
                  });
 
-    m_server.Get("/file/:id", [this](const httplib::Request &req,
-                                     httplib::Response &res) {
-      std::string id = req.path_params.at("id");
-
-      std::unique_lock lock{m_mutex};
-      auto it = m_content.find(id);
-      if (it == m_content.end()) {
-        res.status = 404;
-        return;
-      }
-      lock.unlock();
-      const Content &content = it->second;
-
-      if (std::holds_alternative<File>(content.file)) {
-        serve_file(res, std::get<File>(content.file));
-      } else {
-        serve_file(std::get<DecodedFile>(content.file), id, content.config);
-      }
-    });
-  }
-
-  void serve_file(httplib::Response &res, const File &file) {
-    struct State {
-      State(std::unique_ptr<std::istream> stream_, std::size_t buffer_size)
-          : stream{std::move(stream_)}, buffer(buffer_size, 0) {}
-
-      std::unique_ptr<std::istream> stream;
-      std::vector<char> buffer;
-    };
-
-    auto state = std::make_shared<State>(file.stream(), m_config.buffer_size);
-    httplib::ContentProvider content_provider =
-        [state = std::move(state)](std::size_t offset, std::size_t length,
-                                   httplib::DataSink &sink) -> bool {
-      std::istream &stream = *state->stream;
-
-      stream.seekg(static_cast<std::streamsize>(offset), std::ios::beg);
-      stream.read(state->buffer.data(), static_cast<std::streamsize>(length));
-      sink.write(state->buffer.data(),
-                 static_cast<std::size_t>(stream.gcount()));
-
-      return !stream.eof();
-    };
-
-    res.set_content_provider(file.size(), "application/octet-stream",
-                             content_provider);
-  }
-
-  void serve_file(const httplib::Request &req, httplib::Response &res,
-                  DecodedFile file, const std::string &prefix,
-                  const HtmlConfig &config) {
-    std::string output_path = m_config.output_path + "/" + prefix;
-
-    std::filesystem::create_directories(output_path);
-
-    HtmlService html_service;
-
-    if (file.is_document_file()) {
-      DocumentFile document_file = file.document_file();
-      if (document_file.password_encrypted()) {
-        throw std::runtime_error("Document is encrypted");
-      }
-      auto document = document_file.document();
-      html_service = internal::html::create_document_service(
-          document, output_path, config);
-#ifdef ODR_WITH_PDF2HTMLEX
-    } else if (file.is_pdf_file()) {
-      PdfFile pdf_file = file.pdf_file();
-      if (pdf_file.password_encrypted()) {
-        throw std::runtime_error("Document is encrypted");
-      }
-      html_service = internal::html::create_poppler_pdf_service(
-          dynamic_cast<const internal::PopplerPdfFile &>(*pdf_file.impl()),
-          output_path, config);
-#endif
-    } else {
-      throw std::runtime_error("Unsupported file type");
-    }
-
-    internal::common::NullStream null;
-    HtmlResources resources = html_service.write_document(null);
-
-    m_server.Get("/" + id, [id](const httplib::Request & /*req*/,
-                                httplib::Response &res) {
-      res.set_redirect("/" + id + "/document.html");
-    });
-
-    m_server.Get("/" + id + "/document.html",
-                 [=](const httplib::Request & /*req*/, httplib::Response &res) {
-                   httplib::ContentProviderWithoutLength content_provider =
-                       [html_service](std::size_t offset,
-                                      httplib::DataSink &sink) -> bool {
-                     if (offset != 0) {
-                       throw std::runtime_error(
-                           "Invalid offset: " + std::to_string(offset) +
-                           ". Must be 0.");
-                     }
-                     html_service.write_document(sink.os);
-                     return false;
-                   };
-                   res.set_content_provider("text/html", content_provider);
+    m_server.Get("/file/:id/.*",
+                 [&](const httplib::Request &req, httplib::Response &res) {
+                   serve_file(req, res);
                  });
+  }
 
-    for (const auto &[resource, location] : resources) {
-      if (!location.has_value() || resource.is_external()) {
-        continue;
-      }
+  const HttpServer::Config &config() const { return m_config; }
 
-      m_server.Get(
-          "/" + id + "/" + location.value(),
-          [=](const httplib::Request & /*req*/, httplib::Response &res) {
-            httplib::ContentProviderWithoutLength content_provider =
-                [resource](std::size_t offset,
-                           httplib::DataSink &sink) -> bool {
-              if (offset != 0) {
-                throw std::runtime_error(
-                    "Invalid offset: " + std::to_string(offset) +
-                    ". Must be 0.");
-              }
-              resource.write_resource(sink.os);
-              return false;
-            };
-            res.set_content_provider(resource.mime_type(), content_provider);
-          });
+  void serve_file(const httplib::Request &req, httplib::Response &res) {
+    std::string id = req.path_params.at("id");
+    std::string path = req.matches[0].str();
+
+    std::unique_lock lock{m_mutex};
+    auto it = m_content.find(id);
+    if (it == m_content.end()) {
+      res.status = 404;
+      return;
     }
+    const Content &content = it->second;
+
+    serve_file(res, content.service, path);
+  }
+
+  void serve_file(httplib::Response &res, const HtmlService &service,
+                  const std::string &path) {
+    httplib::ContentProviderWithoutLength content_provider =
+        [&](std::size_t offset, httplib::DataSink &sink) -> bool {
+      if (offset != 0) {
+        throw std::runtime_error("Invalid offset: " + std::to_string(offset) +
+                                 ". Must be 0.");
+      }
+      service.write(path, sink.os);
+      return false;
+    };
+    res.set_content_provider(service.mimetype(path), content_provider);
+  }
+
+  void connect_service(HtmlService service, const std::string &prefix) {
+    m_content.emplace(prefix, Content{prefix, std::move(service)});
   }
 
   void listen(const std::string &host, std::uint32_t port) {
@@ -163,8 +76,7 @@ private:
 
   struct Content {
     std::string id;
-    HtmlConfig config;
-    std::variant<File, DecodedFile> file;
+    HtmlService service;
   };
 
   std::mutex m_mutex;
@@ -174,13 +86,35 @@ private:
 HttpServer::HttpServer(const Config &config)
     : m_impl{std::make_unique<Impl>(config)} {}
 
-void HttpServer::host_file(File file, const std::string &prefix) {
-  m_impl->host_file(std::move(file), prefix);
+void HttpServer::connect_service(HtmlService service,
+                                 const std::string &prefix) {
+  m_impl->connect_service(std::move(service), prefix);
 }
 
-void HttpServer::host_file(DecodedFile file, const std::string &prefix,
-                           const HtmlConfig &config) {
-  m_impl->host_file(std::move(file), prefix, config);
+void HttpServer::serve_file(DecodedFile file, const std::string &prefix,
+                            const HtmlConfig &config) {
+  std::string output_path = m_impl->config().output_path + "/" + prefix;
+
+  HtmlService service;
+
+  if (file.is_document_file()) {
+    service = internal::html::create_document_service(
+        file.document_file().document(), output_path, config);
+#ifdef ODR_WITH_PDF2HTMLEX
+  } else if (file.is_pdf_file()) {
+    PdfFile pdf_file = file.pdf_file();
+    if (pdf_file.password_encrypted()) {
+      throw std::runtime_error("Document is encrypted");
+    }
+    service = internal::html::create_poppler_pdf_service(
+        dynamic_cast<const internal::PopplerPdfFile &>(*pdf_file.impl()),
+        output_path, config);
+#endif
+  } else {
+    throw std::runtime_error("Unsupported file type.");
+  }
+
+  m_impl->connect_service(std::move(service), prefix);
 }
 
 void HttpServer::listen(const std::string &host, std::uint32_t port) {

--- a/src/odr/http_server.hpp
+++ b/src/odr/http_server.hpp
@@ -9,6 +9,7 @@ class File;
 class DecodedFile;
 class Filesystem;
 struct HtmlConfig;
+class HtmlService;
 
 class HttpServer {
 public:
@@ -19,9 +20,10 @@ public:
 
   explicit HttpServer(const Config &config);
 
-  void host_file(File file, const std::string &prefix);
-  void host_file(DecodedFile file, const std::string &prefix,
-                 const HtmlConfig &config);
+  void connect_service(HtmlService service, const std::string &prefix);
+
+  void serve_file(DecodedFile file, const std::string &prefix,
+                  const HtmlConfig &config);
 
   void listen(const std::string &host, std::uint32_t port);
 

--- a/src/odr/http_server.hpp
+++ b/src/odr/http_server.hpp
@@ -8,19 +8,20 @@ namespace odr {
 class File;
 class DecodedFile;
 class Filesystem;
+struct HtmlConfig;
 
 class HttpServer {
 public:
   struct Config {
     std::size_t buffer_size{4096};
-    std::string output_path = "/tmp";
+    std::string output_path{"/tmp"};
   };
 
   explicit HttpServer(const Config &config);
 
-  std::string host_file(File file);
-  std::string host_file(DecodedFile file);
-  std::string host_filesystem(Filesystem filesystem);
+  void host_file(File file, const std::string &prefix);
+  void host_file(DecodedFile file, const std::string &prefix,
+                 const HtmlConfig &config);
 
   void listen(const std::string &host, std::uint32_t port);
 

--- a/src/odr/internal/abstract/html_service.hpp
+++ b/src/odr/internal/abstract/html_service.hpp
@@ -24,6 +24,8 @@ public:
 
   virtual void warmup() const = 0;
 
+  [[nodiscard]] virtual std::string mimetype(const std::string &path) const = 0;
+
   virtual void write(const std::string &path, std::ostream &out) const = 0;
   virtual HtmlResources write_html(const std::string &path,
                                    html::HtmlWriter &out) const = 0;

--- a/src/odr/internal/abstract/html_service.hpp
+++ b/src/odr/internal/abstract/html_service.hpp
@@ -24,11 +24,9 @@ public:
 
   virtual void warmup() const = 0;
 
-  [[nodiscard]] virtual HtmlResources resources() const = 0;
-
   virtual void write(const std::string &path, std::ostream &out) const = 0;
-  virtual void write_html(const std::string &path,
-                          html::HtmlWriter &out) const = 0;
+  virtual HtmlResources write_html(const std::string &path,
+                                   html::HtmlWriter &out) const = 0;
 };
 
 class HtmlResource {

--- a/src/odr/internal/abstract/html_service.hpp
+++ b/src/odr/internal/abstract/html_service.hpp
@@ -15,25 +15,20 @@ class HtmlWriter;
 
 namespace odr::internal::abstract {
 
-class HtmlDocumentService {
+class HtmlService {
 public:
-  virtual ~HtmlDocumentService() = default;
+  virtual ~HtmlService() = default;
 
   [[nodiscard]] virtual const HtmlConfig &config() const = 0;
   [[nodiscard]] virtual const HtmlResourceLocator &resource_locator() const = 0;
 
-  virtual HtmlResources write_document(html::HtmlWriter &out) const = 0;
-};
+  virtual void warmup() const = 0;
 
-class HtmlFragmentService {
-public:
-  virtual ~HtmlFragmentService() = default;
+  [[nodiscard]] virtual HtmlResources resources() const = 0;
 
-  [[nodiscard]] virtual const HtmlConfig &config() const = 0;
-  [[nodiscard]] virtual const HtmlResourceLocator &resource_locator() const = 0;
-
-  virtual void write_fragment(html::HtmlWriter &out,
-                              HtmlResources &resources) const = 0;
+  virtual void write(const std::string &path, std::ostream &out) const = 0;
+  virtual void write_html(const std::string &path,
+                          html::HtmlWriter &out) const = 0;
 };
 
 class HtmlResource {

--- a/src/odr/internal/html/document.cpp
+++ b/src/odr/internal/html/document.cpp
@@ -189,6 +189,20 @@ public:
     m_warm = true;
   }
 
+  std::string mimetype(const std::string &path) const final {
+    if (path == "document.html") {
+      return "text/html";
+    }
+
+    for (const auto &[resource, location] : m_resources) {
+      if (location.has_value() && location.value() == path) {
+        return resource.mime_type();
+      }
+    }
+
+    throw std::runtime_error("Unknown path: " + path);
+  }
+
   void write(const std::string &path, std::ostream &out) const final {
     if (path == "document.html") {
       HtmlWriter writer(out, config());

--- a/src/odr/internal/html/document.cpp
+++ b/src/odr/internal/html/document.cpp
@@ -189,11 +189,6 @@ public:
     m_warm = true;
   }
 
-  [[nodiscard]] HtmlResources resources() const final {
-    warmup();
-    return m_resources;
-  }
-
   void write(const std::string &path, std::ostream &out) const final {
     if (path == "document.html") {
       HtmlWriter writer(out, config());
@@ -213,15 +208,16 @@ public:
     throw std::runtime_error("Unknown path: " + path);
   }
 
-  void write_html(const std::string &path, html::HtmlWriter &out) const final {
+  HtmlResources write_html(const std::string &path,
+                           html::HtmlWriter &out) const final {
     if (path == "document.html") {
-      write_document(out);
-    } else {
-      throw std::runtime_error("Unknown path: " + path);
+      return write_document(out);
     }
+
+    throw std::runtime_error("Unknown path: " + path);
   }
 
-  void write_document(HtmlWriter &out) const {
+  HtmlResources write_document(HtmlWriter &out) const {
     m_resources.clear();
 
     WritingState state(out, config(), resource_locator(), m_resources);
@@ -231,6 +227,8 @@ public:
       fragment->write_fragment(out, state);
     }
     back(document(), state);
+
+    return m_resources;
   }
 
 protected:

--- a/src/odr/internal/html/document.cpp
+++ b/src/odr/internal/html/document.cpp
@@ -289,7 +289,7 @@ public:
   explicit SlideHtmlFragment(Document document, Slide slide)
       : HtmlFragmentBase(slide.name(), std::move(document)), m_slide{slide} {}
 
-  void write_fragment(HtmlWriter &out, WritingState &state) const final {
+  void write_fragment(HtmlWriter &, WritingState &state) const final {
     html::translate_slide(m_slide, state);
   }
 
@@ -302,7 +302,7 @@ public:
   explicit SheetHtmlFragment(Document document, Sheet sheet)
       : HtmlFragmentBase(sheet.name(), std::move(document)), m_sheet{sheet} {}
 
-  void write_fragment(HtmlWriter &out, WritingState &state) const final {
+  void write_fragment(HtmlWriter &, WritingState &state) const final {
     translate_sheet(m_sheet, state);
   }
 
@@ -315,7 +315,7 @@ public:
   explicit PageHtmlFragment(Document document, Page page)
       : HtmlFragmentBase(page.name(), std::move(document)), m_page{page} {}
 
-  void write_fragment(HtmlWriter &out, WritingState &state) const final {
+  void write_fragment(HtmlWriter &, WritingState &state) const final {
     html::translate_page(m_page, state);
   }
 

--- a/src/odr/internal/html/document.hpp
+++ b/src/odr/internal/html/document.hpp
@@ -6,14 +6,14 @@ namespace odr {
 class Document;
 struct HtmlConfig;
 class Html;
-class HtmlDocumentService;
+class HtmlService;
 } // namespace odr
 
 namespace odr::internal::html {
 
-odr::HtmlDocumentService create_document_service(const Document &document,
-                                                 const std::string &output_path,
-                                                 const HtmlConfig &config);
+odr::HtmlService create_document_service(const Document &document,
+                                         const std::string &output_path,
+                                         const HtmlConfig &config);
 
 Html translate_document(const Document &document,
                         const std::string &output_path,

--- a/src/odr/internal/html/html_service.cpp
+++ b/src/odr/internal/html/html_service.cpp
@@ -7,25 +7,14 @@
 
 namespace odr::internal::html {
 
-HtmlDocumentService::HtmlDocumentService(HtmlConfig config,
-                                         HtmlResourceLocator resource_locator)
+HtmlService::HtmlService(HtmlConfig config,
+                         HtmlResourceLocator resource_locator)
     : m_config{std::move(config)},
       m_resource_locator{std::move(resource_locator)} {}
 
-const HtmlConfig &HtmlDocumentService::config() const { return m_config; }
+const HtmlConfig &HtmlService::config() const { return m_config; }
 
-const HtmlResourceLocator &HtmlDocumentService::resource_locator() const {
-  return m_resource_locator;
-}
-
-HtmlFragmentService::HtmlFragmentService(HtmlConfig config,
-                                         HtmlResourceLocator resource_locator)
-    : m_config{std::move(config)},
-      m_resource_locator{std::move(resource_locator)} {}
-
-const HtmlConfig &HtmlFragmentService::config() const { return m_config; }
-
-const HtmlResourceLocator &HtmlFragmentService::resource_locator() const {
+const HtmlResourceLocator &HtmlService::resource_locator() const {
   return m_resource_locator;
 }
 

--- a/src/odr/internal/html/html_service.hpp
+++ b/src/odr/internal/html/html_service.hpp
@@ -7,21 +7,9 @@
 
 namespace odr::internal::html {
 
-class HtmlDocumentService : public abstract::HtmlDocumentService {
+class HtmlService : public abstract::HtmlService {
 public:
-  HtmlDocumentService(HtmlConfig config, HtmlResourceLocator resource_locator);
-
-  [[nodiscard]] const HtmlConfig &config() const override;
-  [[nodiscard]] const HtmlResourceLocator &resource_locator() const override;
-
-private:
-  HtmlConfig m_config;
-  HtmlResourceLocator m_resource_locator;
-};
-
-class HtmlFragmentService : public abstract::HtmlFragmentService {
-public:
-  HtmlFragmentService(HtmlConfig config, HtmlResourceLocator resource_locator);
+  HtmlService(HtmlConfig config, HtmlResourceLocator resource_locator);
 
   [[nodiscard]] const HtmlConfig &config() const override;
   [[nodiscard]] const HtmlResourceLocator &resource_locator() const override;

--- a/src/odr/internal/html/pdf2htmlex_wrapper.cpp
+++ b/src/odr/internal/html/pdf2htmlex_wrapper.cpp
@@ -192,6 +192,20 @@ public:
     m_warm = true;
   }
 
+  std::string mimetype(const std::string &path) const final {
+    if (path == "document.html") {
+      return "text/html";
+    }
+
+    for (const auto &[resource, location] : m_resources) {
+      if (location.has_value() && location.value() == path) {
+        return resource.mime_type();
+      }
+    }
+
+    throw std::runtime_error("Unknown path: " + path);
+  }
+
   HtmlResources write_document(HtmlWriter &out) const {
     warmup();
 

--- a/src/odr/internal/html/pdf2htmlex_wrapper.cpp
+++ b/src/odr/internal/html/pdf2htmlex_wrapper.cpp
@@ -162,19 +162,26 @@ private:
   mutable std::mutex m_mutex;
 };
 
-class HtmlDocumentServiceImpl final : public HtmlDocumentService {
+class HtmlServiceImpl final : public HtmlService {
 public:
-  HtmlDocumentServiceImpl(
-      PopplerPdfFile pdf_file, std::string output_path,
-      std::shared_ptr<pdf2htmlEX::HTMLRenderer> html_renderer,
-      std::shared_ptr<std::mutex> html_renderer_mutex,
-      std::shared_ptr<pdf2htmlEX::Param> html_renderer_param, HtmlConfig config,
-      HtmlResourceLocator resource_locator)
-      : HtmlDocumentService(std::move(config), std::move(resource_locator)),
+  HtmlServiceImpl(PopplerPdfFile pdf_file, std::string output_path,
+                  std::shared_ptr<pdf2htmlEX::HTMLRenderer> html_renderer,
+                  std::shared_ptr<std::mutex> html_renderer_mutex,
+                  std::shared_ptr<pdf2htmlEX::Param> html_renderer_param,
+                  HtmlConfig config, HtmlResourceLocator resource_locator)
+      : HtmlService(std::move(config), std::move(resource_locator)),
         m_pdf_file{std::move(pdf_file)}, m_output_path{std::move(output_path)},
         m_html_renderer{std::move(html_renderer)},
         m_html_renderer_mutex{std::move(html_renderer_mutex)},
-        m_html_renderer_param{std::move(html_renderer_param)} {
+        m_html_renderer_param{std::move(html_renderer_param)} {}
+
+  [[nodiscard]] HtmlResources resources() const final { return m_resources; }
+
+  void warmup() const final {
+    if (m_warm) {
+      return;
+    }
+
     for (int i = 1; i <= m_pdf_file.pdf_doc().getNumPages(); ++i) {
       auto resource = std::make_shared<BackgroundImageResource>(
           m_pdf_file, m_output_path, m_html_renderer, m_html_renderer_mutex,
@@ -183,15 +190,40 @@ public:
           i, m_html_renderer_param->bg_format);
       m_resources.emplace_back(std::move(resource), std::move(file_name));
     }
+
+    m_warm = true;
   }
 
-  HtmlResources write_document(HtmlWriter &out) const final {
-    {
-      std::ifstream in(m_output_path + "/document.html");
-      util::stream::pipe(in, out.out());
+  void write_document(HtmlWriter &out) const {
+    std::ifstream in(m_output_path + "/document.html");
+    util::stream::pipe(in, out.out());
+  }
+
+  void write(const std::string &path, std::ostream &out) const final {
+    if (path == "document.html") {
+      HtmlWriter writer(out, config());
+      write_document(writer);
+      return;
     }
 
-    return m_resources;
+    warmup();
+
+    for (const auto &[resource, location] : m_resources) {
+      if (location.has_value() && location.value() == path) {
+        util::stream::pipe(*resource.file().stream(), out);
+        return;
+      }
+    }
+
+    throw std::runtime_error("Unknown path: " + path);
+  }
+
+  void write_html(const std::string &path, html::HtmlWriter &out) const final {
+    if (path == "document.html") {
+      write_document(out);
+    } else {
+      throw std::runtime_error("Unknown path: " + path);
+    }
   }
 
 private:
@@ -201,14 +233,15 @@ private:
   std::shared_ptr<std::mutex> m_html_renderer_mutex;
   std::shared_ptr<pdf2htmlEX::Param> m_html_renderer_param;
 
-  HtmlResources m_resources;
+  mutable bool m_warm = false;
+  mutable HtmlResources m_resources;
 };
 
 } // namespace odr::internal::html
 
 namespace odr::internal {
 
-odr::HtmlDocumentService
+odr::HtmlService
 html::create_poppler_pdf_service(const PopplerPdfFile &pdf_file,
                                  const std::string &output_path,
                                  const HtmlConfig &config) {
@@ -238,7 +271,7 @@ html::create_poppler_pdf_service(const PopplerPdfFile &pdf_file,
   // TODO check if this can be achieved in pdf2htmlEX
   auto html_renderer_mutex = std::make_shared<std::mutex>();
 
-  return odr::HtmlDocumentService(std::make_shared<HtmlDocumentServiceImpl>(
+  return odr::HtmlService(std::make_shared<HtmlServiceImpl>(
       pdf_file, output_path, std::move(html_renderer),
       std::move(html_renderer_mutex), std::move(html_renderer_param), config,
       resource_locator));

--- a/src/odr/internal/html/pdf2htmlex_wrapper.hpp
+++ b/src/odr/internal/html/pdf2htmlex_wrapper.hpp
@@ -6,7 +6,7 @@
 namespace odr {
 struct HtmlConfig;
 class Html;
-class HtmlDocumentService;
+class HtmlService;
 } // namespace odr
 
 namespace odr::internal {
@@ -15,10 +15,9 @@ class PopplerPdfFile;
 
 namespace odr::internal::html {
 
-odr::HtmlDocumentService
-create_poppler_pdf_service(const PopplerPdfFile &pdf_file,
-                           const std::string &output_path,
-                           const HtmlConfig &config);
+odr::HtmlService create_poppler_pdf_service(const PopplerPdfFile &pdf_file,
+                                            const std::string &output_path,
+                                            const HtmlConfig &config);
 
 Html translate_poppler_pdf_file(const PopplerPdfFile &pdf_file,
                                 const std::string &output_path,


### PR DESCRIPTION
Moving HTML service closer to paths and an HTTP endpoint. Rewriting the interface to allow writing to any kind of paths. Throws exception if that path does not exist.