### PR TITLE
PDF: xref streams, object streams, hybrid files

### DIFF
--- a/src/odr/internal/html/pdf_file.cpp
+++ b/src/odr/internal/html/pdf_file.cpp
@@ -73,7 +73,7 @@ public:
     HtmlResources resources;
 
     auto in = m_pdf_file.file().stream();
-    pdf::DocumentParser parser(*in);
+    pdf::DocumentParser parser(*in, *m_logger);
 
     std::unique_ptr<pdf::Document> document = parser.parse_document();
 

--- a/src/odr/internal/pdf/pdf_document_parser.cpp
+++ b/src/odr/internal/pdf/pdf_document_parser.cpp
@@ -198,18 +198,17 @@ DocumentParser::read_object(const ObjectReference &reference) {
     object = parser().read_indirect_object();
   } else if (entry.is_compressed()) {
     const auto &[stream_id, index] = entry.as_compressed();
-    ObjectStream &object_stream = load_object_stream(stream_id);
-    if (index >= object_stream.members().size()) {
+    const ObjectStream &members = load_object_stream(stream_id);
+    if (index >= members.size()) {
       throw std::runtime_error("object stream member index out of range");
     }
-    if (object_stream.members()[index].first != reference.id) {
+    if (members[index].id != reference.id) {
       ODR_WARNING(*m_logger, "pdf: object stream "
                                  << stream_id << " member " << index
-                                 << " has id "
-                                 << object_stream.members()[index].first
+                                 << " has id " << members[index].id
                                  << ", expected " << reference.id);
     }
-    object.object = object_stream.member_object(index);
+    object.object = members[index].object;
   } else {
     ODR_WARNING(*m_logger, "pdf: reference " << reference
                                              << " to freed object, treating "
@@ -219,7 +218,7 @@ DocumentParser::read_object(const ObjectReference &reference) {
   return m_objects.emplace(reference, std::move(object)).first->second;
 }
 
-ObjectStream &
+const ObjectStream &
 DocumentParser::load_object_stream(const std::uint32_t stream_id) {
   if (const auto it = m_object_streams.find(stream_id);
       it != std::end(m_object_streams)) {
@@ -238,8 +237,8 @@ DocumentParser::load_object_stream(const std::uint32_t stream_id) {
   const std::uint32_t first =
       resolve_object_copy(dictionary["First"]).as_integer();
 
-  return m_object_streams
-      .emplace(stream_id, ObjectStream(std::move(data), n, first))
+  std::istringstream in(std::move(data));
+  return m_object_streams.emplace(stream_id, parse_object_stream(in, n, first))
       .first->second;
 }
 
@@ -330,10 +329,15 @@ DocumentParser::read_xref_section(const std::uint32_t position) {
                              *decoded.stopped_at_filter);
   }
 
-  std::vector<std::uint32_t> field_widths;
-  for (const Object &width : dictionary["W"].as_array()) {
-    field_widths.push_back(width.as_integer());
+  const Array &widths = dictionary["W"].as_array();
+  if (widths.size() != 3) {
+    throw std::runtime_error(
+        "expected three field widths in cross-reference stream /W");
   }
+  const std::array<std::uint32_t, 3> field_widths = {
+      static_cast<std::uint32_t>(widths[0].as_integer()),
+      static_cast<std::uint32_t>(widths[1].as_integer()),
+      static_cast<std::uint32_t>(widths[2].as_integer())};
 
   std::vector<std::pair<std::uint32_t, std::uint32_t>> subsections;
   if (dictionary.has_key("Index")) {

--- a/src/odr/internal/pdf/pdf_document_parser.cpp
+++ b/src/odr/internal/pdf/pdf_document_parser.cpp
@@ -1,12 +1,16 @@
 #include <odr/internal/pdf/pdf_document_parser.hpp>
 
+#include <odr/logger.hpp>
+
 #include <odr/internal/pdf/pdf_cmap_parser.hpp>
 #include <odr/internal/pdf/pdf_document.hpp>
 #include <odr/internal/pdf/pdf_document_element.hpp>
 #include <odr/internal/pdf/pdf_file_parser.hpp>
 #include <odr/internal/pdf/pdf_filter.hpp>
 
+#include <optional>
 #include <ranges>
+#include <set>
 #include <sstream>
 
 namespace odr::internal::pdf {
@@ -163,7 +167,11 @@ Catalog *parse_catalog(DocumentParser &parser, const ObjectReference &reference,
 
 } // namespace
 
-DocumentParser::DocumentParser(std::istream &in) : m_parser(in) {}
+DocumentParser::DocumentParser(std::istream &in)
+    : DocumentParser(in, Logger::null()) {}
+
+DocumentParser::DocumentParser(std::istream &in, Logger &logger)
+    : m_parser(in), m_logger{&logger} {}
 
 std::istream &DocumentParser::in() { return m_parser.in(); }
 
@@ -177,11 +185,62 @@ DocumentParser::read_object(const ObjectReference &reference) {
     return it->second;
   }
 
-  const std::uint32_t position = m_xref.table.at(reference).position;
-  in().seekg(position);
-  IndirectObject object = parser().read_indirect_object();
+  IndirectObject object;
+  object.reference = reference;
+
+  const auto entry_it = m_xref.table.find(reference);
+  if (entry_it == std::end(m_xref.table)) {
+    ODR_WARNING(*m_logger, "pdf: object " << reference
+                                          << " not in cross-reference table, "
+                                             "treating as null");
+  } else if (const Xref::Entry &entry = entry_it->second; entry.is_used()) {
+    in().seekg(entry.as_used().position);
+    object = parser().read_indirect_object();
+  } else if (entry.is_compressed()) {
+    const auto &[stream_id, index] = entry.as_compressed();
+    ObjectStream &object_stream = load_object_stream(stream_id);
+    if (index >= object_stream.members().size()) {
+      throw std::runtime_error("object stream member index out of range");
+    }
+    if (object_stream.members()[index].first != reference.id) {
+      ODR_WARNING(*m_logger, "pdf: object stream "
+                                 << stream_id << " member " << index
+                                 << " has id "
+                                 << object_stream.members()[index].first
+                                 << ", expected " << reference.id);
+    }
+    object.object = object_stream.member_object(index);
+  } else {
+    ODR_WARNING(*m_logger, "pdf: reference " << reference
+                                             << " to freed object, treating "
+                                                "as null");
+  }
 
   return m_objects.emplace(reference, std::move(object)).first->second;
+}
+
+ObjectStream &
+DocumentParser::load_object_stream(const std::uint32_t stream_id) {
+  if (const auto it = m_object_streams.find(stream_id);
+      it != std::end(m_object_streams)) {
+    return it->second;
+  }
+
+  const IndirectObject &object = read_object(ObjectReference(stream_id, 0));
+  if (!object.has_stream) {
+    throw std::runtime_error("object stream " + std::to_string(stream_id) +
+                             " has no stream data");
+  }
+  const Dictionary &dictionary = object.object.as_dictionary();
+
+  std::string data = read_decoded_stream(object);
+  const std::uint32_t n = resolve_object_copy(dictionary["N"]).as_integer();
+  const std::uint32_t first =
+      resolve_object_copy(dictionary["First"]).as_integer();
+
+  return m_object_streams
+      .emplace(stream_id, ObjectStream(std::move(data), n, first))
+      .first->second;
 }
 
 std::string
@@ -230,34 +289,103 @@ std::string DocumentParser::read_decoded_stream(const IndirectObject &object) {
   return std::move(result.data);
 }
 
+std::pair<Xref, Dictionary>
+DocumentParser::read_xref_section(const std::uint32_t position) {
+  in().clear();
+  in().seekg(position);
+  parser().parser().skip_whitespace();
+
+  if (!parser().parser().peek_number()) {
+    // classic cross-reference table
+    Xref xref = parser().read_xref();
+    parser().parser().skip_whitespace();
+    Trailer trailer = parser().read_trailer();
+    return {std::move(xref), std::move(trailer.dictionary)};
+  }
+
+  // cross-reference stream (ISO 32000-1 7.5.8); its dictionary doubles as
+  // the trailer dictionary
+  IndirectObject object = parser().read_indirect_object();
+  const Dictionary &dictionary = object.object.as_dictionary();
+
+  if (!object.has_stream) {
+    throw std::runtime_error("cross-reference stream has no stream data");
+  }
+  if (!dictionary.has_key("Type") || !dictionary["Type"].is_name() ||
+      dictionary["Type"].as_name() != "XRef") {
+    ODR_WARNING(*m_logger, "pdf: cross-reference stream at "
+                               << position << " is not marked /Type /XRef");
+  }
+
+  // `/Filter`, `/DecodeParms` and `/Length` are required to be direct in
+  // cross-reference streams (7.5.8.2), so no reference resolution here.
+  std::string data = read_object_stream(object);
+  DecodeResult decoded = decode(
+      dictionary.has_key("Filter") ? dictionary["Filter"] : Object(),
+      dictionary.has_key("DecodeParms") ? dictionary["DecodeParms"] : Object(),
+      std::move(data));
+  if (decoded.stopped_at_filter.has_value()) {
+    throw std::runtime_error("unexpected image filter in cross-reference "
+                             "stream: " +
+                             *decoded.stopped_at_filter);
+  }
+
+  std::vector<std::uint32_t> field_widths;
+  for (const Object &width : dictionary["W"].as_array()) {
+    field_widths.push_back(width.as_integer());
+  }
+
+  std::vector<std::pair<std::uint32_t, std::uint32_t>> subsections;
+  if (dictionary.has_key("Index")) {
+    const Array &index = dictionary["Index"].as_array();
+    for (std::size_t i = 0; i + 1 < index.size(); i += 2) {
+      subsections.emplace_back(index[i].as_integer(),
+                               index[i + 1].as_integer());
+    }
+  } else {
+    subsections.emplace_back(0, dictionary["Size"].as_integer());
+  }
+
+  Xref xref = parse_xref_stream_table(decoded.data, field_widths, subsections);
+  return {std::move(xref), dictionary};
+}
+
 std::unique_ptr<Document> DocumentParser::parse_document() {
   parser().seek_start_xref();
   const StartXref start_xref = parser().read_start_xref();
 
-  std::uint32_t xref_position = start_xref.start;
-  std::optional<Trailer> trailer;
+  std::optional<Dictionary> trailer;
+  std::optional<std::uint32_t> position = start_xref.start;
+  std::set<std::uint32_t> visited; // guards against `Prev` cycles
 
-  while (true) {
-    in().seekg(xref_position);
+  while (position.has_value() && visited.insert(*position).second) {
+    auto [xref, trailer_dict] = read_xref_section(*position);
 
-    m_xref.append(parser().read_xref());
-    parser().parser().skip_whitespace();
-    Trailer new_trailer = parser().read_trailer();
-    if (!trailer) {
-      trailer = new_trailer;
+    // hybrid-reference file (7.5.8.4): the `XRefStm` entries fill in what
+    // the classic table leaves absent or marks free, before older sections
+    // are appended
+    if (trailer_dict.has_key("XRefStm")) {
+      auto [stream_xref, stream_dict] =
+          read_xref_section(trailer_dict["XRefStm"].as_integer());
+      xref.merge_hybrid(stream_xref);
     }
 
-    if (new_trailer.dictionary.has_key("Prev")) {
-      xref_position = new_trailer.dictionary["Prev"].as_integer();
-      continue;
+    m_xref.append(xref);
+
+    if (trailer_dict.has_key("Prev")) {
+      position = trailer_dict["Prev"].as_integer();
+    } else {
+      position.reset();
     }
 
-    break;
+    if (!trailer.has_value()) {
+      trailer = std::move(trailer_dict);
+    }
   }
 
   auto document = std::make_unique<Document>();
   document->catalog =
-      parse_catalog(*this, trailer->root_reference(), *document);
+      parse_catalog(*this, (*trailer)["Root"].as_reference(), *document);
   return document;
 }
 

--- a/src/odr/internal/pdf/pdf_document_parser.hpp
+++ b/src/odr/internal/pdf/pdf_document_parser.hpp
@@ -7,6 +7,7 @@
 #include <map>
 #include <memory>
 #include <utility>
+#include <vector>
 
 namespace odr {
 class Logger;
@@ -16,6 +17,22 @@ namespace odr::internal::pdf {
 
 struct Document;
 
+/// Resolution/memoization layer on top of the sequential `FileParser`: maps
+/// `ObjectReference`s to file positions via the cross-reference table and
+/// hands out resolved objects by reference.
+///
+/// Reads are memoized in `m_objects` / `m_object_streams`. This is intrinsic,
+/// not a convenience: a compressed object can only be read by inflating and
+/// parsing the whole object stream that holds it, and only this class knows
+/// (from the xref) which objects share a stream — so the caller cannot dedupe
+/// that work. `read_object` is also reentrant (length resolution, object-stream
+/// loading, deep resolution), and the object graph has heavy sharing, so the
+/// cache must live here.
+///
+/// Both caches grow monotonically and are never evicted, which is safe only
+/// because a `DocumentParser` is a transient per-render object: build one,
+/// produce a `Document`, read its lazy streams, then discard it. Do not hold it
+/// long-lived or share it across documents.
 class DocumentParser {
 public:
   explicit DocumentParser(std::istream &);
@@ -46,10 +63,10 @@ private:
   /// dictionary is the trailer dictionary (the stream dictionary doubles as
   /// one for cross-reference streams).
   std::pair<Xref, Dictionary> read_xref_section(std::uint32_t position);
-  ObjectStream &load_object_stream(std::uint32_t stream_id);
+  const ObjectStream &load_object_stream(std::uint32_t stream_id);
 
   FileParser m_parser;
-  Logger *m_logger;
+  Logger *m_logger{nullptr};
   Xref m_xref;
   std::map<ObjectReference, IndirectObject> m_objects;
   std::map<std::uint32_t, ObjectStream> m_object_streams;

--- a/src/odr/internal/pdf/pdf_document_parser.hpp
+++ b/src/odr/internal/pdf/pdf_document_parser.hpp
@@ -6,6 +6,11 @@
 #include <iosfwd>
 #include <map>
 #include <memory>
+#include <utility>
+
+namespace odr {
+class Logger;
+}
 
 namespace odr::internal::pdf {
 
@@ -14,6 +19,7 @@ struct Document;
 class DocumentParser {
 public:
   explicit DocumentParser(std::istream &);
+  DocumentParser(std::istream &, Logger &logger);
 
   [[nodiscard]] std::istream &in();
   [[nodiscard]] FileParser &parser();
@@ -35,9 +41,18 @@ public:
   std::unique_ptr<Document> parse_document();
 
 private:
+  /// Read one cross-reference section (classic table or cross-reference
+  /// stream, ISO 32000-1 7.5.4 / 7.5.8) at `position`. The returned
+  /// dictionary is the trailer dictionary (the stream dictionary doubles as
+  /// one for cross-reference streams).
+  std::pair<Xref, Dictionary> read_xref_section(std::uint32_t position);
+  ObjectStream &load_object_stream(std::uint32_t stream_id);
+
   FileParser m_parser;
+  Logger *m_logger;
   Xref m_xref;
   std::map<ObjectReference, IndirectObject> m_objects;
+  std::map<std::uint32_t, ObjectStream> m_object_streams;
 };
 
 } // namespace odr::internal::pdf

--- a/src/odr/internal/pdf/pdf_file_object.cpp
+++ b/src/odr/internal/pdf/pdf_file_object.cpp
@@ -1,5 +1,9 @@
 #include <odr/internal/pdf/pdf_file_object.hpp>
 
+#include <odr/internal/pdf/pdf_object_parser.hpp>
+
+#include <stdexcept>
+
 namespace odr::internal::pdf {
 
 const ObjectReference &Trailer::root_reference() const {
@@ -8,6 +12,105 @@ const ObjectReference &Trailer::root_reference() const {
 
 void Xref::append(const Xref &xref) {
   table.insert(std::begin(xref.table), std::end(xref.table));
+}
+
+void Xref::merge_hybrid(const Xref &xref_stream) {
+  for (const auto &[reference, entry] : xref_stream.table) {
+    bool absent_or_free = true;
+    for (auto it = table.lower_bound(ObjectReference(reference.id, 0));
+         it != std::end(table) && it->first.id == reference.id; ++it) {
+      if (!it->second.is_free()) {
+        absent_or_free = false;
+        break;
+      }
+    }
+    if (absent_or_free) {
+      table.insert_or_assign(reference, entry);
+    }
+  }
+}
+
+Xref parse_xref_stream_table(
+    const std::string &data, const std::vector<std::uint32_t> &field_widths,
+    const std::vector<std::pair<std::uint32_t, std::uint32_t>> &subsections) {
+  if (field_widths.size() != 3) {
+    throw std::runtime_error(
+        "expected three field widths in cross-reference stream /W");
+  }
+
+  const std::size_t entry_size = static_cast<std::size_t>(field_widths[0]) +
+                                 field_widths[1] + field_widths[2];
+  std::size_t position = 0;
+
+  const auto read_field = [&](const std::uint32_t width,
+                              const std::uint64_t default_value) {
+    if (width == 0) {
+      return default_value;
+    }
+    std::uint64_t value = 0;
+    for (std::uint32_t i = 0; i < width; ++i) {
+      value = (value << 8) | static_cast<unsigned char>(data[position++]);
+    }
+    return value;
+  };
+
+  Xref result;
+
+  for (const auto &[first_id, count] : subsections) {
+    for (std::uint32_t i = 0; i < count; ++i) {
+      if (position + entry_size > data.size()) {
+        throw std::runtime_error("cross-reference stream data exhausted");
+      }
+
+      const std::uint64_t type = read_field(field_widths[0], 1);
+      const std::uint64_t second = read_field(field_widths[1], 0);
+      const std::uint64_t third = read_field(field_widths[2], 0);
+      const std::uint32_t id = first_id + i;
+
+      if (type == 0) {
+        result.table.emplace(
+            ObjectReference(id, third),
+            Xref::FreeEntry{static_cast<std::uint32_t>(second),
+                            static_cast<std::uint32_t>(third)});
+      } else if (type == 1) {
+        result.table.emplace(
+            ObjectReference(id, third),
+            Xref::UsedEntry{static_cast<std::uint32_t>(second)});
+      } else if (type == 2) {
+        result.table.emplace(
+            ObjectReference(id, 0),
+            Xref::CompressedEntry{static_cast<std::uint32_t>(second),
+                                  static_cast<std::uint32_t>(third)});
+      }
+    }
+  }
+
+  return result;
+}
+
+ObjectStream::ObjectStream(std::string data, const std::uint32_t n,
+                           const std::uint32_t first)
+    : m_in{std::move(data)} {
+  ObjectParser parser(m_in);
+  m_members.reserve(n);
+  for (std::uint32_t i = 0; i < n; ++i) {
+    parser.skip_whitespace();
+    const std::uint64_t id = parser.read_unsigned_integer();
+    parser.skip_whitespace();
+    const std::uint64_t offset = parser.read_unsigned_integer();
+    m_members.emplace_back(id, first + static_cast<std::uint32_t>(offset));
+  }
+}
+
+Object ObjectStream::member_object(const std::uint32_t index) {
+  if (index >= m_members.size()) {
+    throw std::runtime_error("object stream member index out of range");
+  }
+  m_in.clear();
+  m_in.seekg(m_members[index].second);
+  ObjectParser parser(m_in);
+  parser.skip_whitespace();
+  return parser.read_object();
 }
 
 } // namespace odr::internal::pdf

--- a/src/odr/internal/pdf/pdf_file_object.cpp
+++ b/src/odr/internal/pdf/pdf_file_object.cpp
@@ -4,40 +4,23 @@
 
 #include <stdexcept>
 
-namespace odr::internal::pdf {
+namespace odr::internal {
 
-const ObjectReference &Trailer::root_reference() const {
-  return dictionary["Root"].as_reference();
-}
+namespace {
 
-void Xref::append(const Xref &xref) {
-  table.insert(std::begin(xref.table), std::end(xref.table));
-}
+/// Cross-reference stream entry type (ISO 32000-1 7.5.8.3, Table 18, field 1).
+/// Other values shall be treated as references to the null object (ignored).
+enum class XrefStreamType : std::uint64_t {
+  free = 0,
+  uncompressed = 1,
+  compressed = 2,
+};
 
-void Xref::merge_hybrid(const Xref &xref_stream) {
-  for (const auto &[reference, entry] : xref_stream.table) {
-    bool absent_or_free = true;
-    for (auto it = table.lower_bound(ObjectReference(reference.id, 0));
-         it != std::end(table) && it->first.id == reference.id; ++it) {
-      if (!it->second.is_free()) {
-        absent_or_free = false;
-        break;
-      }
-    }
-    if (absent_or_free) {
-      table.insert_or_assign(reference, entry);
-    }
-  }
-}
+} // namespace
 
-Xref parse_xref_stream_table(
-    const std::string &data, const std::vector<std::uint32_t> &field_widths,
+pdf::Xref pdf::parse_xref_stream_table(
+    const std::string &data, const std::array<std::uint32_t, 3> &field_widths,
     const std::vector<std::pair<std::uint32_t, std::uint32_t>> &subsections) {
-  if (field_widths.size() != 3) {
-    throw std::runtime_error(
-        "expected three field widths in cross-reference stream /W");
-  }
-
   const std::size_t entry_size = static_cast<std::size_t>(field_widths[0]) +
                                  field_widths[1] + field_widths[2];
   std::size_t position = 0;
@@ -62,25 +45,31 @@ Xref parse_xref_stream_table(
         throw std::runtime_error("cross-reference stream data exhausted");
       }
 
-      const std::uint64_t type = read_field(field_widths[0], 1);
+      const auto type = static_cast<XrefStreamType>(
+          read_field(field_widths[0],
+                     static_cast<std::uint64_t>(XrefStreamType::uncompressed)));
       const std::uint64_t second = read_field(field_widths[1], 0);
       const std::uint64_t third = read_field(field_widths[2], 0);
       const std::uint32_t id = first_id + i;
 
-      if (type == 0) {
+      switch (type) {
+      case XrefStreamType::free:
         result.table.emplace(
             ObjectReference(id, third),
             Xref::FreeEntry{static_cast<std::uint32_t>(second),
                             static_cast<std::uint32_t>(third)});
-      } else if (type == 1) {
+        break;
+      case XrefStreamType::uncompressed:
         result.table.emplace(
             ObjectReference(id, third),
             Xref::UsedEntry{static_cast<std::uint32_t>(second)});
-      } else if (type == 2) {
+        break;
+      case XrefStreamType::compressed:
         result.table.emplace(
             ObjectReference(id, 0),
             Xref::CompressedEntry{static_cast<std::uint32_t>(second),
                                   static_cast<std::uint32_t>(third)});
+        break;
       }
     }
   }
@@ -88,29 +77,64 @@ Xref parse_xref_stream_table(
   return result;
 }
 
-ObjectStream::ObjectStream(std::string data, const std::uint32_t n,
-                           const std::uint32_t first)
-    : m_in{std::move(data)} {
-  ObjectParser parser(m_in);
-  m_members.reserve(n);
-  for (std::uint32_t i = 0; i < n; ++i) {
-    parser.skip_whitespace();
-    const std::uint64_t id = parser.read_unsigned_integer();
-    parser.skip_whitespace();
-    const std::uint64_t offset = parser.read_unsigned_integer();
-    m_members.emplace_back(id, first + static_cast<std::uint32_t>(offset));
+pdf::ObjectStream pdf::parse_object_stream(std::istream &in,
+                                           const std::uint32_t n,
+                                           const std::uint32_t first) {
+  // Read the header of `n` (id, offset) pairs, recording the absolute payload
+  // position of each member.
+  std::vector<std::pair<std::uint64_t, std::uint32_t>> offsets;
+  offsets.reserve(n);
+  {
+    ObjectParser parser(in);
+    for (std::uint32_t i = 0; i < n; ++i) {
+      parser.skip_whitespace();
+      const std::uint64_t id = parser.read_unsigned_integer();
+      parser.skip_whitespace();
+      const std::uint64_t offset = parser.read_unsigned_integer();
+      offsets.emplace_back(id, first + static_cast<std::uint32_t>(offset));
+    }
   }
+
+  // Parse each member object (a bare value) at its position.
+  ObjectStream members;
+  members.reserve(n);
+  for (const auto &[id, position] : offsets) {
+    in.clear();
+    in.seekg(position);
+    ObjectParser parser(in);
+    parser.skip_whitespace();
+    members.push_back({id, parser.read_object()});
+  }
+
+  return members;
 }
 
-Object ObjectStream::member_object(const std::uint32_t index) {
-  if (index >= m_members.size()) {
-    throw std::runtime_error("object stream member index out of range");
+} // namespace odr::internal
+
+namespace odr::internal::pdf {
+
+const ObjectReference &Trailer::root_reference() const {
+  return dictionary["Root"].as_reference();
+}
+
+void Xref::append(const Xref &xref) {
+  table.insert(std::begin(xref.table), std::end(xref.table));
+}
+
+void Xref::merge_hybrid(const Xref &xref_stream) {
+  for (const auto &[reference, entry] : xref_stream.table) {
+    bool absent_or_free = true;
+    for (auto it = table.lower_bound(ObjectReference(reference.id, 0));
+         it != std::end(table) && it->first.id == reference.id; ++it) {
+      if (!it->second.is_free()) {
+        absent_or_free = false;
+        break;
+      }
+    }
+    if (absent_or_free) {
+      table.insert_or_assign(reference, entry);
+    }
   }
-  m_in.clear();
-  m_in.seekg(m_members[index].second);
-  ObjectParser parser(m_in);
-  parser.skip_whitespace();
-  return parser.read_object();
 }
 
 } // namespace odr::internal::pdf

--- a/src/odr/internal/pdf/pdf_file_object.hpp
+++ b/src/odr/internal/pdf/pdf_file_object.hpp
@@ -4,6 +4,10 @@
 
 #include <map>
 #include <optional>
+#include <sstream>
+#include <utility>
+#include <variant>
+#include <vector>
 
 namespace odr::internal::pdf {
 
@@ -25,15 +29,96 @@ struct Trailer {
 };
 
 struct Xref {
-  struct Entry {
-    std::uint32_t position{};
-    bool in_use{};
+  /// classic `f` / stream type 0: object on the free list
+  struct FreeEntry {
+    std::uint32_t next_free_id{};
+    std::uint32_t next_generation{};
   };
+  /// classic `n` / stream type 1: object stored at a byte offset
+  struct UsedEntry {
+    std::uint32_t position{};
+  };
+  /// stream type 2: object stored compressed in an object stream
+  struct CompressedEntry {
+    std::uint32_t stream_id{};
+    std::uint32_t index{};
+  };
+
+  class Entry {
+  public:
+    using Holder = std::variant<FreeEntry, UsedEntry, CompressedEntry>;
+
+    Entry() = default;
+    Entry(const FreeEntry &entry) : m_holder{entry} {}
+    Entry(const UsedEntry &entry) : m_holder{entry} {}
+    Entry(const CompressedEntry &entry) : m_holder{entry} {}
+
+    [[nodiscard]] bool is_free() const {
+      return std::holds_alternative<FreeEntry>(m_holder);
+    }
+    [[nodiscard]] bool is_used() const {
+      return std::holds_alternative<UsedEntry>(m_holder);
+    }
+    [[nodiscard]] bool is_compressed() const {
+      return std::holds_alternative<CompressedEntry>(m_holder);
+    }
+
+    [[nodiscard]] const FreeEntry &as_free() const {
+      return std::get<FreeEntry>(m_holder);
+    }
+    [[nodiscard]] const UsedEntry &as_used() const {
+      return std::get<UsedEntry>(m_holder);
+    }
+    [[nodiscard]] const CompressedEntry &as_compressed() const {
+      return std::get<CompressedEntry>(m_holder);
+    }
+
+  private:
+    Holder m_holder{FreeEntry{}};
+  };
+
   using Table = std::map<ObjectReference, Entry>;
 
   Table table;
 
+  /// Merge an older section into this one; existing (newer) entries win.
   void append(const Xref &xref);
+  /// Hybrid-reference combine (ISO 32000-1 7.5.8.4): adopt entries from the
+  /// `XRefStm` cross-reference stream for ids this (classic) section lacks
+  /// or marks free.
+  void merge_hybrid(const Xref &xref_stream);
+};
+
+/// Decode the entry table of a cross-reference stream (ISO 32000-1 7.5.8.3)
+/// from the already de-filtered `data`. `field_widths` is the `/W` array
+/// (three big-endian byte widths; width 0 means the field defaults: type 1,
+/// other fields 0), `subsections` the `/Index` pairs (first id, count).
+/// Entries of unknown type are treated as absent.
+[[nodiscard]] Xref parse_xref_stream_table(
+    const std::string &data, const std::vector<std::uint32_t> &field_widths,
+    const std::vector<std::pair<std::uint32_t, std::uint32_t>> &subsections);
+
+/// Decoded object stream (`/Type /ObjStm`, ISO 32000-1 7.5.7): a header of
+/// `n` (id, offset) integer pairs followed by the member objects.
+class ObjectStream {
+public:
+  /// `data` is the de-filtered stream payload, `n` and `first` the `/N` and
+  /// `/First` dictionary entries.
+  ObjectStream(std::string data, std::uint32_t n, std::uint32_t first);
+
+  /// Member object ids with their absolute payload offsets (`first` applied).
+  [[nodiscard]] const std::vector<std::pair<std::uint64_t, std::uint32_t>> &
+  members() const {
+    return m_members;
+  }
+
+  /// Parse the member object at `index` (a bare value — no `n g obj`
+  /// wrapper, no stream).
+  [[nodiscard]] Object member_object(std::uint32_t index);
+
+private:
+  std::istringstream m_in;
+  std::vector<std::pair<std::uint64_t, std::uint32_t>> m_members;
 };
 
 struct StartXref {

--- a/src/odr/internal/pdf/pdf_file_object.hpp
+++ b/src/odr/internal/pdf/pdf_file_object.hpp
@@ -2,9 +2,10 @@
 
 #include <odr/internal/pdf/pdf_object.hpp>
 
+#include <array>
+#include <iosfwd>
 #include <map>
 #include <optional>
-#include <sstream>
 #include <utility>
 #include <variant>
 #include <vector>
@@ -49,9 +50,9 @@ struct Xref {
     using Holder = std::variant<FreeEntry, UsedEntry, CompressedEntry>;
 
     Entry() = default;
-    Entry(const FreeEntry &entry) : m_holder{entry} {}
-    Entry(const UsedEntry &entry) : m_holder{entry} {}
-    Entry(const CompressedEntry &entry) : m_holder{entry} {}
+    explicit Entry(const FreeEntry &entry) : m_holder{entry} {}
+    explicit Entry(const UsedEntry &entry) : m_holder{entry} {}
+    explicit Entry(const CompressedEntry &entry) : m_holder{entry} {}
 
     [[nodiscard]] bool is_free() const {
       return std::holds_alternative<FreeEntry>(m_holder);
@@ -95,31 +96,24 @@ struct Xref {
 /// other fields 0), `subsections` the `/Index` pairs (first id, count).
 /// Entries of unknown type are treated as absent.
 [[nodiscard]] Xref parse_xref_stream_table(
-    const std::string &data, const std::vector<std::uint32_t> &field_widths,
+    const std::string &data, const std::array<std::uint32_t, 3> &field_widths,
     const std::vector<std::pair<std::uint32_t, std::uint32_t>> &subsections);
 
-/// Decoded object stream (`/Type /ObjStm`, ISO 32000-1 7.5.7): a header of
-/// `n` (id, offset) integer pairs followed by the member objects.
-class ObjectStream {
-public:
-  /// `data` is the de-filtered stream payload, `n` and `first` the `/N` and
-  /// `/First` dictionary entries.
-  ObjectStream(std::string data, std::uint32_t n, std::uint32_t first);
-
-  /// Member object ids with their absolute payload offsets (`first` applied).
-  [[nodiscard]] const std::vector<std::pair<std::uint64_t, std::uint32_t>> &
-  members() const {
-    return m_members;
-  }
-
-  /// Parse the member object at `index` (a bare value — no `n g obj`
-  /// wrapper, no stream).
-  [[nodiscard]] Object member_object(std::uint32_t index);
-
-private:
-  std::istringstream m_in;
-  std::vector<std::pair<std::uint64_t, std::uint32_t>> m_members;
+/// One member of a decoded object stream: its object id and parsed value.
+struct ObjectStreamMember {
+  std::uint64_t id{};
+  Object object;
 };
+
+using ObjectStream = std::vector<ObjectStreamMember>;
+
+/// Parse all `n` members of a decoded object stream (`/Type /ObjStm`,
+/// ISO 32000-1 7.5.7) from the de-filtered payload `in`: a header of `n`
+/// (id, offset) integer pairs followed by the member objects (bare values —
+/// no `n g obj` wrapper, no stream) at `first + offset`. `n` and `first` are
+/// the `/N` and `/First` dictionary entries.
+[[nodiscard]] ObjectStream
+parse_object_stream(std::istream &in, std::uint32_t n, std::uint32_t first);
 
 struct StartXref {
   std::uint32_t start{};

--- a/src/odr/internal/pdf/pdf_file_parser.cpp
+++ b/src/odr/internal/pdf/pdf_file_parser.cpp
@@ -23,9 +23,10 @@ IndirectObject FileParser::read_indirect_object() {
   m_parser.skip_whitespace();
   result.reference.gen = m_parser.read_unsigned_integer();
   m_parser.skip_whitespace();
-  if (const std::string line = m_parser.read_line(); line != "obj") {
-    throw std::runtime_error("expected obj");
-  }
+  // `obj` is not necessarily followed by a newline; some producers keep the
+  // object on the same line
+  m_parser.expect_characters("obj");
+  m_parser.skip_whitespace();
 
   result.object = m_parser.read_object();
   m_parser.skip_whitespace();
@@ -81,15 +82,16 @@ Xref FileParser::read_xref() {
     m_parser.skip_line();
 
     for (std::uint32_t i = 0; i < entry_count; ++i) {
-      Xref::Entry entry;
-
-      entry.position = m_parser.read_unsigned_integer();
+      const std::uint32_t field1 = m_parser.read_unsigned_integer();
       m_parser.skip_whitespace();
-      const std::uint64_t generation = m_parser.read_unsigned_integer();
+      const std::uint32_t field2 = m_parser.read_unsigned_integer();
       m_parser.skip_whitespace();
-      entry.in_use = m_parser.read_line().at(0) == 'n';
+      const bool in_use = m_parser.read_line().at(0) == 'n';
 
-      result.table.emplace(ObjectReference(first_id + i, generation), entry);
+      const Xref::Entry entry =
+          in_use ? Xref::Entry(Xref::UsedEntry{field1})
+                 : Xref::Entry(Xref::FreeEntry{field1, field2});
+      result.table.emplace(ObjectReference(first_id + i, field2), entry);
     }
   }
 }

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -38,8 +38,10 @@ add_executable(odr_test
         "src/internal/ooxml/ooxml_crypto_test.cpp"
 
         "src/internal/pdf/pdf_document_parser.cpp"
+        "src/internal/pdf/pdf_file_object.cpp"
         "src/internal/pdf/pdf_file_parser.cpp"
         "src/internal/pdf/pdf_filter.cpp"
+        "src/internal/pdf/pdf_test_file_builder.cpp"
 
         "src/internal/svm/svm_test.cpp"
 

--- a/test/src/internal/pdf/pdf_document_parser.cpp
+++ b/test/src/internal/pdf/pdf_document_parser.cpp
@@ -8,13 +8,17 @@
 
 #include <test_util.hpp>
 
+#include "pdf_test_file_builder.hpp"
+
 #include <memory>
+#include <sstream>
 
 #include <gtest/gtest.h>
 
 using namespace odr::internal;
 using namespace odr::internal::pdf;
 using namespace odr::test;
+using PdfFileBuilder = odr::test::pdf::PdfFileBuilder;
 
 TEST(DocumentParser, foo) {
   const auto file = std::make_shared<DiskFile>(
@@ -93,4 +97,95 @@ TEST(DocumentParser, foo) {
       std::cout << "TODO show_text_next_line_set_spacing" << std::endl;
     }
   }
+}
+
+namespace {
+
+std::string two_object_mini_pdf(PdfFileBuilder &builder, const bool classic) {
+  builder.object("<< /Type /Catalog /Pages 2 0 R >>")
+      .object("<< /Type /Pages /Kids [3 0 R] /Count 1 >>")
+      .object("<< /Type /Page /Parent 2 0 R /MediaBox [0 0 612 792] "
+              "/Resources << >> /Contents 4 0 R >>")
+      .stream_object("", "BT ET")
+      .trailer("/Root 1 0 R");
+  return classic ? builder.build_classic() : builder.build_xref_stream();
+}
+
+void check_mini_pdf(const std::string &pdf) {
+  std::istringstream in(pdf);
+  DocumentParser parser(in);
+
+  std::unique_ptr<Document> document = parser.parse_document();
+
+  ASSERT_EQ(document->catalog->pages->count, 1);
+  ASSERT_EQ(document->catalog->pages->kids.size(), 1);
+  auto *page = dynamic_cast<Page *>(document->catalog->pages->kids.front());
+  ASSERT_NE(page, nullptr);
+  ASSERT_EQ(page->contents_reference.size(), 1);
+  EXPECT_EQ(parser.read_decoded_stream(page->contents_reference.front()),
+            "BT ET");
+}
+
+} // namespace
+
+TEST(DocumentParser, mini_pdf_with_classic_xref_table) {
+  PdfFileBuilder builder;
+  check_mini_pdf(two_object_mini_pdf(builder, true));
+}
+
+TEST(DocumentParser, mini_pdf_with_xref_stream) {
+  PdfFileBuilder builder;
+  const std::string pdf = two_object_mini_pdf(builder, false);
+
+  std::istringstream in(pdf);
+  DocumentParser parser(in);
+  parser.parse_document();
+
+  // 4 objects, the cross-reference stream itself, and the free head
+  EXPECT_EQ(parser.xref().table.size(), 6);
+  EXPECT_TRUE(parser.xref().table.at(ObjectReference(5, 0)).is_used());
+
+  check_mini_pdf(pdf);
+}
+
+namespace {
+
+void check_fixture_parses(const std::string &short_path) {
+  SCOPED_TRACE(short_path);
+
+  const auto file =
+      std::make_shared<DiskFile>(TestData::test_file_path(short_path));
+
+  auto in = file->stream();
+  DocumentParser parser(*in);
+
+  std::unique_ptr<Document> document = parser.parse_document();
+
+  std::vector<Page *> ordered_pages;
+  std::function<void(Pages * pages)> recurse_pages = [&](const Pages *pages) {
+    for (Element *kid : pages->kids) {
+      if (const auto p = dynamic_cast<Pages *>(kid); p != nullptr) {
+        recurse_pages(p);
+      } else if (auto page = dynamic_cast<Page *>(kid); page != nullptr) {
+        ordered_pages.push_back(page);
+      } else {
+        FAIL() << "unhandled element";
+      }
+    }
+  };
+  recurse_pages(document->catalog->pages);
+
+  EXPECT_FALSE(ordered_pages.empty());
+
+  for (const Page *page : ordered_pages) {
+    for (const auto &content_reference : page->contents_reference) {
+      EXPECT_FALSE(parser.read_decoded_stream(content_reference).empty());
+    }
+  }
+}
+
+} // namespace
+
+TEST(DocumentParser, classic_xref_fixture) {
+  check_fixture_parses("odr-public/pdf/style-various-1.pdf");
 }

--- a/test/src/internal/pdf/pdf_document_parser.cpp
+++ b/test/src/internal/pdf/pdf_document_parser.cpp
@@ -4,11 +4,10 @@
 #include <odr/internal/pdf/pdf_document_parser.hpp>
 #include <odr/internal/pdf/pdf_graphics_operator.hpp>
 #include <odr/internal/pdf/pdf_graphics_operator_parser.hpp>
-#include <odr/internal/pdf/pdf_graphics_state.hpp>
 
 #include <test_util.hpp>
 
-#include "pdf_test_file_builder.hpp"
+#include <internal/pdf/pdf_test_file_builder.hpp>
 
 #include <memory>
 #include <sstream>
@@ -20,88 +19,10 @@ using namespace odr::internal::pdf;
 using namespace odr::test;
 using PdfFileBuilder = odr::test::pdf::PdfFileBuilder;
 
-TEST(DocumentParser, foo) {
-  const auto file = std::make_shared<DiskFile>(
-      TestData::test_file_path("odr-public/pdf/style-various-1.pdf"));
-
-  auto in = file->stream();
-  DocumentParser parser(*in);
-
-  std::unique_ptr<Document> document = parser.parse_document();
-
-  std::cout << "elements " << document->elements.size() << std::endl;
-  std::cout << "pages count " << document->catalog->pages->count << std::endl;
-
-  std::vector<Page *> ordered_pages;
-  std::function<void(Pages * pages)> recurse_pages = [&](const Pages *pages) {
-    for (Element *kid : pages->kids) {
-      if (const auto p = dynamic_cast<Pages *>(kid); p != nullptr) {
-        recurse_pages(p);
-      } else if (auto page = dynamic_cast<Page *>(kid); page != nullptr) {
-        ordered_pages.push_back(page);
-      } else {
-        throw std::runtime_error("unhandled element");
-      }
-    }
-  };
-
-  recurse_pages(document->catalog->pages);
-
-  for (Page *page : ordered_pages) {
-    std::cout << "page content " << page->contents_reference.front().id
-              << std::endl;
-    std::cout << "page annotations " << page->annotations.size() << std::endl;
-    std::cout << "page resources " << page->resources << std::endl;
-  }
-
-  Page *first_page = ordered_pages.front();
-  std::string first_page_content;
-  for (const auto &content_reference : first_page->contents_reference) {
-    first_page_content += parser.read_decoded_stream(content_reference);
-    first_page_content += '\n';
-  }
-
-  std::istringstream ss(first_page_content);
-  GraphicsOperatorParser parser2(ss);
-  GraphicsState state;
-  while (!ss.eof()) {
-    GraphicsOperator op = parser2.read_operator();
-    state.execute(op);
-
-    const std::string &font = state.current().text.font;
-    double size = state.current().text.size;
-
-    if (op.type == GraphicsOperatorType::show_text) {
-      const std::string &glyphs = op.arguments[0].as_string();
-      std::string unicode =
-          first_page->resources->font.at(font)->cmap.translate_string(glyphs);
-      std::cout << "show text: font=" << font << ", size=" << size
-                << ", text=" << unicode << std::endl;
-    } else if (op.type == GraphicsOperatorType::show_text_manual_spacing) {
-      for (const auto &element : op.arguments[0].as_array()) {
-        if (element.is_real()) {
-          std::cout << "spacing: " << element.as_real() << std::endl;
-        } else if (element.is_string()) {
-          const std::string &glyphs = element.as_string();
-          std::string unicode =
-              first_page->resources->font.at(font)->cmap.translate_string(
-                  glyphs);
-          std::cout << "show text manual spacing: font=" << font
-                    << ", size=" << size << ", text=" << unicode << std::endl;
-        }
-      }
-    } else if (op.type == GraphicsOperatorType::show_text_next_line) {
-      std::cout << "TODO show_text_next_line" << std::endl;
-    } else if (op.type ==
-               GraphicsOperatorType::show_text_next_line_set_spacing) {
-      std::cout << "TODO show_text_next_line_set_spacing" << std::endl;
-    }
-  }
-}
-
 namespace {
 
-std::string two_object_mini_pdf(PdfFileBuilder &builder, const bool classic) {
+std::string two_object_mini_pdf(const bool classic) {
+  PdfFileBuilder builder;
   builder.object("<< /Type /Catalog /Pages 2 0 R >>")
       .object("<< /Type /Pages /Kids [3 0 R] /Count 1 >>")
       .object("<< /Type /Page /Parent 2 0 R /MediaBox [0 0 612 792] "
@@ -119,7 +40,8 @@ void check_mini_pdf(const std::string &pdf) {
 
   ASSERT_EQ(document->catalog->pages->count, 1);
   ASSERT_EQ(document->catalog->pages->kids.size(), 1);
-  auto *page = dynamic_cast<Page *>(document->catalog->pages->kids.front());
+  const auto *page =
+      dynamic_cast<Page *>(document->catalog->pages->kids.front());
   ASSERT_NE(page, nullptr);
   ASSERT_EQ(page->contents_reference.size(), 1);
   EXPECT_EQ(parser.read_decoded_stream(page->contents_reference.front()),
@@ -129,13 +51,11 @@ void check_mini_pdf(const std::string &pdf) {
 } // namespace
 
 TEST(DocumentParser, mini_pdf_with_classic_xref_table) {
-  PdfFileBuilder builder;
-  check_mini_pdf(two_object_mini_pdf(builder, true));
+  check_mini_pdf(two_object_mini_pdf(true));
 }
 
 TEST(DocumentParser, mini_pdf_with_xref_stream) {
-  PdfFileBuilder builder;
-  const std::string pdf = two_object_mini_pdf(builder, false);
+  const std::string pdf = two_object_mini_pdf(false);
 
   std::istringstream in(pdf);
   DocumentParser parser(in);
@@ -156,23 +76,24 @@ void check_fixture_parses(const std::string &short_path) {
   const auto file =
       std::make_shared<DiskFile>(TestData::test_file_path(short_path));
 
-  auto in = file->stream();
+  const auto in = file->stream();
   DocumentParser parser(*in);
 
   std::unique_ptr<Document> document = parser.parse_document();
 
   std::vector<Page *> ordered_pages;
-  std::function<void(Pages * pages)> recurse_pages = [&](const Pages *pages) {
-    for (Element *kid : pages->kids) {
-      if (const auto p = dynamic_cast<Pages *>(kid); p != nullptr) {
-        recurse_pages(p);
-      } else if (auto page = dynamic_cast<Page *>(kid); page != nullptr) {
-        ordered_pages.push_back(page);
-      } else {
-        FAIL() << "unhandled element";
-      }
-    }
-  };
+  const std::function<void(Pages * pages)> recurse_pages =
+      [&](const Pages *pages) {
+        for (Element *kid : pages->kids) {
+          if (const auto p = dynamic_cast<Pages *>(kid); p != nullptr) {
+            recurse_pages(p);
+          } else if (auto page = dynamic_cast<Page *>(kid); page != nullptr) {
+            ordered_pages.push_back(page);
+          } else {
+            FAIL() << "unhandled element";
+          }
+        }
+      };
   recurse_pages(document->catalog->pages);
 
   EXPECT_FALSE(ordered_pages.empty());

--- a/test/src/internal/pdf/pdf_file_object.cpp
+++ b/test/src/internal/pdf/pdf_file_object.cpp
@@ -1,0 +1,167 @@
+#include <odr/internal/pdf/pdf_file_object.hpp>
+
+#include <stdexcept>
+#include <string>
+
+#include <gtest/gtest.h>
+
+using namespace odr::internal::pdf;
+
+TEST(XrefStreamTable, used_and_compressed_entries) {
+  // W [1 2 1]: type, two-byte big-endian offset, generation
+  const std::string data("\x01\x0e\x8a\x00"
+                         "\x02\x00\x02\x05",
+                         8);
+
+  const Xref xref = parse_xref_stream_table(data, {1, 2, 1}, {{23, 2}});
+
+  ASSERT_EQ(xref.table.size(), 2);
+
+  const Xref::Entry &used = xref.table.at(ObjectReference(23, 0));
+  ASSERT_TRUE(used.is_used());
+  EXPECT_EQ(used.as_used().position, 0x0e8a);
+
+  // type 2 entries always have generation 0
+  const Xref::Entry &compressed = xref.table.at(ObjectReference(24, 0));
+  ASSERT_TRUE(compressed.is_compressed());
+  EXPECT_EQ(compressed.as_compressed().stream_id, 2);
+  EXPECT_EQ(compressed.as_compressed().index, 5);
+}
+
+TEST(XrefStreamTable, free_entry) {
+  const std::string data("\x00\x00\x07\x03", 4);
+
+  const Xref xref = parse_xref_stream_table(data, {1, 2, 1}, {{4, 1}});
+
+  const Xref::Entry &entry = xref.table.at(ObjectReference(4, 3));
+  ASSERT_TRUE(entry.is_free());
+  EXPECT_EQ(entry.as_free().next_free_id, 7);
+  EXPECT_EQ(entry.as_free().next_generation, 3);
+}
+
+TEST(XrefStreamTable, type_field_width_zero_defaults_to_used) {
+  const std::string data("\x0e\x8a\x00", 3);
+
+  const Xref xref = parse_xref_stream_table(data, {0, 2, 1}, {{7, 1}});
+
+  const Xref::Entry &entry = xref.table.at(ObjectReference(7, 0));
+  ASSERT_TRUE(entry.is_used());
+  EXPECT_EQ(entry.as_used().position, 0x0e8a);
+}
+
+TEST(XrefStreamTable, generation_field_width_zero_defaults_to_zero) {
+  const std::string data("\x01\x00\x42", 3);
+
+  const Xref xref = parse_xref_stream_table(data, {1, 2, 0}, {{7, 1}});
+
+  const Xref::Entry &entry = xref.table.at(ObjectReference(7, 0));
+  ASSERT_TRUE(entry.is_used());
+  EXPECT_EQ(entry.as_used().position, 0x42);
+}
+
+TEST(XrefStreamTable, big_endian_wide_fields) {
+  const std::string data("\x01\x00\x01\x02\x03\x00\x05", 7);
+
+  const Xref xref = parse_xref_stream_table(data, {1, 4, 2}, {{1, 1}});
+
+  const Xref::Entry &entry = xref.table.at(ObjectReference(1, 5));
+  ASSERT_TRUE(entry.is_used());
+  EXPECT_EQ(entry.as_used().position, 0x00010203);
+}
+
+TEST(XrefStreamTable, multiple_subsections) {
+  const std::string data("\x01\x00\x10\x00"
+                         "\x01\x00\x20\x00"
+                         "\x01\x00\x30\x00",
+                         12);
+
+  const Xref xref = parse_xref_stream_table(data, {1, 2, 1}, {{3, 1}, {10, 2}});
+
+  ASSERT_EQ(xref.table.size(), 3);
+  EXPECT_EQ(xref.table.at(ObjectReference(3, 0)).as_used().position, 0x10);
+  EXPECT_EQ(xref.table.at(ObjectReference(10, 0)).as_used().position, 0x20);
+  EXPECT_EQ(xref.table.at(ObjectReference(11, 0)).as_used().position, 0x30);
+}
+
+TEST(XrefStreamTable, unknown_entry_type_is_absent) {
+  const std::string data("\x03\x00\x10\x00", 4);
+
+  const Xref xref = parse_xref_stream_table(data, {1, 2, 1}, {{1, 1}});
+
+  EXPECT_TRUE(xref.table.empty());
+}
+
+TEST(XrefStreamTable, exhausted_data_throws) {
+  const std::string data("\x01\x0e", 2);
+
+  EXPECT_THROW((void)parse_xref_stream_table(data, {1, 2, 1}, {{1, 1}}),
+               std::runtime_error);
+}
+
+TEST(XrefStreamTable, wrong_field_width_count_throws) {
+  EXPECT_THROW((void)parse_xref_stream_table("", {1, 2}, {}),
+               std::runtime_error);
+}
+
+TEST(ObjectStream, header_and_member_lookup) {
+  // two members: object 11 (a dictionary) at relative offset 0, object 12
+  // (an array) at relative offset 9; /First is 10 (the header length)
+  const std::string data = "11 0 12 9\n<</A 1>> [1 2 3]";
+
+  ObjectStream object_stream(data, 2, 10);
+
+  ASSERT_EQ(object_stream.members().size(), 2);
+  EXPECT_EQ(object_stream.members()[0].first, 11);
+  EXPECT_EQ(object_stream.members()[0].second, 10);
+  EXPECT_EQ(object_stream.members()[1].first, 12);
+  EXPECT_EQ(object_stream.members()[1].second, 19);
+
+  const Object first = object_stream.member_object(0);
+  ASSERT_TRUE(first.is_dictionary());
+  EXPECT_EQ(first.as_dictionary()["A"].as_integer(), 1);
+
+  const Object second = object_stream.member_object(1);
+  ASSERT_TRUE(second.is_array());
+  ASSERT_EQ(second.as_array().size(), 3);
+  EXPECT_EQ(second.as_array()[2].as_integer(), 3);
+
+  EXPECT_THROW((void)object_stream.member_object(2), std::runtime_error);
+}
+
+TEST(Xref, append_keeps_newest_entry) {
+  Xref newer;
+  newer.table.emplace(ObjectReference(1, 0), Xref::UsedEntry{100});
+
+  Xref older;
+  older.table.emplace(ObjectReference(1, 0), Xref::UsedEntry{50});
+  older.table.emplace(ObjectReference(2, 0), Xref::UsedEntry{60});
+
+  newer.append(older);
+
+  EXPECT_EQ(newer.table.at(ObjectReference(1, 0)).as_used().position, 100);
+  EXPECT_EQ(newer.table.at(ObjectReference(2, 0)).as_used().position, 60);
+}
+
+TEST(Xref, merge_hybrid_fills_absent_and_free_only) {
+  Xref classic;
+  classic.table.emplace(ObjectReference(1, 0), Xref::UsedEntry{100});
+  classic.table.emplace(ObjectReference(2, 0), Xref::FreeEntry{0, 0});
+  classic.table.emplace(ObjectReference(5, 65535), Xref::FreeEntry{0, 65535});
+
+  Xref stream;
+  stream.table.emplace(ObjectReference(1, 0), Xref::UsedEntry{999});
+  stream.table.emplace(ObjectReference(2, 0), Xref::CompressedEntry{7, 0});
+  stream.table.emplace(ObjectReference(3, 0), Xref::UsedEntry{300});
+  stream.table.emplace(ObjectReference(5, 0), Xref::UsedEntry{500});
+
+  classic.merge_hybrid(stream);
+
+  // the classic in-use entry wins over the stream's
+  EXPECT_EQ(classic.table.at(ObjectReference(1, 0)).as_used().position, 100);
+  // hidden object: free in the classic table, live in the stream
+  EXPECT_TRUE(classic.table.at(ObjectReference(2, 0)).is_compressed());
+  // absent in the classic table
+  EXPECT_EQ(classic.table.at(ObjectReference(3, 0)).as_used().position, 300);
+  // free under a different generation key
+  EXPECT_EQ(classic.table.at(ObjectReference(5, 0)).as_used().position, 500);
+}

--- a/test/src/internal/pdf/pdf_file_object.cpp
+++ b/test/src/internal/pdf/pdf_file_object.cpp
@@ -1,7 +1,9 @@
 #include <odr/internal/pdf/pdf_file_object.hpp>
 
+#include <sstream>
 #include <stdexcept>
 #include <string>
+#include <vector>
 
 #include <gtest/gtest.h>
 
@@ -98,34 +100,25 @@ TEST(XrefStreamTable, exhausted_data_throws) {
                std::runtime_error);
 }
 
-TEST(XrefStreamTable, wrong_field_width_count_throws) {
-  EXPECT_THROW((void)parse_xref_stream_table("", {1, 2}, {}),
-               std::runtime_error);
-}
-
-TEST(ObjectStream, header_and_member_lookup) {
+TEST(ObjectStream, parse_members) {
   // two members: object 11 (a dictionary) at relative offset 0, object 12
   // (an array) at relative offset 9; /First is 10 (the header length)
   const std::string data = "11 0 12 9\n<</A 1>> [1 2 3]";
 
-  ObjectStream object_stream(data, 2, 10);
+  std::istringstream in(data);
+  const std::vector<ObjectStreamMember> members =
+      parse_object_stream(in, 2, 10);
 
-  ASSERT_EQ(object_stream.members().size(), 2);
-  EXPECT_EQ(object_stream.members()[0].first, 11);
-  EXPECT_EQ(object_stream.members()[0].second, 10);
-  EXPECT_EQ(object_stream.members()[1].first, 12);
-  EXPECT_EQ(object_stream.members()[1].second, 19);
+  ASSERT_EQ(members.size(), 2);
+  EXPECT_EQ(members[0].id, 11);
+  EXPECT_EQ(members[1].id, 12);
 
-  const Object first = object_stream.member_object(0);
-  ASSERT_TRUE(first.is_dictionary());
-  EXPECT_EQ(first.as_dictionary()["A"].as_integer(), 1);
+  ASSERT_TRUE(members[0].object.is_dictionary());
+  EXPECT_EQ(members[0].object.as_dictionary()["A"].as_integer(), 1);
 
-  const Object second = object_stream.member_object(1);
-  ASSERT_TRUE(second.is_array());
-  ASSERT_EQ(second.as_array().size(), 3);
-  EXPECT_EQ(second.as_array()[2].as_integer(), 3);
-
-  EXPECT_THROW((void)object_stream.member_object(2), std::runtime_error);
+  ASSERT_TRUE(members[1].object.is_array());
+  ASSERT_EQ(members[1].object.as_array().size(), 3);
+  EXPECT_EQ(members[1].object.as_array()[2].as_integer(), 3);
 }
 
 TEST(Xref, append_keeps_newest_entry) {

--- a/test/src/internal/pdf/pdf_file_parser.cpp
+++ b/test/src/internal/pdf/pdf_file_parser.cpp
@@ -105,23 +105,25 @@ TEST(FileParser, bar) {
     }
   }
 
-  std::cout << "xref" << std::endl;
+  EXPECT_FALSE(xref.table.empty());
   for (const auto &[ref, entry] : xref.table) {
-    std::cout << ref << " " << entry.position << " " << entry.in_use
-              << std::endl;
+    if (ref.id == 0) {
+      EXPECT_TRUE(entry.is_free());
+    } else {
+      EXPECT_TRUE(entry.is_used());
+      EXPECT_GT(entry.as_used().position, 0);
+    }
   }
 
-  std::cout << "trailer" << std::endl;
-  for (const auto &key : trailer | std::views::keys) {
-    std::cout << key << std::endl;
-  }
+  ASSERT_TRUE(trailer.has_key("Root"));
 
   const ObjectReference root_ref = trailer["Root"].as_reference();
-  const std::uint32_t root_pos = xref.table.at(root_ref).position;
+  const std::uint32_t root_pos = xref.table.at(root_ref).as_used().position;
   parser.in().seekg(root_pos);
   IndirectObject root = parser.read_indirect_object();
-  std::cout << "root" << std::endl;
+  EXPECT_EQ(root.reference.id, root_ref.id);
+  EXPECT_EQ(root.reference.gen, root_ref.gen);
   const ObjectReference root_pages_ref =
       root.object.as_dictionary()["Pages"].as_reference();
-  std::cout << root_pages_ref.id << " " << root_pages_ref.gen << std::endl;
+  EXPECT_TRUE(xref.table.contains(root_pages_ref));
 }

--- a/test/src/internal/pdf/pdf_filter.cpp
+++ b/test/src/internal/pdf/pdf_filter.cpp
@@ -1,6 +1,6 @@
 #include <odr/internal/pdf/pdf_filter.hpp>
 
-#include "odr/internal/crypto/crypto_util.hpp"
+#include <odr/internal/crypto/crypto_util.hpp>
 #include <odr/internal/pdf/pdf_object.hpp>
 
 #include <stdexcept>

--- a/test/src/internal/pdf/pdf_test_file_builder.cpp
+++ b/test/src/internal/pdf/pdf_test_file_builder.cpp
@@ -6,6 +6,22 @@
 
 namespace odr::test::pdf {
 
+namespace {
+
+/// header plus the wrapped objects; `offsets` receives one byte offset per
+/// object
+std::string assemble_body(const std::vector<std::string> &objects,
+                          std::vector<std::uint32_t> &offsets) {
+  std::string result = "%PDF-1.7\n";
+  for (std::size_t i = 0; i < objects.size(); ++i) {
+    offsets.push_back(result.size());
+    result += std::to_string(i + 1) + " 0 obj\n" + objects[i] + "\nendobj\n";
+  }
+  return result;
+}
+
+} // namespace
+
 PdfFileBuilder &PdfFileBuilder::object(std::string body) {
   m_objects.push_back(std::move(body));
   return *this;
@@ -25,22 +41,6 @@ PdfFileBuilder &PdfFileBuilder::trailer(std::string entries) {
   m_trailer_entries = std::move(entries);
   return *this;
 }
-
-namespace {
-
-/// header plus the wrapped objects; `offsets` receives one byte offset per
-/// object
-std::string assemble_body(const std::vector<std::string> &objects,
-                          std::vector<std::uint32_t> &offsets) {
-  std::string result = "%PDF-1.7\n";
-  for (std::size_t i = 0; i < objects.size(); ++i) {
-    offsets.push_back(result.size());
-    result += std::to_string(i + 1) + " 0 obj\n" + objects[i] + "\nendobj\n";
-  }
-  return result;
-}
-
-} // namespace
 
 std::string PdfFileBuilder::build_classic() const {
   std::vector<std::uint32_t> offsets;

--- a/test/src/internal/pdf/pdf_test_file_builder.cpp
+++ b/test/src/internal/pdf/pdf_test_file_builder.cpp
@@ -1,0 +1,101 @@
+#include "pdf_test_file_builder.hpp"
+
+#include <cstdint>
+#include <iomanip>
+#include <sstream>
+
+namespace odr::test::pdf {
+
+PdfFileBuilder &PdfFileBuilder::object(std::string body) {
+  m_objects.push_back(std::move(body));
+  return *this;
+}
+
+PdfFileBuilder &
+PdfFileBuilder::stream_object(const std::string &dictionary_entries,
+                              const std::string &stream_data) {
+  std::string body = "<< " + dictionary_entries + " /Length " +
+                     std::to_string(stream_data.size()) + " >>\nstream\n" +
+                     stream_data + "\nendstream";
+  m_objects.push_back(std::move(body));
+  return *this;
+}
+
+PdfFileBuilder &PdfFileBuilder::trailer(std::string entries) {
+  m_trailer_entries = std::move(entries);
+  return *this;
+}
+
+namespace {
+
+/// header plus the wrapped objects; `offsets` receives one byte offset per
+/// object
+std::string assemble_body(const std::vector<std::string> &objects,
+                          std::vector<std::uint32_t> &offsets) {
+  std::string result = "%PDF-1.7\n";
+  for (std::size_t i = 0; i < objects.size(); ++i) {
+    offsets.push_back(result.size());
+    result += std::to_string(i + 1) + " 0 obj\n" + objects[i] + "\nendobj\n";
+  }
+  return result;
+}
+
+} // namespace
+
+std::string PdfFileBuilder::build_classic() const {
+  std::vector<std::uint32_t> offsets;
+  std::string result = assemble_body(m_objects, offsets);
+
+  const std::uint32_t xref_position = result.size();
+  std::ostringstream xref;
+  xref << "xref\n0 " << (m_objects.size() + 1) << "\n";
+  xref << "0000000000 65535 f \n";
+  for (const std::uint32_t offset : offsets) {
+    xref << std::setfill('0') << std::setw(10) << offset << " 00000 n \n";
+  }
+  result += xref.str();
+
+  result += "trailer\n<< /Size " + std::to_string(m_objects.size() + 1) + " " +
+            m_trailer_entries + " >>\n";
+  result += "startxref\n" + std::to_string(xref_position) + "\n%%EOF\n";
+
+  return result;
+}
+
+std::string PdfFileBuilder::build_xref_stream() const {
+  std::vector<std::uint32_t> offsets;
+  std::string result = assemble_body(m_objects, offsets);
+
+  const std::uint32_t xref_id = m_objects.size() + 1;
+  const std::uint32_t xref_position = result.size();
+  offsets.push_back(xref_position);
+
+  // one entry per object plus the free head (id 0) and the cross-reference
+  // stream itself; W [1 4 2]: type, big-endian offset, generation
+  std::string table;
+  const auto entry = [&table](const std::uint8_t type,
+                              const std::uint32_t second,
+                              const std::uint16_t third) {
+    table.push_back(static_cast<char>(type));
+    table.push_back(static_cast<char>((second >> 24) & 0xff));
+    table.push_back(static_cast<char>((second >> 16) & 0xff));
+    table.push_back(static_cast<char>((second >> 8) & 0xff));
+    table.push_back(static_cast<char>(second & 0xff));
+    table.push_back(static_cast<char>((third >> 8) & 0xff));
+    table.push_back(static_cast<char>(third & 0xff));
+  };
+  entry(0, 0, 0xffff);
+  for (const std::uint32_t offset : offsets) {
+    entry(1, offset, 0);
+  }
+
+  result += std::to_string(xref_id) + " 0 obj\n<< /Type /XRef /Size " +
+            std::to_string(xref_id + 1) + " /W [1 4 2] /Length " +
+            std::to_string(table.size()) + " " + m_trailer_entries +
+            " >>\nstream\n" + table + "\nendstream\nendobj\n";
+  result += "startxref\n" + std::to_string(xref_position) + "\n%%EOF\n";
+
+  return result;
+}
+
+} // namespace odr::test::pdf

--- a/test/src/internal/pdf/pdf_test_file_builder.hpp
+++ b/test/src/internal/pdf/pdf_test_file_builder.hpp
@@ -1,0 +1,40 @@
+#pragma once
+
+#include <string>
+#include <vector>
+
+namespace odr::test::pdf {
+
+/// Test-only mini-PDF assembler: collects object snippets and computes the
+/// cross-reference offsets and `startxref` itself, so the test source only
+/// shows the interesting dictionaries. Object ids are assigned 1..n in
+/// insertion order. This must never grow into a writer API.
+class PdfFileBuilder {
+public:
+  /// Add an indirect object; `body` is its value, e.g.
+  /// `"<< /Type /Catalog /Pages 2 0 R >>"`.
+  PdfFileBuilder &object(std::string body);
+
+  /// Add a stream object; `dictionary_entries` are the dictionary's entries
+  /// without the `<< >>` delimiters (`/Length` is computed and added).
+  PdfFileBuilder &stream_object(const std::string &dictionary_entries,
+                                const std::string &stream_data);
+
+  /// Trailer entries without the `<< >>` delimiters and without `/Size`,
+  /// e.g. `"/Root 1 0 R"`.
+  PdfFileBuilder &trailer(std::string entries);
+
+  /// Assemble with a classic `xref` table and `trailer`.
+  [[nodiscard]] std::string build_classic() const;
+
+  /// Assemble with an uncompressed cross-reference stream (`/W [1 4 2]`,
+  /// no `/Filter`) instead of a classic table; the trailer entries go into
+  /// the stream dictionary.
+  [[nodiscard]] std::string build_xref_stream() const;
+
+private:
+  std::vector<std::string> m_objects;
+  std::string m_trailer_entries;
+};
+
+} // namespace odr::test::pdf


### PR DESCRIPTION
Files from modern producers (PDF 1.5+) no longer fail with `expected xref`.

## Changes

- **`Xref::Entry` is now a tagged union** — `FreeEntry` / `UsedEntry` / `CompressedEntry` — instead of `{position, in_use}`.
- **Cross-reference streams** (ISO 32000-1 7.5.8): the trailer-chain walk dispatches per section on classic table vs. xref stream; the stream dictionary doubles as the trailer dict. Entry tables are decoded from `/W`/`/Index` (big-endian fields, width-0 defaults, unknown entry types treated as absent).
- **Object streams** (7.5.7): compressed objects are read from their `/ObjStm`, decoded once via the filter framework and cached; members are parsed from the `/N`/`/First` header with an id sanity check.
- **Hybrid-reference files** (7.5.8.4): `XRefStm` is read before `Prev`, and its entries fill in objects the classic table lacks or marks free, so hidden objects are found.
- **Lenience**: references to free/absent objects resolve to null with a warning instead of throwing; `/Type /XRef` only warns; `n g obj` no longer requires a trailing newline (some producers keep the dictionary on the same line). New diagnostics go through `Logger` — `DocumentParser` takes an optional `Logger &` and the HTML service passes its own.

## Tests

- Inline-string unit tests for xref-stream entry decoding, object-stream header/member parsing, and `append`/`merge_hybrid` precedence — no fixture files.
- A test-only mini-PDF builder (`pdf_test_file_builder`) that computes xref offsets/`startxref`, used for whole-file tests in both classic-table and uncompressed-xref-stream variants.
- Classic fixture `odr-public/pdf/style-various-1.pdf` as end-to-end regression; the existing `FileParser` smoke test converted to assertions. The `odr-private` xref-stream/objstm/hybrid fixtures (`basic_text.pdf`, `geneve_1564.pdf`, `test_fail.pdf`, `Kayla….pdf`, `svg_background…issue402.pdf`, `Core_v5.1.pdf`, `onepage.pdf`) were verified locally but are intentionally not pinned in unit tests since the submodule is not always available.