### PR TITLE
refactor decryption frontend

### DIFF
--- a/cli/src/server.cpp
+++ b/cli/src/server.cpp
@@ -21,17 +21,17 @@ int main(int argc, char **argv) {
 
   DecodedFile decoded_file{input, decode_preference};
 
-  if (decoded_file.is_document_file()) {
-    DocumentFile document_file = decoded_file.document_file();
-    if (document_file.password_encrypted() && !password) {
-      std::cerr << "document encrypted but no password given" << std::endl;
-      return 2;
-    }
-    if (document_file.password_encrypted() &&
-        !document_file.decrypt(*password)) {
+  if (decoded_file.password_encrypted() && !password) {
+    std::cerr << "document encrypted but no password given" << std::endl;
+    return 2;
+  }
+  if (decoded_file.password_encrypted()) {
+    auto decrypt_result = decoded_file.decrypt(*password);
+    if (!decrypt_result.has_value()) {
       std::cerr << "wrong password" << std::endl;
       return 1;
     }
+    decoded_file = std::move(*decrypt_result);
   }
 
   HttpServer::Config server_config;

--- a/cli/src/translate.cpp
+++ b/cli/src/translate.cpp
@@ -19,17 +19,17 @@ int main(int argc, char **argv) {
 
   DecodedFile decoded_file{input};
 
-  if (decoded_file.is_document_file()) {
-    DocumentFile document_file = decoded_file.document_file();
-    if (document_file.password_encrypted() && !password) {
-      std::cerr << "document encrypted but no password given" << std::endl;
-      return 2;
-    }
-    if (document_file.password_encrypted() &&
-        !document_file.decrypt(*password)) {
+  if (decoded_file.password_encrypted() && !password) {
+    std::cerr << "document encrypted but no password given" << std::endl;
+    return 2;
+  }
+  if (decoded_file.password_encrypted()) {
+    auto decrypt_result = decoded_file.decrypt(*password);
+    if (!decrypt_result.has_value()) {
       std::cerr << "wrong password" << std::endl;
       return 1;
     }
+    decoded_file = std::move(*decrypt_result);
   }
 
   HtmlConfig config;

--- a/src/odr/file.hpp
+++ b/src/odr/file.hpp
@@ -154,8 +154,6 @@ public:
   explicit File(std::shared_ptr<internal::abstract::File>);
   explicit File(const std::string &path);
 
-  [[nodiscard]] explicit operator bool() const;
-
   [[nodiscard]] FileLocation location() const noexcept;
   [[nodiscard]] std::size_t size() const;
 
@@ -189,14 +187,16 @@ public:
   DecodedFile(const std::string &path, FileType as);
   DecodedFile(const std::string &path, const DecodePreference &preference);
 
-  [[nodiscard]] explicit operator bool() const;
+  [[nodiscard]] File file() const;
 
   [[nodiscard]] FileType file_type() const noexcept;
   [[nodiscard]] FileCategory file_category() const noexcept;
   [[nodiscard]] FileMeta file_meta() const noexcept;
   [[nodiscard]] DecoderEngine decoder_engine() const noexcept;
 
-  [[nodiscard]] File file() const;
+  [[nodiscard]] bool password_encrypted() const;
+  [[nodiscard]] EncryptionState encryption_state() const;
+  [[nodiscard]] std::optional<DecodedFile> decrypt(const std::string &password);
 
   [[nodiscard]] bool is_text_file() const;
   [[nodiscard]] bool is_image_file() const;
@@ -259,10 +259,6 @@ public:
   explicit DocumentFile(std::shared_ptr<internal::abstract::DocumentFile>);
   explicit DocumentFile(const std::string &path);
 
-  [[nodiscard]] bool password_encrypted() const;
-  [[nodiscard]] EncryptionState encryption_state() const;
-  bool decrypt(const std::string &password);
-
   [[nodiscard]] DocumentType document_type() const;
   [[nodiscard]] DocumentMeta document_meta() const;
 
@@ -278,10 +274,6 @@ private:
 class PdfFile final : public DecodedFile {
 public:
   explicit PdfFile(std::shared_ptr<internal::abstract::PdfFile>);
-
-  [[nodiscard]] bool password_encrypted() const;
-  [[nodiscard]] EncryptionState encryption_state() const;
-  bool decrypt(const std::string &password);
 
   [[nodiscard]] std::shared_ptr<internal::abstract::PdfFile> impl() const;
 

--- a/src/odr/internal/abstract/file.hpp
+++ b/src/odr/internal/abstract/file.hpp
@@ -47,6 +47,7 @@ public:
   }
   [[nodiscard]] virtual std::shared_ptr<DecodedFile>
   decrypt(const std::string &password) const noexcept {
+    (void)password;
     return nullptr;
   }
 };

--- a/src/odr/internal/abstract/file.hpp
+++ b/src/odr/internal/abstract/file.hpp
@@ -38,6 +38,17 @@ public:
   [[nodiscard]] virtual FileCategory file_category() const noexcept = 0;
   [[nodiscard]] virtual FileMeta file_meta() const noexcept = 0;
   [[nodiscard]] virtual DecoderEngine decoder_engine() const noexcept = 0;
+
+  [[nodiscard]] virtual bool password_encrypted() const noexcept {
+    return false;
+  }
+  [[nodiscard]] virtual EncryptionState encryption_state() const noexcept {
+    return EncryptionState::not_encrypted;
+  }
+  [[nodiscard]] virtual std::shared_ptr<DecodedFile>
+  decrypt(const std::string &password) const noexcept {
+    return nullptr;
+  }
 };
 
 class TextFile : public DecodedFile {
@@ -71,10 +82,6 @@ public:
     return FileCategory::document;
   }
 
-  [[nodiscard]] virtual bool password_encrypted() const noexcept = 0;
-  [[nodiscard]] virtual EncryptionState encryption_state() const noexcept = 0;
-  [[nodiscard]] virtual bool decrypt(const std::string &password) = 0;
-
   [[nodiscard]] virtual DocumentType document_type() const = 0;
   [[nodiscard]] virtual DocumentMeta document_meta() const = 0;
 
@@ -89,10 +96,6 @@ public:
   [[nodiscard]] FileCategory file_category() const noexcept final {
     return FileCategory::document;
   }
-
-  [[nodiscard]] virtual bool password_encrypted() const noexcept = 0;
-  [[nodiscard]] virtual EncryptionState encryption_state() const noexcept = 0;
-  [[nodiscard]] virtual bool decrypt(const std::string &password) = 0;
 };
 
 } // namespace odr::internal::abstract

--- a/src/odr/internal/odf/odf_crypto.hpp
+++ b/src/odr/internal/odf/odf_crypto.hpp
@@ -13,7 +13,7 @@ class ReadableFilesystem;
 
 namespace odr::internal::odf {
 
-bool can_decrypt(const Manifest::Entry &) noexcept;
+bool can_decrypt(const Manifest::Entry &entry) noexcept;
 
 std::string hash(const std::string &input, ChecksumType checksum_type);
 
@@ -21,17 +21,21 @@ std::string decrypt(const std::string &input, const std::string &derived_key,
                     const std::string &initialisation_vector,
                     AlgorithmType algorithm);
 
-std::string start_key(const Manifest::Entry &, const std::string &password);
+std::string start_key(const Manifest::Entry &entry,
+                      const std::string &password);
 
-std::string derive_key(const Manifest::Entry &, const std::string &start_key);
+std::string derive_key(const Manifest::Entry &entry,
+                       const std::string &start_key);
 
-std::string derive_key_and_decrypt(const Manifest::Entry &,
+std::string derive_key_and_decrypt(const Manifest::Entry &entry,
                                    const std::string &start_key,
                                    const std::string &input);
 
-bool validate_password(const Manifest::Entry &, std::string decrypted) noexcept;
+bool validate_password(const Manifest::Entry &entry,
+                       std::string decrypted) noexcept;
 
-bool decrypt(std::shared_ptr<abstract::ReadableFilesystem> &, const Manifest &,
-             const std::string &password);
+std::shared_ptr<abstract::ReadableFilesystem>
+decrypt(const std::shared_ptr<abstract::ReadableFilesystem> &filesystem,
+        const Manifest &manifest, const std::string &password);
 
 } // namespace odr::internal::odf

--- a/src/odr/internal/odf/odf_file.cpp
+++ b/src/odr/internal/odf/odf_file.cpp
@@ -78,7 +78,7 @@ OpenDocumentFile::decrypt(const std::string &password) const noexcept {
   decrypted_file->m_file_meta =
       parse_file_meta(*decrypted_file->m_filesystem, nullptr, true);
   decrypted_file->m_encryption_state = EncryptionState::decrypted;
-  return std::move(decrypted_file);
+  return decrypted_file;
 }
 
 std::shared_ptr<abstract::Document> OpenDocumentFile::document() const {

--- a/src/odr/internal/odf/odf_file.hpp
+++ b/src/odr/internal/odf/odf_file.hpp
@@ -34,7 +34,8 @@ public:
 
   [[nodiscard]] bool password_encrypted() const noexcept final;
   [[nodiscard]] EncryptionState encryption_state() const noexcept final;
-  bool decrypt(const std::string &password) final;
+  [[nodiscard]] std::shared_ptr<abstract::DecodedFile>
+  decrypt(const std::string &password) const noexcept final;
 
   [[nodiscard]] std::shared_ptr<abstract::Document> document() const final;
 

--- a/src/odr/internal/oldms/oldms_file.cpp
+++ b/src/odr/internal/oldms/oldms_file.cpp
@@ -79,6 +79,7 @@ EncryptionState LegacyMicrosoftFile::encryption_state() const noexcept {
 
 std::shared_ptr<abstract::DecodedFile>
 LegacyMicrosoftFile::decrypt(const std::string &password) const noexcept {
+  (void)password;
   return {}; // TODO throw
 }
 

--- a/src/odr/internal/oldms/oldms_file.cpp
+++ b/src/odr/internal/oldms/oldms_file.cpp
@@ -77,8 +77,9 @@ EncryptionState LegacyMicrosoftFile::encryption_state() const noexcept {
   return EncryptionState::unknown;
 }
 
-bool LegacyMicrosoftFile::decrypt(const std::string &) {
-  return false; // TODO throw
+std::shared_ptr<abstract::DecodedFile>
+LegacyMicrosoftFile::decrypt(const std::string &password) const noexcept {
+  return {}; // TODO throw
 }
 
 std::shared_ptr<abstract::Document> LegacyMicrosoftFile::document() const {

--- a/src/odr/internal/oldms/oldms_file.hpp
+++ b/src/odr/internal/oldms/oldms_file.hpp
@@ -31,7 +31,8 @@ public:
 
   [[nodiscard]] bool password_encrypted() const noexcept final;
   [[nodiscard]] EncryptionState encryption_state() const noexcept final;
-  bool decrypt(const std::string &password) final;
+  [[nodiscard]] std::shared_ptr<abstract::DecodedFile>
+  decrypt(const std::string &password) const noexcept final;
 
   [[nodiscard]] std::shared_ptr<abstract::Document> document() const final;
 

--- a/src/odr/internal/oldms_wvware/wvware_oldms_file.cpp
+++ b/src/odr/internal/oldms_wvware/wvware_oldms_file.cpp
@@ -125,7 +125,7 @@ WvWareLegacyMicrosoftFile::decrypt(const std::string &password) const noexcept {
 
   auto decrypted = std::make_shared<WvWareLegacyMicrosoftFile>(*this);
   decrypted->m_encryption_state = EncryptionState::decrypted;
-  return std::move(decrypted);
+  return decrypted;
 }
 
 std::shared_ptr<abstract::Document>

--- a/src/odr/internal/oldms_wvware/wvware_oldms_file.hpp
+++ b/src/odr/internal/oldms_wvware/wvware_oldms_file.hpp
@@ -33,7 +33,8 @@ public:
 
   [[nodiscard]] bool password_encrypted() const noexcept final;
   [[nodiscard]] EncryptionState encryption_state() const noexcept final;
-  bool decrypt(const std::string &password) final;
+  [[nodiscard]] std::shared_ptr<abstract::DecodedFile>
+  decrypt(const std::string &password) const noexcept final;
 
   [[nodiscard]] std::shared_ptr<abstract::Document> document() const final;
 

--- a/src/odr/internal/ooxml/ooxml_file.cpp
+++ b/src/odr/internal/ooxml/ooxml_file.cpp
@@ -20,9 +20,13 @@ class Document;
 namespace odr::internal::ooxml {
 
 OfficeOpenXmlFile::OfficeOpenXmlFile(
-    std::shared_ptr<abstract::ReadableFilesystem> filesystem) {
-  m_file_meta = parse_file_meta(*filesystem);
-  m_filesystem = std::move(filesystem);
+    std::shared_ptr<abstract::ReadableFilesystem> filesystem)
+    : m_filesystem(std::move(filesystem)) {
+  m_file_meta = parse_file_meta(*m_filesystem);
+
+  if (m_file_meta.password_encrypted) {
+    m_encryption_state = EncryptionState::encrypted;
+  }
 }
 
 std::shared_ptr<abstract::File> OfficeOpenXmlFile::file() const noexcept {

--- a/src/odr/internal/ooxml/ooxml_file.cpp
+++ b/src/odr/internal/ooxml/ooxml_file.cpp
@@ -80,7 +80,7 @@ OfficeOpenXmlFile::decrypt(const std::string &password) const noexcept {
   decrypted->m_filesystem = zip::ZipFile(memory_file).archive()->filesystem();
   decrypted->m_file_meta = parse_file_meta(*decrypted->m_filesystem);
   decrypted->m_encryption_state = EncryptionState::decrypted;
-  return std::move(decrypted);
+  return decrypted;
 }
 
 std::shared_ptr<abstract::Document> OfficeOpenXmlFile::document() const {

--- a/src/odr/internal/ooxml/ooxml_file.cpp
+++ b/src/odr/internal/ooxml/ooxml_file.cpp
@@ -55,26 +55,32 @@ EncryptionState OfficeOpenXmlFile::encryption_state() const noexcept {
   return m_encryption_state;
 }
 
-bool OfficeOpenXmlFile::decrypt(const std::string &password) {
-  // TODO throw if not encrypted
-  // TODO throw if decrypted
+std::shared_ptr<abstract::DecodedFile>
+OfficeOpenXmlFile::decrypt(const std::string &password) const noexcept {
+  if (m_encryption_state != EncryptionState::encrypted) {
+    return nullptr;
+  }
+
   std::string encryption_info = util::stream::read(
       *m_filesystem->open(common::Path("/EncryptionInfo"))->stream());
   // TODO cache Crypto::Util
   crypto::Util util(encryption_info);
   std::string key = util.derive_key(password);
   if (!util.verify(key)) {
-    return false;
+    return nullptr;
   }
+
   std::string encrypted_package = util::stream::read(
       *m_filesystem->open(common::Path("/EncryptedPackage"))->stream());
   std::string decrypted_package = util.decrypt(encrypted_package, key);
+
   auto memory_file =
       std::make_shared<common::MemoryFile>(std::move(decrypted_package));
-  m_filesystem = zip::ZipFile(memory_file).archive()->filesystem();
-  m_file_meta = parse_file_meta(*m_filesystem);
-  m_encryption_state = EncryptionState::decrypted;
-  return true;
+  auto decrypted = std::make_shared<OfficeOpenXmlFile>(*this);
+  decrypted->m_filesystem = zip::ZipFile(memory_file).archive()->filesystem();
+  decrypted->m_file_meta = parse_file_meta(*decrypted->m_filesystem);
+  decrypted->m_encryption_state = EncryptionState::decrypted;
+  return std::move(decrypted);
 }
 
 std::shared_ptr<abstract::Document> OfficeOpenXmlFile::document() const {

--- a/src/odr/internal/ooxml/ooxml_file.hpp
+++ b/src/odr/internal/ooxml/ooxml_file.hpp
@@ -33,7 +33,8 @@ public:
 
   [[nodiscard]] bool password_encrypted() const noexcept final;
   [[nodiscard]] EncryptionState encryption_state() const noexcept final;
-  bool decrypt(const std::string &password) final;
+  [[nodiscard]] std::shared_ptr<abstract::DecodedFile>
+  decrypt(const std::string &password) const noexcept final;
 
   [[nodiscard]] std::shared_ptr<abstract::Document> document() const final;
 

--- a/src/odr/internal/pdf/pdf_file.cpp
+++ b/src/odr/internal/pdf/pdf_file.cpp
@@ -21,6 +21,9 @@ EncryptionState PdfFile::encryption_state() const noexcept {
   return EncryptionState::not_encrypted;
 }
 
-bool PdfFile::decrypt(const std::string &) { return false; }
+std::shared_ptr<abstract::DecodedFile>
+PdfFile::decrypt(const std::string &password) const noexcept {
+  return nullptr;
+}
 
 } // namespace odr::internal

--- a/src/odr/internal/pdf/pdf_file.cpp
+++ b/src/odr/internal/pdf/pdf_file.cpp
@@ -23,6 +23,7 @@ EncryptionState PdfFile::encryption_state() const noexcept {
 
 std::shared_ptr<abstract::DecodedFile>
 PdfFile::decrypt(const std::string &password) const noexcept {
+  (void)password;
   return nullptr;
 }
 

--- a/src/odr/internal/pdf/pdf_file.hpp
+++ b/src/odr/internal/pdf/pdf_file.hpp
@@ -15,7 +15,8 @@ public:
 
   [[nodiscard]] bool password_encrypted() const noexcept final;
   [[nodiscard]] EncryptionState encryption_state() const noexcept final;
-  [[nodiscard]] bool decrypt(const std::string &password) final;
+  [[nodiscard]] std::shared_ptr<abstract::DecodedFile>
+  decrypt(const std::string &password) const noexcept final;
 
 private:
   std::shared_ptr<abstract::File> m_file;

--- a/src/odr/internal/pdf_poppler/poppler_pdf_file.cpp
+++ b/src/odr/internal/pdf_poppler/poppler_pdf_file.cpp
@@ -79,14 +79,21 @@ EncryptionState PopplerPdfFile::encryption_state() const noexcept {
   return m_encryption_state;
 }
 
-bool PopplerPdfFile::decrypt(const std::string &password) {
+std::shared_ptr<abstract::DecodedFile>
+PopplerPdfFile::decrypt(const std::string &password) const noexcept {
   if (encryption_state() != EncryptionState::encrypted) {
-    return false;
+    return nullptr;
   }
 
-  open(password);
-
-  return encryption_state() == EncryptionState::decrypted;
+  auto decrypted_file = std::make_shared<PopplerPdfFile>(*this);
+  try {
+    decrypted_file->open(password);
+    if (decrypted_file->encryption_state() == EncryptionState::decrypted) {
+      return std::move(decrypted_file);
+    }
+  } catch (const std::exception &e) {
+  }
+  return nullptr;
 }
 
 PDFDoc &PopplerPdfFile::pdf_doc() const { return *m_pdf_doc; }

--- a/src/odr/internal/pdf_poppler/poppler_pdf_file.cpp
+++ b/src/odr/internal/pdf_poppler/poppler_pdf_file.cpp
@@ -89,7 +89,7 @@ PopplerPdfFile::decrypt(const std::string &password) const noexcept {
   try {
     decrypted_file->open(password);
     if (decrypted_file->encryption_state() == EncryptionState::decrypted) {
-      return std::move(decrypted_file);
+      return decrypted_file;
     }
   } catch (const std::exception &e) {
   }

--- a/src/odr/internal/pdf_poppler/poppler_pdf_file.hpp
+++ b/src/odr/internal/pdf_poppler/poppler_pdf_file.hpp
@@ -20,7 +20,8 @@ public:
 
   [[nodiscard]] bool password_encrypted() const noexcept final;
   [[nodiscard]] EncryptionState encryption_state() const noexcept final;
-  [[nodiscard]] bool decrypt(const std::string &password) final;
+  [[nodiscard]] std::shared_ptr<abstract::DecodedFile>
+  decrypt(const std::string &password) const noexcept final;
 
   [[nodiscard]] PDFDoc &pdf_doc() const;
 

--- a/test/src/document_test.cpp
+++ b/test/src/document_test.cpp
@@ -106,8 +106,12 @@ TEST(Document, edit_ods_diff) {
       R"({"modifiedText":{"/child:0/row:0/child:0/child:0/child:0":"Page 1 hi","/child:1/row:0/child:0/child:0/child:0":"Page 2 hihi","/child:2/row:0/child:0/child:0/child:0":"Page 3 hihihi","/child:3/row:0/child:0/child:0/child:0":"Page 4 hihihihi","/child:4/row:0/child:0/child:0/child:0":"Page 5 hihihihihi"}})";
   DocumentFile document_file(
       TestData::test_file_path("odr-public/ods/pages.ods"));
-  document_file.decrypt(
-      TestData::test_file("odr-public/ods/pages.ods").password.value());
+  document_file =
+      document_file
+          .decrypt(
+              TestData::test_file("odr-public/ods/pages.ods").password.value())
+          .value()
+          .document_file();
   Document document = document_file.document();
 
   html::edit(document, diff);

--- a/test/src/html_output_test.cpp
+++ b/test/src/html_output_test.cpp
@@ -81,33 +81,25 @@ TEST_P(HtmlOutputTests, html_meta) {
     GTEST_SKIP();
   }
 
+  // TODO wvware decryption
+  if (test_file.password.has_value() &&
+      (test_file.type == FileType::legacy_word_document) &&
+      (engine == DecoderEngine::wvware)) {
+    GTEST_SKIP();
+  }
+
+  EXPECT_EQ(test_file.password.has_value(), file.password_encrypted());
+
+  if (test_file.password.has_value()) {
+    auto decrypt_result = file.decrypt(test_file.password.value());
+    EXPECT_TRUE(decrypt_result.has_value());
+    file = std::move(*decrypt_result);
+  }
+
   if (file.is_document_file()) {
     DocumentFile document_file = file.document_file();
 
-    EXPECT_EQ(test_file.password.has_value(),
-              document_file.password_encrypted());
-
-    // TODO wvware decryption
-    if (test_file.password.has_value() &&
-        (test_file.type == FileType::legacy_word_document) &&
-        (engine == DecoderEngine::wvware)) {
-      GTEST_SKIP();
-    }
-
-    if (test_file.password.has_value()) {
-      EXPECT_TRUE(document_file.decrypt(test_file.password.value()));
-    }
-
     EXPECT_EQ(test_file.type, document_file.file_type());
-  }
-
-  if (file.is_pdf_file()) {
-    PdfFile pdf_file = file.pdf_file();
-
-    EXPECT_EQ(test_file.password.has_value(), pdf_file.password_encrypted());
-    if (test_file.password.has_value()) {
-      EXPECT_TRUE(pdf_file.decrypt(test_file.password.value()));
-    }
   }
 
   fs::create_directories(output_path);


### PR DESCRIPTION
- move `decrypt` to `DecodedFile`
- `decrypt` creates a new `DecodedFile` instead of mutating the existing one