### PR TITLE
PDF: stream filter framework

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -180,6 +180,7 @@ set(ODR_SOURCE_FILES
         "src/odr/internal/pdf/pdf_file.cpp"
         "src/odr/internal/pdf/pdf_file_object.cpp"
         "src/odr/internal/pdf/pdf_file_parser.cpp"
+        "src/odr/internal/pdf/pdf_filter.cpp"
         "src/odr/internal/pdf/pdf_graphics_operator_parser.cpp"
         "src/odr/internal/pdf/pdf_graphics_state.cpp"
         "src/odr/internal/pdf/pdf_object.cpp"

--- a/src/odr/internal/crypto/crypto_util.cpp
+++ b/src/odr/internal/crypto/crypto_util.cpp
@@ -204,4 +204,13 @@ std::string util::zlib_inflate(const std::string &input) {
   return result;
 }
 
+std::string util::zlib_deflate(const std::string &input) {
+  std::string out;
+  CryptoPP::ZlibCompressor compressor(new CryptoPP::StringSink(out));
+  compressor.Put(reinterpret_cast<const CryptoPP::byte *>(input.data()),
+                 input.size());
+  compressor.MessageEnd();
+  return out;
+}
+
 } // namespace odr::internal::crypto

--- a/src/odr/internal/crypto/crypto_util.hpp
+++ b/src/odr/internal/crypto/crypto_util.hpp
@@ -32,5 +32,6 @@ std::string inflate(const std::string &input);
 std::size_t padding(const std::string &input);
 
 std::string zlib_inflate(const std::string &input);
+std::string zlib_deflate(const std::string &input);
 
 } // namespace odr::internal::crypto::util

--- a/src/odr/internal/html/pdf_file.cpp
+++ b/src/odr/internal/html/pdf_file.cpp
@@ -4,7 +4,6 @@
 #include <odr/file.hpp>
 #include <odr/html.hpp>
 
-#include <odr/internal/crypto/crypto_util.hpp>
 #include <odr/internal/html/html_service.hpp>
 #include <odr/internal/html/html_writer.hpp>
 #include <odr/internal/pdf/pdf_document.hpp>
@@ -118,12 +117,9 @@ public:
 
       std::string stream;
       for (const auto &content_reference : page->contents_reference) {
-        pdf::IndirectObject page_contents_object =
-            parser.read_object(content_reference);
-        std::string page_content =
-            parser.read_object_stream(page_contents_object);
-        page_content = crypto::util::zlib_inflate(page_content);
-        stream += page_content;
+        // streams of one page join at token boundaries (ISO 32000-1 7.7.3.3)
+        stream += parser.read_decoded_stream(content_reference);
+        stream += '\n';
       }
 
       std::istringstream ss(stream);

