### PR TITLE
PDF: encryption follow-ups from #525 review

### DIFF
--- a/src/odr/internal/pdf/pdf_document_parser.cpp
+++ b/src/odr/internal/pdf/pdf_document_parser.cpp
@@ -256,27 +256,30 @@ Catalog *parse_catalog(DocumentParser &parser, const ObjectReference &reference,
 DocumentParser::DocumentParser(std::unique_ptr<std::istream> in,
                                std::optional<Decryptor> decryptor,
                                const Logger &logger)
-    : m_stream(std::move(in)), m_parser(*m_stream), m_logger{&logger},
-      m_decryptor(std::move(decryptor)) {
+    : m_stream(std::move(in)), m_parser(*m_stream), m_logger{&logger} {
   auto [xref, trailer] = read_trailer_chain();
   m_xref = std::move(xref);
   m_trailer = std::move(trailer);
 
   if (m_trailer.has_key("Encrypt")) {
     // Build an `Authenticator` from the trailer `/Encrypt` and `/ID`
-    // (ISO 32000-1 7.6), caching the `/Encrypt` dictionary and its reference
-    // (the self-skip guard that keeps its own `/O`,`/U` strings un-decrypted).
-    // Returns `nullopt` if the trailer declares no `/Encrypt`.
+    // (ISO 32000-1 7.6). `m_is_encrypted` records that the file declares
+    // encryption regardless of whether we can authenticate it, so an
+    // unsupported handler still reports as encrypted.
+    m_is_encrypted = true;
 
+    // The `/Encrypt` dictionary's own `/O`,`/U`,… strings are never encrypted
+    // (7.6.2), and need no explicit self-skip guard: it is resolved here while
+    // `m_decryptor` is still empty (installed only after this block), so
+    // `read_object` leaves its strings raw and caches that copy — every later
+    // lookup hits the cache and never re-decrypts it.
     Object encrypt = m_trailer["Encrypt"];
     if (encrypt.is_reference()) {
-      m_encrypt_reference = encrypt.as_reference();
-      encrypt = read_object(*m_encrypt_reference).object;
+      encrypt = read_object(encrypt.as_reference()).object;
     }
     if (!encrypt.is_dictionary()) {
       throw std::runtime_error("pdf: /Encrypt is not a dictionary");
     }
-    m_encrypt_dict = std::move(encrypt);
 
     // The trailer /ID[0] feeds the R 2-4 key derivation (raw bytes).
     std::string id0;
@@ -287,9 +290,12 @@ DocumentParser::DocumentParser(std::unique_ptr<std::istream> in,
       }
     }
 
-    m_authenticator =
-        Authenticator::create(m_encrypt_dict->as_dictionary(), id0);
+    m_authenticator = Authenticator::create(encrypt.as_dictionary(), id0);
   }
+
+  // Install the decryptor only after read_trailer_chain(): cross-reference
+  // streams are read during that walk and must stay un-decrypted (7.5.8.2).
+  m_decryptor = std::move(decryptor);
 }
 
 std::istream &DocumentParser::in() { return m_parser.in(); }
@@ -302,7 +308,7 @@ const Xref &DocumentParser::xref() const { return m_xref; }
 
 const Dictionary &DocumentParser::trailer() const { return m_trailer; }
 
-bool DocumentParser::is_encrypted() const { return m_encrypt_dict.has_value(); }
+bool DocumentParser::is_encrypted() const { return m_is_encrypted; }
 
 const std::optional<Authenticator> &DocumentParser::authenticator() const {
   return m_authenticator;
@@ -340,10 +346,11 @@ DocumentParser::read_object(const ObjectReference &reference) {
   } else if (const Xref::Entry &entry = entry_it->second; entry.is_used()) {
     in().seekg(entry.as_used().position);
     object = parser().read_indirect_object();
-    // Decrypt string leaves (7.6.2). Skip the /Encrypt dictionary itself (its
-    // strings are the un-decrypted /O,/U,…) — it is read before the decryptor
-    // exists, so this is defensive.
-    if (m_decryptor.has_value() && m_encrypt_reference != object.reference) {
+    // Decrypt string leaves (7.6.2). The /Encrypt dictionary needs no special
+    // case here: it is read and cached during construction before the
+    // decryptor is installed, so its un-decrypted /O,/U,… strings are served
+    // from the cache and never reach this path.
+    if (m_decryptor.has_value()) {
       decrypt_strings(object.object, object.reference);
     }
   } else if (entry.is_compressed()) {

--- a/src/odr/internal/pdf/pdf_document_parser.hpp
+++ b/src/odr/internal/pdf/pdf_document_parser.hpp
@@ -123,10 +123,9 @@ private:
   Xref m_xref;
   Dictionary m_trailer;
 
+  bool m_is_encrypted{false};
   std::optional<Authenticator> m_authenticator;
   std::optional<Decryptor> m_decryptor;
-  std::optional<ObjectReference> m_encrypt_reference;
-  std::optional<Object> m_encrypt_dict;
 
   std::map<ObjectReference, IndirectObject> m_objects;
   std::map<std::uint32_t, ObjectStream> m_object_streams;

--- a/src/odr/internal/pdf/pdf_file.cpp
+++ b/src/odr/internal/pdf/pdf_file.cpp
@@ -17,25 +17,24 @@ PdfFile::PdfFile(std::shared_ptr<abstract::File> file)
     throw std::invalid_argument("pdf: file is null");
   }
 
-  DocumentParser parser(m_file->stream());
-  m_authenticator = parser.authenticator();
+  const DocumentParser parser(m_file->stream());
 
   m_file_meta.type = FileType::portable_document_format;
 
   // Most "protected" PDFs are owner-locked only, so try the empty user
   // password first; if it opens the file, no password is required.
+  m_authenticator = parser.authenticator();
   if (m_authenticator.has_value()) {
     m_decryptor = m_authenticator->authenticate("");
   }
+
   if (parser.is_encrypted()) {
-    m_file_meta.password_encrypted = !m_authenticator.has_value();
-    if (m_decryptor.has_value()) {
-      // Owner-locked only: opens with the empty user password. Keep the
-      // decryptor so rendering needs neither the password nor a decrypt() call.
-      m_encryption_state = EncryptionState::not_encrypted;
-    } else {
-      m_encryption_state = EncryptionState::encrypted;
-    }
+    // Owner-locked only: opens with the empty user password. Keep the
+    // decryptor so rendering needs neither the password nor a decrypt() call.
+    m_file_meta.password_encrypted = !m_decryptor.has_value();
+    m_encryption_state = m_decryptor.has_value()
+                             ? EncryptionState::not_encrypted
+                             : EncryptionState::encrypted;
   }
 }
 

--- a/test/src/internal/pdf/pdf_document_parser.cpp
+++ b/test/src/internal/pdf/pdf_document_parser.cpp
@@ -3,7 +3,6 @@
 #include <odr/internal/pdf/pdf_document_element.hpp>
 #include <odr/internal/pdf/pdf_document_parser.hpp>
 #include <odr/internal/pdf/pdf_graphics_operator.hpp>
-#include <odr/internal/pdf/pdf_graphics_operator_parser.hpp>
 
 #include <test_util.hpp>
 
@@ -38,7 +37,7 @@ std::string two_object_mini_pdf(const bool classic) {
 void check_mini_pdf(const std::string &pdf) {
   DocumentParser parser(std::make_unique<std::istringstream>(pdf));
 
-  std::unique_ptr<Document> document = parser.parse_document();
+  const std::unique_ptr<Document> document = parser.parse_document();
 
   ASSERT_EQ(document->catalog->pages->count, 1);
   ASSERT_EQ(document->catalog->pages->kids.size(), 1);
@@ -59,7 +58,7 @@ TEST(DocumentParser, mini_pdf_with_classic_xref_table) {
 TEST(DocumentParser, mini_pdf_with_xref_stream) {
   const std::string pdf = two_object_mini_pdf(false);
 
-  DocumentParser parser(std::make_unique<std::istringstream>(pdf));
+  const DocumentParser parser(std::make_unique<std::istringstream>(pdf));
 
   // 4 objects, the cross-reference stream itself, and the free head
   EXPECT_EQ(parser.xref().table.size(), 6);
@@ -78,7 +77,7 @@ void check_fixture_parses(const std::string &short_path,
       std::make_shared<DiskFile>(TestData::test_file_path(short_path));
 
   DocumentParser parser(file->stream());
-  if (parser.is_encrypted()) {
+  if (parser.authenticator().has_value()) {
     parser.authenticate(password);
   }
 


### PR DESCRIPTION
Follow-ups addressing the Codex review on #525.

## P1 — don't decrypt cross-reference streams (correctness)

On the reopen-after-authentication path, `create_parser()` passed `m_decryptor` into the `DocumentParser` constructor, which runs `read_trailer_chain()` with the decryptor already installed. Cross-reference streams are read during that walk and are **never** encrypted (ISO 32000-1 7.5.8.2), so they were being RC4/AES-decrypted — corrupting the xref and failing to parse any encrypted file that uses xref streams.

Fix: install the decryptor only *after* `read_trailer_chain()`, restoring the invariant the surrounding comment already documented.

## P2 — report encryption state correctly (metadata)

A *supported* Standard-encrypted PDF whose empty user password fails has an authenticator but no decryptor; the old code set `password_encrypted = !m_authenticator.has_value()`, reporting it as **not** encrypted. The state is now keyed off whether a decryptor was established. `is_encrypted()` is backed by a dedicated `m_is_encrypted` flag (set whenever the trailer declares `/Encrypt`), so an *unsupported* handler still reports as `encrypted` rather than silently `not_encrypted`.

## Cleanup

Dropped the `m_encrypt_reference` self-skip guard: the `/Encrypt` dictionary is read and cached during construction, before the decryptor is installed, so its raw `/O`,`/U`,… strings are served from the object cache and never re-decrypted. Comments at both sites rewritten to describe the cache-based mechanism.