### PR TITLE
pdf: replace Element type-enum tag with RTTI is/as accessors

### DIFF
--- a/src/odr/internal/pdf/pdf_document.cpp
+++ b/src/odr/internal/pdf/pdf_document.cpp
@@ -11,10 +11,10 @@ namespace {
 template <typename Collection>
 void collect_pages_impl(const Pages &pages, Collection &out) {
   for (Element *kid : pages.kids) {
-    if (auto *inner = dynamic_cast<Pages *>(kid); inner != nullptr) {
-      collect_pages_impl(*inner, out);
-    } else if (auto *page = dynamic_cast<Page *>(kid); page != nullptr) {
-      out.push_back(page);
+    if (kid->is<Pages>()) {
+      collect_pages_impl(kid->as<Pages>(), out);
+    } else if (kid->is<Page>()) {
+      out.push_back(&kid->as<Page>());
     } else {
       throw std::runtime_error("unexpected element in PDF page tree");
     }

--- a/src/odr/internal/pdf/pdf_document_element.hpp
+++ b/src/odr/internal/pdf/pdf_document_element.hpp
@@ -3,6 +3,7 @@
 #include <odr/internal/pdf/pdf_cmap.hpp>
 #include <odr/internal/pdf/pdf_object.hpp>
 
+#include <concepts>
 #include <unordered_map>
 #include <vector>
 
@@ -14,22 +15,30 @@ struct Annotation;
 struct Resources;
 struct Font;
 
-enum class Type {
-  unknown,
-  catalog,
-  pages,
-  page,
-  annotation,
-  resources,
-  font,
-};
-
 struct Element {
   virtual ~Element() = default;
 
-  Type type{Type::unknown};
   ObjectReference object_reference;
   Object object;
+
+  // Value-semantic discrimination over the element hierarchy, backed by RTTI;
+  // mirrors `Object`'s `is_*`/`as_*` surface. `T` must be a complete derived
+  // type at the call site.
+  template <typename T>
+    requires std::derived_from<T, Element>
+  [[nodiscard]] bool is() const {
+    return dynamic_cast<const T *>(this) != nullptr;
+  }
+  template <typename T>
+    requires std::derived_from<T, Element>
+  [[nodiscard]] T &as() {
+    return dynamic_cast<T &>(*this);
+  }
+  template <typename T>
+    requires std::derived_from<T, Element>
+  [[nodiscard]] const T &as() const {
+    return dynamic_cast<const T &>(*this);
+  }
 };
 
 struct Catalog final : Element {

--- a/src/odr/internal/pdf/pdf_document_parser.cpp
+++ b/src/odr/internal/pdf/pdf_document_parser.cpp
@@ -100,7 +100,7 @@ struct PageAttributes {
 
 Element *parse_page_or_pages(DocumentParser &parser,
                              const ObjectReference &reference,
-                             Document &document, Element *parent,
+                             Document &document, Pages *parent,
                              const PageAttributes &inherited);
 
 Font *parse_font(DocumentParser &parser, const ObjectReference &reference,
@@ -110,7 +110,6 @@ Font *parse_font(DocumentParser &parser, const ObjectReference &reference,
   IndirectObject object = parser.read_object(reference);
   const Dictionary &dictionary = object.object.as_dictionary();
 
-  font->type = Type::font;
   font->object_reference = reference;
   font->object = Object(dictionary);
 
@@ -131,7 +130,6 @@ Resources *parse_resources(DocumentParser &parser, const Object &object,
 
   Dictionary dictionary = parser.resolve_object_copy(object).as_dictionary();
 
-  resources->type = Type::resources;
   resources->object = Object(dictionary);
 
   if (!dictionary["Font"].is_null()) {
@@ -153,7 +151,6 @@ Annotation *parse_annotation(DocumentParser &parser,
   IndirectObject object = parser.read_object(reference);
   const Dictionary &dictionary = object.object.as_dictionary();
 
-  annotation->type = Type::annotation;
   annotation->object_reference = reference;
   annotation->object = Object(dictionary);
 
@@ -161,17 +158,15 @@ Annotation *parse_annotation(DocumentParser &parser,
 }
 
 Page *parse_page(DocumentParser &parser, const ObjectReference &reference,
-                 Document &document, Element *parent,
-                 PageAttributes attributes) {
+                 Document &document, Pages *parent, PageAttributes attributes) {
   Page *page = document.create_element<Page>();
 
   IndirectObject object = parser.read_object(reference);
   const Dictionary &dictionary = object.object.as_dictionary();
 
-  page->type = Type::page;
   page->object_reference = reference;
   page->object = Object(dictionary);
-  page->parent = dynamic_cast<Pages *>(parent);
+  page->parent = parent;
 
   // the page overlays its own inheritable entries, then the accumulated
   // attributes are resolved into the page with Table-30 defaults (7.7.3.4)
@@ -207,7 +202,6 @@ Pages *parse_pages(DocumentParser &parser, const ObjectReference &reference,
   IndirectObject object = parser.read_object(reference);
   const Dictionary &dictionary = object.object.as_dictionary();
 
-  pages->type = Type::pages;
   pages->object_reference = reference;
   pages->object = Object(dictionary);
   pages->count = dictionary["Count"].as_integer();
@@ -225,7 +219,7 @@ Pages *parse_pages(DocumentParser &parser, const ObjectReference &reference,
 
 Element *parse_page_or_pages(DocumentParser &parser,
                              const ObjectReference &reference,
-                             Document &document, Element *parent,
+                             Document &document, Pages *parent,
                              const PageAttributes &inherited) {
   // TODO we are parsing twice
   IndirectObject object = parser.read_object(reference);
@@ -250,7 +244,6 @@ Catalog *parse_catalog(DocumentParser &parser, const ObjectReference &reference,
   const Dictionary &dictionary = object.object.as_dictionary();
   const ObjectReference &pages_reference = dictionary["Pages"].as_reference();
 
-  catalog->type = Type::catalog;
   catalog->object_reference = reference;
   catalog->object = Object(dictionary);
   catalog->pages = parse_pages(parser, pages_reference, document, {});


### PR DESCRIPTION
## Summary

Replaces the redundant `Type` enum tag on the PDF `Element` hierarchy with value-semantic `is<T>()`/`as<T>()` accessors backed by RTTI.

`Element` is owned as `unique_ptr<Element>`, so a virtual destructor (and therefore RTTI) is already mandatory. The parallel `Type` enum was redundant — it was written in every `parse_*` but never read; the only discrimination site (`collect_pages_impl`) already used `dynamic_cast`.

## Changes

- Remove `enum class Type` and the `Element::type` field, plus the six write-only `x->type = Type::…` assignments in the parser.
- Add `Element::is<T>()` / `as<T>()` (const + non-const), mirroring `Object`'s `is_*`/`as_*` surface, constrained with `requires std::derived_from<T, Element>`.
- Migrate `collect_pages_impl` to `kid->is<Pages>()` / `kid->as<Page>()`.

Net effect: all `dynamic_cast` is centralized into the base, and the element kinds have one source of truth for discrimination.

## Notes

- Generic `is<T>()`/`as<T>()` (rather than named `is_page()` etc.) avoids the incomplete-type ordering problem and per-type boilerplate; the template instantiates at the call site where the type is complete.
- Graph-edge fields (`parent`, `kids`, `resources`, …) remain pointers — they encode a cyclic identity graph that can't be value-copied. Only the access/discrimination API is value-semantic.