--- a/src/odr/internal/oldms/presentation/ppt_structs.hpp
+++ b/src/odr/internal/oldms/presentation/ppt_structs.hpp
@@ -7,7 +7,7 @@ namespace odr::internal::oldms::presentation {
 // Filled by copying file bytes straight in (see ppt_io), so multi-byte fields
 // use host byte order — correct only on little-endian hosts (see ppt_io.hpp).
 // Bit-fields additionally assume LSB-first allocation, which all supported
-// compilers use on little-endian targets (same as the sibling .doc module).
+// compilers use on little-endian targets (shared oldms/ assumption).
 
 /// Record types relevant to text extraction. See [MS-PPT] 2.13.24 RecordType.
 enum RecordType : std::uint16_t {

--- a/src/odr/internal/oldms/spreadsheet/xls_structs.hpp
+++ b/src/odr/internal/oldms/spreadsheet/xls_structs.hpp
@@ -10,7 +10,7 @@ namespace odr::internal::oldms::spreadsheet {
 // Filled by copying file bytes straight in (see xls_io), so multi-byte fields
 // use host byte order — correct only on little-endian hosts (see xls_io.hpp).
 // Bit-fields additionally assume LSB-first allocation, which all supported
-// compilers use on little-endian targets (same as the sibling .doc module).
+// compilers use on little-endian targets (shared oldms/ assumption).
 
 /// BIFF8 record type values handled here ([MS-XLS] 2.3 Record Enumeration).
 enum BiffRecordType : std::uint16_t {

--- a/src/odr/internal/oldms/text/doc_structs.hpp
+++ b/src/odr/internal/oldms/text/doc_structs.hpp
@@ -9,6 +9,11 @@
 
 namespace odr::internal::oldms::text {
 
+// Filled by copying file bytes straight in (see doc_io), so multi-byte fields
+// use host byte order — correct only on little-endian hosts. Bit-fields
+// additionally assume LSB-first allocation, which all supported compilers use
+// on little-endian targets (shared oldms/ assumption).
+
 enum NFibValues : std::uint16_t {
   nFib97 = 0x00C1,
   nFib2000 = 0x00D9,

--- a/src/odr/internal/pdf/pdf_document_parser.cpp
+++ b/src/odr/internal/pdf/pdf_document_parser.cpp
@@ -1,10 +1,10 @@
 #include <odr/internal/pdf/pdf_document_parser.hpp>
 
-#include <odr/internal/crypto/crypto_util.hpp>
 #include <odr/internal/pdf/pdf_cmap_parser.hpp>
 #include <odr/internal/pdf/pdf_document.hpp>
 #include <odr/internal/pdf/pdf_document_element.hpp>
 #include <odr/internal/pdf/pdf_file_parser.hpp>
+#include <odr/internal/pdf/pdf_filter.hpp>
 
 #include <ranges>
 #include <sstream>
@@ -28,11 +28,9 @@ Font *parse_font(DocumentParser &parser, const ObjectReference &reference,
   font->object = Object(dictionary);
 
   if (dictionary.has_key("ToUnicode")) {
-    IndirectObject to_unicode_obj =
-        parser.read_object(dictionary["ToUnicode"].as_reference());
-    std::string stream = parser.read_object_stream(to_unicode_obj);
-    std::string inflate = crypto::util::zlib_inflate(stream);
-    std::istringstream ss(inflate);
+    std::string stream =
+        parser.read_decoded_stream(dictionary["ToUnicode"].as_reference());
+    std::istringstream ss(stream);
     CMapParser cmap_parser(ss);
     font->cmap = cmap_parser.parse_cmap();
   }
@@ -204,6 +202,32 @@ std::string DocumentParser::read_object_stream(const IndirectObject &object) {
 
   in().seekg(object.stream_position.value());
   return m_parser.read_stream(static_cast<std::int32_t>(size));
+}
+
+std::string
+DocumentParser::read_decoded_stream(const ObjectReference &reference) {
+  return read_decoded_stream(read_object(reference));
+}
+
+std::string DocumentParser::read_decoded_stream(const IndirectObject &object) {
+  std::string raw = read_object_stream(object);
+
+  const Dictionary &dictionary = object.object.as_dictionary();
+  Object filter;
+  Object decode_parms;
+  if (dictionary.has_key("Filter")) {
+    filter = deep_resolve_object_copy(dictionary["Filter"]);
+  }
+  if (dictionary.has_key("DecodeParms")) {
+    decode_parms = deep_resolve_object_copy(dictionary["DecodeParms"]);
+  }
+
+  DecodeResult result = decode(filter, decode_parms, std::move(raw));
+  if (result.stopped_at_filter.has_value()) {
+    throw std::runtime_error("unexpected image filter: " +
+                             *result.stopped_at_filter);
+  }
+  return std::move(result.data);
 }
 
 std::unique_ptr<Document> DocumentParser::parse_document() {

--- a/src/odr/internal/pdf/pdf_document_parser.hpp
+++ b/src/odr/internal/pdf/pdf_document_parser.hpp
@@ -22,6 +22,9 @@ public:
   const IndirectObject &read_object(const ObjectReference &reference);
   std::string read_object_stream(const ObjectReference &reference);
   std::string read_object_stream(const IndirectObject &object);
+  /// `read_object_stream` plus the `/Filter` chain (image codecs throw).
+  std::string read_decoded_stream(const ObjectReference &reference);
+  std::string read_decoded_stream(const IndirectObject &object);
 
   void resolve_object(Object &object);
   void deep_resolve_object(Object &object);

--- a/src/odr/internal/pdf/pdf_filter.cpp
+++ b/src/odr/internal/pdf/pdf_filter.cpp
@@ -409,7 +409,7 @@ std::string pdf::lzw_decode(const std::string &input,
   return result;
 }
 
-std::string run_length_decode(const std::string &input) {
+std::string pdf::run_length_decode(const std::string &input) {
   std::string result;
 
   std::size_t i = 0;

--- a/src/odr/internal/pdf/pdf_filter.cpp
+++ b/src/odr/internal/pdf/pdf_filter.cpp
@@ -1,0 +1,467 @@
+#include <odr/internal/pdf/pdf_filter.hpp>
+
+#include <odr/internal/crypto/crypto_util.hpp>
+
+#include <algorithm>
+#include <cstdint>
+#include <cstdlib>
+#include <stdexcept>
+#include <vector>
+
+namespace odr::internal::pdf {
+
+namespace {
+
+bool is_whitespace(const char c) {
+  return c == '\0' || c == '\t' || c == '\n' || c == '\f' || c == '\r' ||
+         c == ' ';
+}
+
+int hex_value(const char c) {
+  if (c >= '0' && c <= '9') {
+    return c - '0';
+  }
+  if (c >= 'A' && c <= 'F') {
+    return c - 'A' + 10;
+  }
+  if (c >= 'a' && c <= 'f') {
+    return c - 'a' + 10;
+  }
+  return -1;
+}
+
+/// Inline-image abbreviations are accepted for regular streams, too; real
+/// producers use them there.
+std::string canonical_filter_name(const std::string &name) {
+  if (name == "AHx") {
+    return "ASCIIHexDecode";
+  }
+  if (name == "A85") {
+    return "ASCII85Decode";
+  }
+  if (name == "LZW") {
+    return "LZWDecode";
+  }
+  if (name == "Fl") {
+    return "FlateDecode";
+  }
+  if (name == "RL") {
+    return "RunLengthDecode";
+  }
+  if (name == "CCF") {
+    return "CCITTFaxDecode";
+  }
+  if (name == "DCT") {
+    return "DCTDecode";
+  }
+  return name;
+}
+
+bool is_image_codec(const std::string &name) {
+  return name == "DCTDecode" || name == "JPXDecode" ||
+         name == "CCITTFaxDecode" || name == "JBIG2Decode";
+}
+
+Integer parms_integer(const Object &parms, const std::string &key,
+                      const Integer default_value) {
+  if (!parms.is_dictionary()) {
+    return default_value;
+  }
+  const Dictionary &dictionary = parms.as_dictionary();
+  if (!dictionary.has_key(key)) {
+    return default_value;
+  }
+  return dictionary[key].as_integer();
+}
+
+std::string apply_filter(const std::string &name, const Object &parms,
+                         std::string data) {
+  if (name == "FlateDecode" || name == "LZWDecode") {
+    if (name == "FlateDecode") {
+      data = crypto::util::zlib_inflate(data);
+    } else {
+      data = lzw_decode(data, parms_integer(parms, "EarlyChange", 1));
+    }
+    if (const Integer predictor = parms_integer(parms, "Predictor", 1);
+        predictor > 1) {
+      data = apply_predictor(std::move(data), predictor,
+                             parms_integer(parms, "Colors", 1),
+                             parms_integer(parms, "BitsPerComponent", 8),
+                             parms_integer(parms, "Columns", 1));
+    }
+    return data;
+  }
+  if (name == "ASCIIHexDecode") {
+    return ascii_hex_decode(data);
+  }
+  if (name == "ASCII85Decode") {
+    return ascii85_decode(data);
+  }
+  if (name == "RunLengthDecode") {
+    return run_length_decode(data);
+  }
+  if (name == "Crypt") {
+    // Only the Identity crypt filter passes through here (7.4.10); actual
+    // decryption is the security handler's job.
+    if (!parms.is_dictionary() || !parms.as_dictionary().has_key("Name") ||
+        parms.as_dictionary()["Name"].as_string() == "Identity") {
+      return data;
+    }
+    throw std::runtime_error("unsupported Crypt filter: " +
+                             parms.as_dictionary()["Name"].as_string());
+  }
+  throw std::runtime_error("unknown stream filter: " + name);
+}
+
+} // namespace
+
+DecodeResult decode(const Object &filter, const Object &decode_parms,
+                    std::string data) {
+  DecodeResult result;
+
+  std::vector<Object> filters;
+  if (filter.is_array()) {
+    for (const Object &entry : filter.as_array()) {
+      filters.push_back(entry);
+    }
+  } else if (!filter.is_null()) {
+    filters.push_back(filter);
+  }
+
+  const auto parms_for = [&](const std::size_t i) -> Object {
+    if (decode_parms.is_array()) {
+      const Array &array = decode_parms.as_array();
+      return i < array.size() ? array[i] : Object();
+    }
+    return i == 0 ? decode_parms : Object();
+  };
+
+  for (std::size_t i = 0; i < filters.size(); ++i) {
+    const std::string name = canonical_filter_name(filters[i].as_string());
+    const Object parms = parms_for(i);
+    if (is_image_codec(name)) {
+      result.stopped_at_filter = name;
+      result.stopped_at_parms = parms;
+      break;
+    }
+    data = apply_filter(name, parms, std::move(data));
+  }
+
+  result.data = std::move(data);
+  return result;
+}
+
+std::string ascii_hex_decode(const std::string &input) {
+  std::string result;
+  result.reserve(input.size() / 2);
+
+  bool have_first = false;
+  int first = 0;
+  for (const char c : input) {
+    if (is_whitespace(c)) {
+      continue;
+    }
+    if (c == '>') {
+      break;
+    }
+    const int value = hex_value(c);
+    if (value < 0) {
+      throw std::runtime_error("invalid character in ASCIIHexDecode");
+    }
+    if (have_first) {
+      result.push_back(static_cast<char>((first << 4) | value));
+      have_first = false;
+    } else {
+      first = value;
+      have_first = true;
+    }
+  }
+  if (have_first) {
+    // odd number of digits: behave as if a 0 followed (7.4.2)
+    result.push_back(static_cast<char>(first << 4));
+  }
+
+  return result;
+}
+
+std::string ascii85_decode(const std::string &input) {
+  std::string result;
+  result.reserve(input.size() * 4 / 5);
+
+  std::uint32_t digits[5];
+  std::size_t n = 0;
+
+  const auto flush = [&](const std::size_t count) {
+    for (std::size_t i = count; i < 5; ++i) {
+      digits[i] = 84; // pad as if 'u'
+    }
+    std::uint64_t value = 0;
+    for (const std::uint32_t digit : digits) {
+      value = value * 85 + digit;
+    }
+    if (value > 0xffffffffu) {
+      throw std::runtime_error("ASCII85Decode group out of range");
+    }
+    for (std::size_t i = 0; i + 1 < count; ++i) {
+      result.push_back(static_cast<char>((value >> (24 - 8 * i)) & 0xff));
+    }
+  };
+
+  for (std::size_t i = 0; i < input.size(); ++i) {
+    const char c = input[i];
+    if (is_whitespace(c)) {
+      continue;
+    }
+    if (c == 'z') {
+      if (n != 0) {
+        throw std::runtime_error("ASCII85Decode: z inside group");
+      }
+      result.append(4, '\0');
+      continue;
+    }
+    if (c == '~') {
+      break;
+    }
+    if (c < '!' || c > 'u') {
+      throw std::runtime_error("invalid character in ASCII85Decode");
+    }
+    digits[n++] = static_cast<std::uint32_t>(c - '!');
+    if (n == 5) {
+      flush(5);
+      n = 0;
+    }
+  }
+  if (n == 1) {
+    throw std::runtime_error("ASCII85Decode: truncated group");
+  }
+  if (n > 1) {
+    flush(n);
+  }
+
+  return result;
+}
+
+std::string lzw_decode(const std::string &input, const Integer early_change) {
+  std::string result;
+
+  std::vector<std::string> table; // codes 258 and up
+  std::string previous;
+  std::uint32_t width = 9;
+  std::size_t bit_position = 0;
+  const std::size_t bit_end = input.size() * 8;
+
+  const auto read_code = [&]() -> std::uint32_t {
+    if (bit_position + width > bit_end) {
+      return 257; // input exhausted without EOD marker: treat as EOD
+    }
+    std::uint32_t code = 0;
+    for (std::uint32_t i = 0; i < width; ++i, ++bit_position) {
+      const auto byte = static_cast<unsigned char>(input[bit_position >> 3]);
+      code = (code << 1) | ((byte >> (7 - (bit_position & 7))) & 1);
+    }
+    return code;
+  };
+
+  while (true) {
+    const std::uint32_t code = read_code();
+    if (code == 257) {
+      break;
+    }
+    if (code == 256) {
+      table.clear();
+      previous.clear();
+      width = 9;
+      continue;
+    }
+
+    std::string entry;
+    if (code < 256) {
+      entry = std::string(1, static_cast<char>(code));
+    } else {
+      if (previous.empty()) {
+        throw std::runtime_error("LZWDecode: sequence code after clear");
+      }
+      const std::size_t index = code - 258;
+      if (index < table.size()) {
+        entry = table[index];
+      } else if (index == table.size()) {
+        entry = previous + previous[0];
+      } else {
+        throw std::runtime_error("LZWDecode: invalid code");
+      }
+    }
+
+    if (!previous.empty()) {
+      table.push_back(previous + entry[0]);
+      const std::uint64_t next_code = 258 + table.size();
+      if (next_code + early_change == 512) {
+        width = 10;
+      } else if (next_code + early_change == 1024) {
+        width = 11;
+      } else if (next_code + early_change == 2048) {
+        width = 12;
+      }
+    }
+    result += entry;
+    previous = std::move(entry);
+  }
+
+  return result;
+}
+
+std::string run_length_decode(const std::string &input) {
+  std::string result;
+
+  std::size_t i = 0;
+  while (i < input.size()) {
+    const auto length = static_cast<unsigned char>(input[i++]);
+    if (length == 128) {
+      break;
+    }
+    if (length < 128) {
+      if (i + length + 1 > input.size()) {
+        throw std::runtime_error("RunLengthDecode: truncated input");
+      }
+      result.append(input, i, length + 1);
+      i += length + 1;
+    } else {
+      if (i >= input.size()) {
+        throw std::runtime_error("RunLengthDecode: truncated input");
+      }
+      result.append(257 - length, input[i++]);
+    }
+  }
+
+  return result;
+}
+
+namespace {
+
+std::string apply_tiff_predictor(std::string data, const Integer colors,
+                                 const Integer bits_per_component,
+                                 const Integer columns) {
+  if (bits_per_component != 8 && bits_per_component != 16) {
+    throw std::runtime_error("unsupported TIFF predictor bits per component: " +
+                             std::to_string(bits_per_component));
+  }
+
+  const std::size_t component_bytes = bits_per_component / 8;
+  const std::size_t pixel_bytes = colors * component_bytes;
+  const std::size_t row_bytes = columns * pixel_bytes;
+  if (row_bytes == 0 || data.size() % row_bytes != 0) {
+    throw std::runtime_error("TIFF predictor: data not a whole number of rows");
+  }
+
+  for (std::size_t row = 0; row < data.size(); row += row_bytes) {
+    for (std::size_t i = pixel_bytes; i < row_bytes; i += component_bytes) {
+      if (component_bytes == 1) {
+        data[row + i] = static_cast<char>(
+            static_cast<unsigned char>(data[row + i]) +
+            static_cast<unsigned char>(data[row + i - pixel_bytes]));
+      } else {
+        const std::uint32_t left =
+            (static_cast<unsigned char>(data[row + i - pixel_bytes]) << 8) |
+            static_cast<unsigned char>(data[row + i - pixel_bytes + 1]);
+        const std::uint32_t value =
+            (static_cast<unsigned char>(data[row + i]) << 8) |
+            static_cast<unsigned char>(data[row + i + 1]);
+        const std::uint32_t sum = value + left;
+        data[row + i] = static_cast<char>((sum >> 8) & 0xff);
+        data[row + i + 1] = static_cast<char>(sum & 0xff);
+      }
+    }
+  }
+
+  return data;
+}
+
+std::string apply_png_predictor(const std::string &data, const Integer colors,
+                                const Integer bits_per_component,
+                                const Integer columns) {
+  const std::size_t row_bytes = (columns * colors * bits_per_component + 7) / 8;
+  const std::size_t pixel_bytes =
+      std::max<Integer>(1, colors * bits_per_component / 8);
+  if (row_bytes == 0 || data.size() % (row_bytes + 1) != 0) {
+    throw std::runtime_error("PNG predictor: data not a whole number of rows");
+  }
+
+  std::string result;
+  result.reserve(data.size());
+  std::string up_row(row_bytes, '\0');
+  std::string row(row_bytes, '\0');
+
+  for (std::size_t in = 0; in < data.size(); in += row_bytes + 1) {
+    const auto tag = static_cast<unsigned char>(data[in]);
+    for (std::size_t i = 0; i < row_bytes; ++i) {
+      const auto raw = static_cast<unsigned char>(data[in + 1 + i]);
+      const unsigned char left =
+          i >= pixel_bytes ? static_cast<unsigned char>(row[i - pixel_bytes])
+                           : 0;
+      const auto up = static_cast<unsigned char>(up_row[i]);
+      const unsigned char up_left =
+          i >= pixel_bytes ? static_cast<unsigned char>(up_row[i - pixel_bytes])
+                           : 0;
+
+      unsigned char value;
+      switch (tag) {
+      case 0: // None
+        value = raw;
+        break;
+      case 1: // Sub
+        value = raw + left;
+        break;
+      case 2: // Up
+        value = raw + up;
+        break;
+      case 3: // Average
+        value = raw + static_cast<unsigned char>((left + up) / 2);
+        break;
+      case 4: { // Paeth
+        const int p = left + up - up_left;
+        const int pa = std::abs(p - left);
+        const int pb = std::abs(p - up);
+        const int pc = std::abs(p - up_left);
+        unsigned char predicted;
+        if (pa <= pb && pa <= pc) {
+          predicted = left;
+        } else if (pb <= pc) {
+          predicted = up;
+        } else {
+          predicted = up_left;
+        }
+        value = raw + predicted;
+        break;
+      }
+      default:
+        throw std::runtime_error("PNG predictor: unknown row tag " +
+                                 std::to_string(tag));
+      }
+      row[i] = static_cast<char>(value);
+    }
+    result += row;
+    std::swap(up_row, row);
+  }
+
+  return result;
+}
+
+} // namespace
+
+std::string apply_predictor(std::string data, const Integer predictor,
+                            const Integer colors,
+                            const Integer bits_per_component,
+                            const Integer columns) {
+  if (predictor <= 1) {
+    return data;
+  }
+  if (predictor == 2) {
+    return apply_tiff_predictor(std::move(data), colors, bits_per_component,
+                                columns);
+  }
+  if (predictor >= 10 && predictor <= 15) {
+    return apply_png_predictor(data, colors, bits_per_component, columns);
+  }
+  throw std::runtime_error("unknown predictor: " + std::to_string(predictor));
+}
+
+} // namespace odr::internal::pdf

--- a/src/odr/internal/pdf/pdf_filter.cpp
+++ b/src/odr/internal/pdf/pdf_filter.cpp
@@ -260,7 +260,7 @@ std::string pdf::ascii_hex_decode(const std::string &input) {
   std::string result;
   result.reserve(input.size() / 2);
 
-  std::optional<std::uint8_t> first = 0;
+  std::optional<std::uint8_t> first;
   for (const char c : input) {
     if (ObjectParser::is_whitespace(c)) {
       continue;

--- a/src/odr/internal/pdf/pdf_filter.cpp
+++ b/src/odr/internal/pdf/pdf_filter.cpp
@@ -1,23 +1,17 @@
 #include <odr/internal/pdf/pdf_filter.hpp>
 
 #include <odr/internal/crypto/crypto_util.hpp>
+#include <odr/internal/pdf/pdf_object_parser.hpp>
 
 #include <algorithm>
-#include <cstdint>
 #include <cstdlib>
 #include <stdexcept>
 #include <vector>
 
 namespace odr::internal::pdf {
-
 namespace {
 
-bool is_whitespace(const char c) {
-  return c == '\0' || c == '\t' || c == '\n' || c == '\f' || c == '\r' ||
-         c == ' ';
-}
-
-int hex_value(const char c) {
+std::uint8_t hex_value(const char c) {
   if (c >= '0' && c <= '9') {
     return c - '0';
   }
@@ -27,7 +21,7 @@ int hex_value(const char c) {
   if (c >= 'a' && c <= 'f') {
     return c - 'a' + 10;
   }
-  return -1;
+  throw std::runtime_error("invalid character in ASCIIHexDecode");
 }
 
 /// Inline-image abbreviations are accepted for regular streams, too; real
@@ -113,10 +107,121 @@ std::string apply_filter(const std::string &name, const Object &parms,
   throw std::runtime_error("unknown stream filter: " + name);
 }
 
-} // namespace
+std::string apply_tiff_predictor(std::string data, const Integer colors,
+                                 const Integer bits_per_component,
+                                 const Integer columns) {
+  if (bits_per_component != 8 && bits_per_component != 16) {
+    throw std::runtime_error("unsupported TIFF predictor bits per component: " +
+                             std::to_string(bits_per_component));
+  }
 
-DecodeResult decode(const Object &filter, const Object &decode_parms,
-                    std::string data) {
+  const std::size_t component_bytes = bits_per_component / 8;
+  const std::size_t pixel_bytes = colors * component_bytes;
+  const std::size_t row_bytes = columns * pixel_bytes;
+  if (row_bytes == 0 || data.size() % row_bytes != 0) {
+    throw std::runtime_error("TIFF predictor: data not a whole number of rows");
+  }
+
+  for (std::size_t row = 0; row < data.size(); row += row_bytes) {
+    for (std::size_t i = pixel_bytes; i < row_bytes; i += component_bytes) {
+      if (component_bytes == 1) {
+        data[row + i] = static_cast<char>(
+            static_cast<std::uint8_t>(data[row + i]) +
+            static_cast<std::uint8_t>(data[row + i - pixel_bytes]));
+      } else {
+        const std::uint32_t left =
+            (static_cast<std::uint8_t>(data[row + i - pixel_bytes]) << 8) |
+            static_cast<std::uint8_t>(data[row + i - pixel_bytes + 1]);
+        const std::uint32_t value =
+            (static_cast<std::uint8_t>(data[row + i]) << 8) |
+            static_cast<std::uint8_t>(data[row + i + 1]);
+        const std::uint32_t sum = value + left;
+        data[row + i] = static_cast<char>((sum >> 8) & 0xff);
+        data[row + i + 1] = static_cast<char>(sum & 0xff);
+      }
+    }
+  }
+
+  return data;
+}
+
+std::string apply_png_predictor(const std::string &data, const Integer colors,
+                                const Integer bits_per_component,
+                                const Integer columns) {
+  const std::size_t row_bytes = (columns * colors * bits_per_component + 7) / 8;
+  const std::size_t pixel_bytes =
+      std::max<Integer>(1, colors * bits_per_component / 8);
+  if (row_bytes == 0 || data.size() % (row_bytes + 1) != 0) {
+    throw std::runtime_error("PNG predictor: data not a whole number of rows");
+  }
+
+  std::string result;
+  result.reserve(data.size());
+  std::string up_row(row_bytes, '\0');
+  std::string row(row_bytes, '\0');
+
+  for (std::size_t in = 0; in < data.size(); in += row_bytes + 1) {
+    const auto tag = static_cast<std::uint8_t>(data[in]);
+    for (std::size_t i = 0; i < row_bytes; ++i) {
+      const auto raw = static_cast<std::uint8_t>(data[in + 1 + i]);
+      const std::uint8_t left =
+          i >= pixel_bytes ? static_cast<std::uint8_t>(row[i - pixel_bytes])
+                           : 0;
+      const auto up = static_cast<std::uint8_t>(up_row[i]);
+      const std::uint8_t up_left =
+          i >= pixel_bytes ? static_cast<std::uint8_t>(up_row[i - pixel_bytes])
+                           : 0;
+
+      std::uint8_t value;
+      switch (tag) {
+      case 0: // None
+        value = raw;
+        break;
+      case 1: // Sub
+        value = raw + left;
+        break;
+      case 2: // Up
+        value = raw + up;
+        break;
+      case 3: // Average
+        value = raw + static_cast<std::uint8_t>((left + up) / 2);
+        break;
+      case 4: { // Paeth
+        const std::int32_t p = left + up - up_left;
+        const std::int32_t pa = std::abs(p - left);
+        const std::int32_t pb = std::abs(p - up);
+        const std::int32_t pc = std::abs(p - up_left);
+        std::uint8_t predicted;
+        if (pa <= pb && pa <= pc) {
+          predicted = left;
+        } else if (pb <= pc) {
+          predicted = up;
+        } else {
+          predicted = up_left;
+        }
+        value = raw + predicted;
+        break;
+      }
+      default:
+        throw std::runtime_error("PNG predictor: unknown row tag " +
+                                 std::to_string(tag));
+      }
+      row[i] = static_cast<char>(value);
+    }
+    result += row;
+    std::swap(up_row, row);
+  }
+
+  return result;
+}
+
+} // namespace
+} // namespace odr::internal::pdf
+
+namespace odr::internal {
+
+pdf::DecodeResult pdf::decode(const Object &filter, const Object &decode_parms,
+                              std::string data) {
   DecodeResult result;
 
   std::vector<Object> filters;
@@ -151,44 +256,39 @@ DecodeResult decode(const Object &filter, const Object &decode_parms,
   return result;
 }
 
-std::string ascii_hex_decode(const std::string &input) {
+std::string pdf::ascii_hex_decode(const std::string &input) {
   std::string result;
   result.reserve(input.size() / 2);
 
-  bool have_first = false;
-  int first = 0;
+  std::optional<std::uint8_t> first = 0;
   for (const char c : input) {
-    if (is_whitespace(c)) {
+    if (ObjectParser::is_whitespace(c)) {
       continue;
     }
     if (c == '>') {
       break;
     }
-    const int value = hex_value(c);
-    if (value < 0) {
-      throw std::runtime_error("invalid character in ASCIIHexDecode");
-    }
-    if (have_first) {
-      result.push_back(static_cast<char>((first << 4) | value));
-      have_first = false;
+    const std::uint8_t value = hex_value(c);
+    if (first.has_value()) {
+      result.push_back(static_cast<char>((*first << 4) | value));
+      first.reset();
     } else {
       first = value;
-      have_first = true;
     }
   }
-  if (have_first) {
+  if (first.has_value()) {
     // odd number of digits: behave as if a 0 followed (7.4.2)
-    result.push_back(static_cast<char>(first << 4));
+    result.push_back(static_cast<char>(*first << 4));
   }
 
   return result;
 }
 
-std::string ascii85_decode(const std::string &input) {
+std::string pdf::ascii85_decode(const std::string &input) {
   std::string result;
   result.reserve(input.size() * 4 / 5);
 
-  std::uint32_t digits[5];
+  std::array<std::uint32_t, 5> digits{};
   std::size_t n = 0;
 
   const auto flush = [&](const std::size_t count) {
@@ -207,9 +307,8 @@ std::string ascii85_decode(const std::string &input) {
     }
   };
 
-  for (std::size_t i = 0; i < input.size(); ++i) {
-    const char c = input[i];
-    if (is_whitespace(c)) {
+  for (const char c : input) {
+    if (ObjectParser::is_whitespace(c)) {
       continue;
     }
     if (c == 'z') {
@@ -241,7 +340,8 @@ std::string ascii85_decode(const std::string &input) {
   return result;
 }
 
-std::string lzw_decode(const std::string &input, const Integer early_change) {
+std::string pdf::lzw_decode(const std::string &input,
+                            const Integer early_change) {
   std::string result;
 
   std::vector<std::string> table; // codes 258 and up
@@ -256,7 +356,7 @@ std::string lzw_decode(const std::string &input, const Integer early_change) {
     }
     std::uint32_t code = 0;
     for (std::uint32_t i = 0; i < width; ++i, ++bit_position) {
-      const auto byte = static_cast<unsigned char>(input[bit_position >> 3]);
+      const auto byte = static_cast<std::uint8_t>(input[bit_position >> 3]);
       code = (code << 1) | ((byte >> (7 - (bit_position & 7))) & 1);
     }
     return code;
@@ -314,7 +414,7 @@ std::string run_length_decode(const std::string &input) {
 
   std::size_t i = 0;
   while (i < input.size()) {
-    const auto length = static_cast<unsigned char>(input[i++]);
+    const auto length = static_cast<std::uint8_t>(input[i++]);
     if (length == 128) {
       break;
     }
@@ -335,122 +435,10 @@ std::string run_length_decode(const std::string &input) {
   return result;
 }
 
-namespace {
-
-std::string apply_tiff_predictor(std::string data, const Integer colors,
+std::string pdf::apply_predictor(std::string data, const Integer predictor,
+                                 const Integer colors,
                                  const Integer bits_per_component,
                                  const Integer columns) {
-  if (bits_per_component != 8 && bits_per_component != 16) {
-    throw std::runtime_error("unsupported TIFF predictor bits per component: " +
-                             std::to_string(bits_per_component));
-  }
-
-  const std::size_t component_bytes = bits_per_component / 8;
-  const std::size_t pixel_bytes = colors * component_bytes;
-  const std::size_t row_bytes = columns * pixel_bytes;
-  if (row_bytes == 0 || data.size() % row_bytes != 0) {
-    throw std::runtime_error("TIFF predictor: data not a whole number of rows");
-  }
-
-  for (std::size_t row = 0; row < data.size(); row += row_bytes) {
-    for (std::size_t i = pixel_bytes; i < row_bytes; i += component_bytes) {
-      if (component_bytes == 1) {
-        data[row + i] = static_cast<char>(
-            static_cast<unsigned char>(data[row + i]) +
-            static_cast<unsigned char>(data[row + i - pixel_bytes]));
-      } else {
-        const std::uint32_t left =
-            (static_cast<unsigned char>(data[row + i - pixel_bytes]) << 8) |
-            static_cast<unsigned char>(data[row + i - pixel_bytes + 1]);
-        const std::uint32_t value =
-            (static_cast<unsigned char>(data[row + i]) << 8) |
-            static_cast<unsigned char>(data[row + i + 1]);
-        const std::uint32_t sum = value + left;
-        data[row + i] = static_cast<char>((sum >> 8) & 0xff);
-        data[row + i + 1] = static_cast<char>(sum & 0xff);
-      }
-    }
-  }
-
-  return data;
-}
-
-std::string apply_png_predictor(const std::string &data, const Integer colors,
-                                const Integer bits_per_component,
-                                const Integer columns) {
-  const std::size_t row_bytes = (columns * colors * bits_per_component + 7) / 8;
-  const std::size_t pixel_bytes =
-      std::max<Integer>(1, colors * bits_per_component / 8);
-  if (row_bytes == 0 || data.size() % (row_bytes + 1) != 0) {
-    throw std::runtime_error("PNG predictor: data not a whole number of rows");
-  }
-
-  std::string result;
-  result.reserve(data.size());
-  std::string up_row(row_bytes, '\0');
-  std::string row(row_bytes, '\0');
-
-  for (std::size_t in = 0; in < data.size(); in += row_bytes + 1) {
-    const auto tag = static_cast<unsigned char>(data[in]);
-    for (std::size_t i = 0; i < row_bytes; ++i) {
-      const auto raw = static_cast<unsigned char>(data[in + 1 + i]);
-      const unsigned char left =
-          i >= pixel_bytes ? static_cast<unsigned char>(row[i - pixel_bytes])
-                           : 0;
-      const auto up = static_cast<unsigned char>(up_row[i]);
-      const unsigned char up_left =
-          i >= pixel_bytes ? static_cast<unsigned char>(up_row[i - pixel_bytes])
-                           : 0;
-
-      unsigned char value;
-      switch (tag) {
-      case 0: // None
-        value = raw;
-        break;
-      case 1: // Sub
-        value = raw + left;
-        break;
-      case 2: // Up
-        value = raw + up;
-        break;
-      case 3: // Average
-        value = raw + static_cast<unsigned char>((left + up) / 2);
-        break;
-      case 4: { // Paeth
-        const int p = left + up - up_left;
-        const int pa = std::abs(p - left);
-        const int pb = std::abs(p - up);
-        const int pc = std::abs(p - up_left);
-        unsigned char predicted;
-        if (pa <= pb && pa <= pc) {
-          predicted = left;
-        } else if (pb <= pc) {
-          predicted = up;
-        } else {
-          predicted = up_left;
-        }
-        value = raw + predicted;
-        break;
-      }
-      default:
-        throw std::runtime_error("PNG predictor: unknown row tag " +
-                                 std::to_string(tag));
-      }
-      row[i] = static_cast<char>(value);
-    }
-    result += row;
-    std::swap(up_row, row);
-  }
-
-  return result;
-}
-
-} // namespace
-
-std::string apply_predictor(std::string data, const Integer predictor,
-                            const Integer colors,
-                            const Integer bits_per_component,
-                            const Integer columns) {
   if (predictor <= 1) {
     return data;
   }
@@ -464,4 +452,4 @@ std::string apply_predictor(std::string data, const Integer predictor,
   throw std::runtime_error("unknown predictor: " + std::to_string(predictor));
 }
 
-} // namespace odr::internal::pdf
+} // namespace odr::internal

--- a/src/odr/internal/pdf/pdf_filter.hpp
+++ b/src/odr/internal/pdf/pdf_filter.hpp
@@ -1,0 +1,36 @@
+#pragma once
+
+#include <odr/internal/pdf/pdf_object.hpp>
+
+#include <optional>
+#include <string>
+
+namespace odr::internal::pdf {
+
+/// Result of decoding a stream through its `/Filter` chain (ISO 32000-1 7.4).
+/// If the chain reaches an image codec (DCTDecode, JPXDecode, CCITTFaxDecode,
+/// JBIG2Decode), decoding stops there: `data` holds the still-encoded payload,
+/// `stopped_at_filter` the codec's canonical name and `stopped_at_parms` its
+/// decode parameters.
+struct DecodeResult {
+  std::string data;
+  std::optional<std::string> stopped_at_filter;
+  Object stopped_at_parms;
+};
+
+/// `filter` and `decode_parms` are the already reference-resolved values of
+/// `/Filter` and `/DecodeParms`: null, a single name/dictionary, or parallel
+/// arrays.
+DecodeResult decode(const Object &filter, const Object &decode_parms,
+                    std::string data);
+
+std::string ascii_hex_decode(const std::string &input);
+std::string ascii85_decode(const std::string &input);
+std::string lzw_decode(const std::string &input, Integer early_change = 1);
+std::string run_length_decode(const std::string &input);
+
+/// Predictor post-pass for Flate/LZW streams (ISO 32000-1 7.4.4.4).
+std::string apply_predictor(std::string data, Integer predictor, Integer colors,
+                            Integer bits_per_component, Integer columns);
+
+} // namespace odr::internal::pdf

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -39,6 +39,7 @@ add_executable(odr_test
 
         "src/internal/pdf/pdf_document_parser.cpp"
         "src/internal/pdf/pdf_file_parser.cpp"
+        "src/internal/pdf/pdf_filter.cpp"
 
         "src/internal/svm/svm_test.cpp"
 

--- a/test/src/internal/pdf/pdf_document_parser.cpp
+++ b/test/src/internal/pdf/pdf_document_parser.cpp
@@ -1,5 +1,4 @@
 #include <odr/internal/common/file.hpp>
-#include <odr/internal/crypto/crypto_util.hpp>
 #include <odr/internal/pdf/pdf_document.hpp>
 #include <odr/internal/pdf/pdf_document_element.hpp>
 #include <odr/internal/pdf/pdf_document_parser.hpp>
@@ -52,12 +51,11 @@ TEST(DocumentParser, foo) {
   }
 
   Page *first_page = ordered_pages.front();
-  std::string stream;
+  std::string first_page_content;
   for (const auto &content_reference : first_page->contents_reference) {
-    IndirectObject page_contents_object = parser.read_object(content_reference);
-    stream += parser.read_object_stream(page_contents_object);
+    first_page_content += parser.read_decoded_stream(content_reference);
+    first_page_content += '\n';
   }
-  std::string first_page_content = crypto::util::zlib_inflate(stream);
 
   std::istringstream ss(first_page_content);
   GraphicsOperatorParser parser2(ss);

--- a/test/src/internal/pdf/pdf_filter.cpp
+++ b/test/src/internal/pdf/pdf_filter.cpp
@@ -1,0 +1,178 @@
+#include <odr/internal/pdf/pdf_filter.hpp>
+#include <odr/internal/pdf/pdf_object.hpp>
+
+#include <stdexcept>
+#include <string>
+
+#include <cryptopp/filters.h>
+#include <cryptopp/zlib.h>
+
+#include <gtest/gtest.h>
+
+using namespace odr::internal::pdf;
+
+namespace {
+
+std::string zlib_deflate(const std::string &in) {
+  std::string out;
+  CryptoPP::ZlibCompressor compressor(new CryptoPP::StringSink(out));
+  compressor.Put(reinterpret_cast<const CryptoPP::byte *>(in.data()),
+                 in.size());
+  compressor.MessageEnd();
+  return out;
+}
+
+Object name(const std::string &string) { return Object(Name(string)); }
+
+Object dictionary(Dictionary::Holder holder) {
+  return Object(Dictionary(std::move(holder)));
+}
+
+Object array(Array::Holder holder) { return Object(Array(std::move(holder))); }
+
+} // namespace
+
+TEST(PdfFilter, ascii_hex_decode) {
+  EXPECT_EQ(ascii_hex_decode("48656C6C6F>"), "Hello");
+  EXPECT_EQ(ascii_hex_decode("48 65\n6c6C\t6F >"), "Hello");
+  // odd digit count: as if a 0 followed (0x70 = 'p')
+  EXPECT_EQ(ascii_hex_decode("48656C6C6F7>"), "Hellop");
+  EXPECT_EQ(ascii_hex_decode(">"), "");
+  EXPECT_THROW(ascii_hex_decode("4G>"), std::runtime_error);
+}
+
+TEST(PdfFilter, ascii85_decode) {
+  EXPECT_EQ(ascii85_decode("9jqo^~>"), "Man ");
+  EXPECT_EQ(ascii85_decode("9j qo\n^~>"), "Man ");
+  // partial group: 2 bytes from 3 characters
+  EXPECT_EQ(ascii85_decode("9jn~>"), "Ma");
+  // z is shorthand for four zero bytes
+  EXPECT_EQ(ascii85_decode("z~>"), std::string(4, '\0'));
+  // group value above 2^32 - 1
+  EXPECT_THROW(ascii85_decode("uuuuu~>"), std::runtime_error);
+  // single leftover character is impossible
+  EXPECT_THROW(ascii85_decode("9~>"), std::runtime_error);
+  EXPECT_THROW(ascii85_decode("9jzo^~>"), std::runtime_error);
+}
+
+TEST(PdfFilter, lzw_decode) {
+  // ISO 32000-1 7.4.4.2, Examples 1+2: codes for 45 45 45 45 45 65 45 45 45 66
+  const std::string encoded = "\x80\x0B\x60\x50\x22\x0C\x0C\x85\x01";
+  EXPECT_EQ(lzw_decode(encoded), "-----A---B");
+}
+
+TEST(PdfFilter, run_length_decode) {
+  // copy 3 literal bytes, then repeat 'z' 257-254 = 3 times
+  EXPECT_EQ(run_length_decode("\x02"
+                              "abc\xFEz\x80"),
+            "abczzz");
+  EXPECT_EQ(run_length_decode("\x80"), "");
+  EXPECT_THROW(run_length_decode("\x05"
+                                 "ab"),
+               std::runtime_error);
+}
+
+TEST(PdfFilter, png_predictor_up) {
+  // two rows of four bytes, both tagged Up (2)
+  const std::string data("\x02\x01\x01\x01\x01"
+                         "\x02\x01\x01\x01\x01",
+                         10);
+  EXPECT_EQ(apply_predictor(data, 12, 1, 8, 4),
+            std::string("\x01\x01\x01\x01\x02\x02\x02\x02", 8));
+}
+
+TEST(PdfFilter, png_predictor_sub) {
+  const std::string data("\x01\x01\x01\x01\x01", 5);
+  EXPECT_EQ(apply_predictor(data, 11, 1, 8, 4),
+            std::string("\x01\x02\x03\x04", 4));
+}
+
+TEST(PdfFilter, png_predictor_paeth) {
+  // row 1 unfiltered (None), row 2 Paeth against row 1
+  const std::string data("\x00\x0A\x14\x1E\x28"
+                         "\x04\x05\x05\x05\x05",
+                         10);
+  EXPECT_EQ(apply_predictor(data, 14, 1, 8, 4),
+            std::string("\x0A\x14\x1E\x28\x0F\x19\x23\x2D", 8));
+}
+
+TEST(PdfFilter, png_predictor_rejects_partial_row) {
+  EXPECT_THROW(apply_predictor(std::string("\x02\x01", 2), 12, 1, 8, 4),
+               std::runtime_error);
+}
+
+TEST(PdfFilter, tiff_predictor) {
+  // one row, three colour components, two columns
+  const std::string data("\x01\x02\x03\x01\x02\x03", 6);
+  EXPECT_EQ(apply_predictor(data, 2, 3, 8, 2),
+            std::string("\x01\x02\x03\x02\x04\x06", 6));
+}
+
+TEST(PdfFilter, decode_no_filter) {
+  const DecodeResult result = decode(Object(), Object(), "hello");
+  EXPECT_EQ(result.data, "hello");
+  EXPECT_FALSE(result.stopped_at_filter.has_value());
+}
+
+TEST(PdfFilter, decode_flate) {
+  const DecodeResult result =
+      decode(name("FlateDecode"), Object(), zlib_deflate("hello"));
+  EXPECT_EQ(result.data, "hello");
+}
+
+TEST(PdfFilter, decode_flate_abbreviation) {
+  const DecodeResult result =
+      decode(name("Fl"), Object(), zlib_deflate("hello"));
+  EXPECT_EQ(result.data, "hello");
+}
+
+TEST(PdfFilter, decode_flate_with_png_predictor) {
+  // the layout every xref stream uses: Flate around PNG Up rows
+  const std::string predicted("\x02\x01\x01\x01\x01"
+                              "\x02\x01\x01\x01\x01",
+                              10);
+  const DecodeResult result =
+      decode(name("FlateDecode"),
+             dictionary({{"Predictor", Object(Integer(12))},
+                         {"Columns", Object(Integer(4))}}),
+             zlib_deflate(predicted));
+  EXPECT_EQ(result.data, std::string("\x01\x01\x01\x01\x02\x02\x02\x02", 8));
+}
+
+TEST(PdfFilter, decode_chain) {
+  // [ /AHx /RL ]: hex encoding of the run-length example above
+  const DecodeResult result =
+      decode(array({name("AHx"), name("RL")}), Object(), "02616263FE7A80>");
+  EXPECT_EQ(result.data, "abczzz");
+}
+
+TEST(PdfFilter, decode_stops_at_image_codec) {
+  const Object parms = dictionary({{"ColorTransform", Object(Integer(0))}});
+  const DecodeResult result =
+      decode(array({name("FlateDecode"), name("DCTDecode")}),
+             array({Object(), parms}), zlib_deflate("jpeg payload"));
+  ASSERT_TRUE(result.stopped_at_filter.has_value());
+  EXPECT_EQ(*result.stopped_at_filter, "DCTDecode");
+  EXPECT_EQ(result.data, "jpeg payload");
+  ASSERT_TRUE(result.stopped_at_parms.is_dictionary());
+  EXPECT_EQ(
+      result.stopped_at_parms.as_dictionary()["ColorTransform"].as_integer(),
+      0);
+}
+
+TEST(PdfFilter, decode_crypt_identity_passes_through) {
+  const DecodeResult result =
+      decode(name("Crypt"), dictionary({{"Name", name("Identity")}}), "data");
+  EXPECT_EQ(result.data, "data");
+}
+
+TEST(PdfFilter, decode_crypt_other_throws) {
+  EXPECT_THROW(
+      decode(name("Crypt"), dictionary({{"Name", name("StdCF")}}), "data"),
+      std::runtime_error);
+}
+
+TEST(PdfFilter, decode_unknown_filter_throws) {
+  EXPECT_THROW(decode(name("NoSuchDecode"), Object(), "data"),
+               std::runtime_error);
+}

--- a/test/src/internal/pdf/pdf_filter.cpp
+++ b/test/src/internal/pdf/pdf_filter.cpp
@@ -1,26 +1,17 @@
 #include <odr/internal/pdf/pdf_filter.hpp>
+
+#include "odr/internal/crypto/crypto_util.hpp"
 #include <odr/internal/pdf/pdf_object.hpp>
 
 #include <stdexcept>
 #include <string>
 
-#include <cryptopp/filters.h>
-#include <cryptopp/zlib.h>
-
 #include <gtest/gtest.h>
 
 using namespace odr::internal::pdf;
+using namespace odr::internal::crypto::util;
 
 namespace {
-
-std::string zlib_deflate(const std::string &in) {
-  std::string out;
-  CryptoPP::ZlibCompressor compressor(new CryptoPP::StringSink(out));
-  compressor.Put(reinterpret_cast<const CryptoPP::byte *>(in.data()),
-                 in.size());
-  compressor.MessageEnd();
-  return out;
-}
 
 Object name(const std::string &string) { return Object(Name(string)); }
 


### PR DESCRIPTION
A stream filter framework, so streams are decoded through their actual `/Filter` chain instead of unconditionally zlib-inflating.

## What

- New `pdf_filter.{hpp,cpp}`: `decode(filter, decode_parms, data)` over the `/Filter`/`/DecodeParms` chain — single name or parallel arrays, inline-image abbreviations (`Fl`, `AHx`, …) accepted.
  - Decoders: **FlateDecode** (existing Crypto++ inflate), hand-rolled **LZWDecode** (9–12-bit codes, `EarlyChange`), **ASCIIHexDecode**, **ASCII85Decode**, **RunLengthDecode**.
  - **TIFF predictor 2** and **PNG predictors 10–15** as the post-pass for Flate/LZW (the layout every PDF 1.5+ xref stream uses — groundwork for later).
  - Image codecs (DCTDecode, JPXDecode, CCITTFaxDecode, JBIG2Decode) are deliberately not decoded: `decode()` stops and returns the still-encoded payload (`DecodeResult::stopped_at_filter`) for later image support.
  - `Crypt` passes through only as `Identity`; actual decryption comes later.
- New `DocumentParser::read_decoded_stream()`: resolves indirect `/Filter`/`/DecodeParms` values and decodes; both previous unconditional-inflate call sites (ToUnicode CMaps, page content) now go through it.
- Multiple `Contents` streams of a page decode individually and join with a newline (token-boundary join, ISO 32000-1 7.7.3.3) — the old code concatenated compressed bytes and inflated once, which only worked for single-stream pages.

## Tests

`test/src/internal/pdf/pdf_filter.cpp` — 18 assertion-based tests, every input an inline string literal (no fixture files): per-decoder vectors incl. the spec's LZW example (7.4.4.2), Flate via a runtime compress helper, predictor rows, chain decoding, image-codec stop, error paths. The ASCII85 vectors were verified against Python's `base64.a85decode`.

Full suite: 378 tests, 0 failures; `translate` CLI renders `odr-public/pdf/style-various-1.pdf` end-to-end through the new path.