### PR TITLE
PDF stage 2.4: text render modes & extraction refinements

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -43,6 +43,11 @@ elseif (CMAKE_CXX_COMPILER_ID STREQUAL "MSVC")
     set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} /EHsc")
 endif ()
 
+# MSVC reads sources in the system codepage by default; force UTF-8 so non-ASCII
+# literals (e.g. the PDFDocEncoding table) compile (C2015) and encode correctly.
+# GCC/Clang already default to UTF-8.
+add_compile_options("$<$<CXX_COMPILER_ID:MSVC>:/utf-8>")
+
 find_package(pugixml REQUIRED)
 find_package(miniz REQUIRED)
 find_package(cryptopp REQUIRED)

--- a/src/odr/internal/html/pdf_file.cpp
+++ b/src/odr/internal/html/pdf_file.cpp
@@ -92,6 +92,9 @@ public:
     out.out() << ".p{position:relative}";
     out.out() << ".t{position:absolute;left:0;top:0;transform-origin:0 0;"
                  "white-space:pre}";
+    // Invisible text render modes (Tr 3/7): kept in the DOM for selection and
+    // search (OCR-over-scan), but not painted.
+    out.out() << ".i{color:transparent}";
     out.write_header_style_end();
     out.write_header_end();
 
@@ -139,28 +142,42 @@ public:
 
       for (const pdf::TextElement &text :
            pdf::extract_text(stream, *page->resources, *m_logger)) {
+        // Nothing extractable here yet: a code with no recoverable Unicode
+        // (`no_unicode`) renders only once the embedded font lands (stage 3),
+        // and an `/ActualText`-suppressed segment carries no text of its own.
+        if (text.text.empty()) {
+          continue;
+        }
+
         const util::math::Transform2D m = flip_glyph * text.transform * to_box;
+
+        // Tr 3 (invisible) and Tr 7 (clip-only) paint nothing; keep them
+        // selectable via the transparent `.i` class.
+        const bool invisible =
+            text.rendering_mode == 3 || text.rendering_mode == 7;
+        const std::string css_class = invisible ? "t i" : "t";
 
         out.write_element_begin(
             "span",
-            HtmlElementOptions().set_class("t").set_style([&](std::ostream &o) {
-              // TODO baseline sits at the box top until font ascent
-              // metrics land
-              if (m.b == 0 && m.c == 0 && m.a == m.d) {
-                // Upright uniform scale: fold the scale into the
-                // font size and place the origin with left/top, so
-                // the (otherwise near-universal) matrix is dropped.
-                o << "left:" << round2(m.e * pt_to_px) << "px;";
-                o << "top:" << round2(m.f * pt_to_px) << "px;";
-                o << "font-size:" << round2(m.a * text.size * pt_to_px)
-                  << "px;";
-              } else {
-                o << "transform:matrix(" << m.a << "," << m.b << "," << m.c
-                  << "," << m.d << "," << round2(m.e * pt_to_px) << ","
-                  << round2(m.f * pt_to_px) << ");";
-                o << "font-size:" << round2(text.size * pt_to_px) << "px;";
-              }
-            }));
+            HtmlElementOptions().set_class(css_class).set_style(
+                [&](std::ostream &o) {
+                  // TODO baseline sits at the box top until font ascent
+                  // metrics land
+                  if (m.b == 0 && m.c == 0 && m.a == m.d) {
+                    // Upright uniform scale: fold the scale into the
+                    // font size and place the origin with left/top, so
+                    // the (otherwise near-universal) matrix is dropped.
+                    o << "left:" << round2(m.e * pt_to_px) << "px;";
+                    o << "top:" << round2(m.f * pt_to_px) << "px;";
+                    o << "font-size:" << round2(m.a * text.size * pt_to_px)
+                      << "px;";
+                  } else {
+                    o << "transform:matrix(" << m.a << "," << m.b << "," << m.c
+                      << "," << m.d << "," << round2(m.e * pt_to_px) << ","
+                      << round2(m.f * pt_to_px) << ");";
+                    o << "font-size:" << round2(text.size * pt_to_px) << "px;";
+                  }
+                }));
         out.write_raw(escape_text(text.text));
         out.write_element_end("span");
       }

--- a/src/odr/internal/pdf/AGENTS.md
+++ b/src/odr/internal/pdf/AGENTS.md
@@ -15,8 +15,10 @@ tree with fonts and annotations, tokenize page content streams into graphics
 operators, and emit a **proof-of-concept HTML rendering**: absolutely positioned
 text spans, one per shown segment, placed by the full text transform (CTM × text
 matrix) and advanced by the parsed glyph widths (stages 2.1–2.2), recursing into
-form XObjects (stage 2.3), pages sized from `MediaBox`. Encrypted files are decrypted (RC4, AES-128, AES-256). No
-graphics, no images, no font files. Experimental and not production-quality.
+form XObjects (stage 2.3), with text render modes and `/ActualText` honoured
+(stage 2.4), pages sized from `MediaBox`. Encrypted files are decrypted (RC4,
+AES-128, AES-256). No graphics, no images, no font files. Experimental and not
+production-quality.
 
 ---
 
@@ -134,9 +136,19 @@ graphics, no images, no font files. Experimental and not production-quality.
   translates `Tm` by `−n/1000 × Tfs × Th` — so segments, `TJ` kerning and lines
   land in the right place. The element carries the per-code advances directly, so
   a renderer wanting per-glyph placement need not re-derive them from
-  `font->advance_width`. Still deferred: intra-segment glyph shaping (the browser
-  lays a segment out in a fallback font until stage 3) and vertical writing-mode
-  advances (stage 2.6).
+  `font->advance_width`. **Extraction refinements** (stage 2.4): each element
+  carries its text render mode (`Tr`) and a `no_unicode` flag — set when the
+  font's code → Unicode chain yields nothing (a composite font with no
+  `/ToUnicode` or usable predefined encoding), so `text` is empty and the run is
+  knowingly non-extractable until stage 3 re-encodes the glyphs to the PUA.
+  Marked content is tracked (`BMC`/`BDC … EMC`, balanced per stream and reset
+  across form invocation): a sequence carrying `/ActualText` (inline property
+  dictionary, or a name resolved through the `/Properties` resource) overrides the
+  per-glyph Unicode of its enclosed shows — the decoded text (UTF-16BE BOM or
+  PDFDocEncoding) emitted once and the rest of the sequence suppressed. Still
+  deferred: intra-segment glyph shaping (the browser lays a segment out in a
+  fallback font until stage 3), space inference (stage 2.5) and vertical
+  writing-mode advances (stage 2.6).
 - **Form XObjects** (stage 2.3): a resource dictionary's `/XObject`
   subdictionary is parsed into `Resources::x_object`; each `/Subtype /Form` is an
   `XObject` element carrying its `/Matrix` (default identity), its decoded
@@ -157,8 +169,11 @@ graphics, no images, no font files. Experimental and not production-quality.
   carrying a CSS `transform` matrix (the placement transform mapped from PDF user
   space — y-up, MediaBox origin — into the page box in CSS pixels, the glyphs
   un-mirrored so text stays upright), `font-size` from the text state, and the
-  Unicode text. Precise baseline placement (needs font ascent metrics) is
-  deferred; the baseline currently sits at the span's box top.
+  Unicode text. Invisible render modes (`Tr` 3/7) keep the span but paint it
+  transparent (the `.i` class) so OCR-over-scan text stays selectable; segments
+  with no extractable text (a `no_unicode` run or an `/ActualText`-suppressed
+  show) emit no span at all for now. Precise baseline placement (needs font
+  ascent metrics) is deferred; the baseline currently sits at the span's box top.
 
 ## Module layout
 
@@ -172,7 +187,7 @@ graphics, no images, no font files. Experimental and not production-quality.
 | `pdf_document_parser.{hpp,cpp}`        | `parse_document()`: xref/trailer chain → catalog → page tree; lazy object reads with cache; (deep) reference resolution; resources incl. the `/XObject` table, with an `ObjectReference → XObject*` cache that dedups shared forms and breaks cyclic form references |
 | `pdf_encryption.{hpp,cpp}`             | Standard security handler: `Authenticator` (parse `/Encrypt`, authenticate password → `Decryptor`) and `Decryptor` (decrypt strings/streams; RC4, AES-128, AES-256), plus a `standard_security` namespace of pure key/password algorithms for known-answer tests |
 | `pdf_document.hpp`                     | `Document`: arena of `Element`s + `catalog` pointer |
-| `pdf_document_element.hpp`             | Element structs: `Catalog`, `Pages`, `Page`, `Annotation`, `Resources` (font + XObject tables), `XObject` (Form/Image subtype, `/Matrix`, decoded content, own `/Resources`), `Font` (incl. the `composite`/`cid_registry`/`cid_ordering` Type0 facts, the `/Widths`-`/W`/`/DW` glyph metrics + `advance_width`, and `to_unicode`) |
+| `pdf_document_element.hpp`             | Element structs: `Catalog`, `Pages`, `Page`, `Annotation`, `Resources` (font + XObject + `/Properties` tables), `XObject` (Form/Image subtype, `/Matrix`, decoded content, own `/Resources`), `Font` (incl. the `composite`/`cid_registry`/`cid_ordering` Type0 facts, the `/Widths`-`/W`/`/DW` glyph metrics + `advance_width`, and `to_unicode`) |
 | `pdf_cmap.{hpp,cpp}`                   | `CMap`: 1-byte glyph → UTF-16 `bfchar` map + string translation |
 | `pdf_cmap_parser.{hpp,cpp}`            | `ToUnicode` CMap stream parser (`begincodespacerange`/`beginbfchar`/`beginbfrange`; only `bfchar` applied) |
 | `pdf_encoding.{hpp,cpp}`               | Simple-font `/Encoding` → Unicode: `BaseEncoding` tables, `/Differences` overlay (`Encoding`), glyph-name → Unicode via AGL + `uniXXXX`/`uXXXXXX` (stage 1.2) |
@@ -182,7 +197,7 @@ graphics, no images, no font files. Experimental and not production-quality.
 | `pdf_graphics_operator.hpp`            | `GraphicsOperatorType` enum (full operator set) + `GraphicsOperator` (type + `Object` arguments) |
 | `pdf_graphics_operator_parser.{hpp,cpp}` | Content-stream tokenizer: arguments then operator name |
 | `pdf_graphics_state.{hpp,cpp}`         | `GraphicsState`: stack of `State` (general/path/text/color), `execute(op)` for the modelled subset; CTM/`Tm`/`Tlm` as `Transform2D`, `text_placement_matrix()` for the text rendering transform sans font size, `advance_text()` for the post-glyph `Tm` advance, `save()`/`restore()`/`concat_matrix()` reused by `q`/`Q`/`cm` and by form-XObject invocation |
-| `pdf_page_text.{hpp,cpp}`             | `extract_text`: run the content stream through `GraphicsState`, emit a `TextElement` (placed transform + font/size/spacing + codes + Unicode + per-code advances + total advance) per shown segment, advancing `Tm` by the glyph widths and `TJ` adjustments (stages 2.1–2.2); `Do` recurses into a form XObject (state save / `/Matrix` concat / scoped resources / restore) with an active-set cycle guard (stage 2.3) |
+| `pdf_page_text.{hpp,cpp}`             | `extract_text`: run the content stream through `GraphicsState`, emit a `TextElement` (placed transform + font/size/spacing + codes + Unicode + per-code advances + total advance + render mode + `no_unicode` flag) per shown segment, advancing `Tm` by the glyph widths and `TJ` adjustments (stages 2.1–2.2); `Do` recurses into a form XObject (state save / `/Matrix` concat / scoped resources / restore) with an active-set cycle guard (stage 2.3); a marked-content stack applies `/ActualText` and the no-Unicode marking (stage 2.4) |
 | `pdf_file.{hpp,cpp}`                   | `abstract::PdfFile` wrapper; probes encryption at construction and implements `password_encrypted()`/`decrypt()`, carrying the authenticated `Decryptor` (not the password) so rendering needs no re-derivation |
 
 Consumers outside the module: `open_strategy.cpp` (detection / engine
@@ -378,7 +393,13 @@ such PDFs look right, their text just isn't selectable until the tables land.
   coverage (stage 2.3) with hand-built `XObject`s — invocation via `Do`, the
   `/Matrix` placement, state restoration after the form, the form's own
   `/Resources` scope, nested forms, image/unknown XObjects ignored, and a
-  self-referential form terminating at render time via the active-set guard.
+  self-referential form terminating at render time via the active-set guard;
+  plus render-mode and extraction-refinement coverage (stage 2.4) — `Tr`
+  propagation, a composite font with no `/ToUnicode` marked `no_unicode` with
+  empty text, and `/ActualText` overriding a segment (literal and UTF-16BE),
+  emitted once then suppressed across the sequence, resolved via a named
+  `/Properties` entry, the no-`/ActualText` passthrough, and a tolerated stray
+  `EMC`.
 
 No assertion-based coverage of the tokenizer (escapes, references, hex strings)
 or the HTML output itself (the span emission / CSS transform mapping).
@@ -517,14 +538,22 @@ the summary.
 Deferred: `/BBox` clipping (text-only for now); the form machinery is reused by
 stage 4 (tiling patterns) and stage 5 (annotation appearances).
 
-### 2.4 — text render modes & extraction refinements
+### 2.4 — text render modes & extraction refinements — **done**
 
-**Text render modes** (`Tr`): mode 3 (invisible text, OCR-over-scan) must stay
-selectable but unpainted; stroke/clip modes (1–2, 4–7) need graceful
-degradation. Plus **extraction refinements** (was stage 1.5, rides on the run
-plumbing): mark a run "no Unicode" when the code → Unicode chain yields nothing,
-so stage 3 can re-encode it; honour `/ActualText` (tagged PDFs, ligatures) as an
-extraction override of the whole chain.
+**Text render modes** (`Tr`): the mode rides on every `TextElement` and the HTML
+layer turns the unpainted modes — 3 (invisible text, OCR-over-scan) and 7
+(clip-only) — into a transparent-but-selectable span (the `.i` class); the
+stroke/fill+stroke/clip modes (1–2, 4–6) degrade gracefully to a painted fill.
+**Extraction refinements** (was stage 1.5, on the run plumbing): a segment whose
+code → Unicode chain yields nothing is marked `no_unicode` (empty `text`) so
+stage 3 can re-encode it to the PUA — until then the run simply renders nothing
+and isn't selectable. `/ActualText` is honoured as an extraction override of the
+whole chain: a `BMC`/`BDC … EMC` marked-content sequence (property list inline or
+named via the `/Properties` resource) carrying `/ActualText` replaces the
+per-glyph Unicode of the enclosed shows — emitted once for the sequence, the rest
+suppressed (the glyphs still place and, in stage 3, display). The mechanics live
+in *Text layout* under *What works*. Deferred: `/MCID`-driven structure-tree
+reordering and `/Alt` (those are stage 5 navigation, not extraction).
 
 ### 2.5 — space inference
 

--- a/src/odr/internal/pdf/pdf_document.cpp
+++ b/src/odr/internal/pdf/pdf_document.cpp
@@ -56,7 +56,8 @@ std::string Font::to_unicode(const std::string &codes) const {
     // CID -> Unicode table (the legacy CMaps, deferred) or the embedded font
     // program (stage 3): emit "no Unicode" rather than mis-splitting the
     // multi-byte codes into byte-sized garbage through the identity fallback
-    // below. Stage 2 will mark these runs for re-encoding.
+    // below. `extract_text` marks such runs `no_unicode` (stage 2.4); stage 3
+    // re-encodes their glyphs to the PUA.
     if (!cid_encoding_name.empty()) {
       if (std::optional<std::string> unicode =
               translate_predefined_cmap(cid_encoding_name, codes)) {

--- a/src/odr/internal/pdf/pdf_document_element.hpp
+++ b/src/odr/internal/pdf/pdf_document_element.hpp
@@ -75,6 +75,10 @@ struct Annotation final : Element {};
 struct Resources final : Element {
   std::unordered_map<std::string, Font *> font;
   std::unordered_map<std::string, XObject *> x_object;
+  /// The `/Properties` subdictionary (ISO 32000-1 7.8.3): named property lists
+  /// referenced by `BDC`. Each value is the resolved property-list dictionary
+  /// `Object`; used to recover `/ActualText` for a `BDC /Tag /Name` sequence.
+  std::unordered_map<std::string, Object> properties;
 };
 
 /// An external object referenced by `Do` and listed in a resource dictionary's

--- a/src/odr/internal/pdf/pdf_document_parser.cpp
+++ b/src/odr/internal/pdf/pdf_document_parser.cpp
@@ -480,6 +480,16 @@ Resources *parse_resources(State &state, const Object &object) {
     }
   }
 
+  if (dictionary.has_key("Properties") && !dictionary["Properties"].is_null()) {
+    // Named property lists for `BDC`; resolved eagerly so text extraction can
+    // recover `/ActualText` without a parser handle (cf. form XObjects).
+    const Dictionary property_table =
+        parser.resolve_object_copy(dictionary["Properties"]).as_dictionary();
+    for (const auto &[key, value] : property_table) {
+      resources->properties[key] = parser.resolve_object_copy(value);
+    }
+  }
+
   return resources;
 }
 

--- a/src/odr/internal/pdf/pdf_page_text.cpp
+++ b/src/odr/internal/pdf/pdf_page_text.cpp
@@ -32,20 +32,20 @@ Font *lookup_font(const Resources &resources, const std::string &name,
 /// approximated here as Latin-1, which is exact over ASCII and the common
 /// `/ActualText` payloads (the few upper-half divergences are rare).
 std::string decode_text_string(const std::string &string) {
-  if (string.size() >= 2 && static_cast<unsigned char>(string[0]) == 0xFE &&
-      static_cast<unsigned char>(string[1]) == 0xFF) {
+  if (string.size() >= 2 && static_cast<std::uint8_t>(string[0]) == 0xFE &&
+      static_cast<std::uint8_t>(string[1]) == 0xFF) {
     std::u16string units;
     units.reserve((string.size() - 2) / 2);
     for (std::size_t i = 2; i + 1 < string.size(); i += 2) {
       units.push_back(
-          static_cast<char16_t>((static_cast<unsigned char>(string[i]) << 8) |
-                                static_cast<unsigned char>(string[i + 1])));
+          static_cast<char16_t>((static_cast<std::uint8_t>(string[i]) << 8) |
+                                static_cast<std::uint8_t>(string[i + 1])));
     }
     return util::string::u16string_to_string(units);
   }
   std::string result;
   for (const char c : string) {
-    util::string::append_c32(static_cast<unsigned char>(c), result);
+    util::string::append_c32(static_cast<std::uint8_t>(c), result);
   }
   return result;
 }

--- a/src/odr/internal/pdf/pdf_page_text.cpp
+++ b/src/odr/internal/pdf/pdf_page_text.cpp
@@ -27,10 +27,100 @@ Font *lookup_font(const Resources &resources, const std::string &name,
   return nullptr;
 }
 
+/// Map a single PDFDocEncoding byte to its Unicode code point (ISO 32000-1
+/// Annex D.2). It agrees with Latin-1 over ASCII and 0xA1–0xFF, so only the
+/// diacritic block (0x18–0x1F), the typographic block (0x80–0x9E), and the
+/// euro (0xA0) need overriding; every other byte stands for the code point of
+/// the same value. The few undefined slots (0x7F, 0x9F, 0xAD) pass through.
+char32_t pdf_doc_encoding_to_unicode(std::uint8_t byte) {
+  switch (byte) {
+  case 0x18:
+    return U'˘'; // breve
+  case 0x19:
+    return U'ˇ'; // caron
+  case 0x1A:
+    return U'ˆ'; // circumflex
+  case 0x1B:
+    return U'˙'; // dot above
+  case 0x1C:
+    return U'˝'; // double acute
+  case 0x1D:
+    return U'˛'; // ogonek
+  case 0x1E:
+    return U'˚'; // ring above
+  case 0x1F:
+    return U'˜'; // small tilde
+  case 0x80:
+    return U'•'; // bullet
+  case 0x81:
+    return U'†'; // dagger
+  case 0x82:
+    return U'‡'; // double dagger
+  case 0x83:
+    return U'…'; // ellipsis
+  case 0x84:
+    return U'—'; // em dash
+  case 0x85:
+    return U'–'; // en dash
+  case 0x86:
+    return U'ƒ'; // florin
+  case 0x87:
+    return U'⁄'; // fraction slash
+  case 0x88:
+    return U'‹'; // single left angle quote
+  case 0x89:
+    return U'›'; // single right angle quote
+  case 0x8A:
+    return U'−'; // minus
+  case 0x8B:
+    return U'‰'; // per mille
+  case 0x8C:
+    return U'„'; // double low-9 quote
+  case 0x8D:
+    return U'“'; // left double quote
+  case 0x8E:
+    return U'”'; // right double quote
+  case 0x8F:
+    return U'‘'; // left single quote
+  case 0x90:
+    return U'’'; // right single quote
+  case 0x91:
+    return U'‚'; // single low-9 quote
+  case 0x92:
+    return U'™'; // trademark
+  case 0x93:
+    return U'ﬁ'; // fi ligature
+  case 0x94:
+    return U'ﬂ'; // fl ligature
+  case 0x95:
+    return U'Ł'; // L with stroke
+  case 0x96:
+    return U'Œ'; // OE
+  case 0x97:
+    return U'Š'; // S with caron
+  case 0x98:
+    return U'Ÿ'; // Y with diaeresis
+  case 0x99:
+    return U'Ž'; // Z with caron
+  case 0x9A:
+    return U'ı'; // dotless i
+  case 0x9B:
+    return U'ł'; // l with stroke
+  case 0x9C:
+    return U'œ'; // oe
+  case 0x9D:
+    return U'š'; // s with caron
+  case 0x9E:
+    return U'ž'; // z with caron
+  case 0xA0:
+    return U'€'; // euro
+  default:
+    return byte;
+  }
+}
+
 /// Decode a PDF text string (ISO 32000-1 7.9.2.2) to UTF-8: UTF-16BE when it
-/// opens with the `FE FF` byte-order mark, otherwise PDFDocEncoding —
-/// approximated here as Latin-1, which is exact over ASCII and the common
-/// `/ActualText` payloads (the few upper-half divergences are rare).
+/// opens with the `FE FF` byte-order mark, otherwise PDFDocEncoding.
 std::string decode_text_string(const std::string &string) {
   if (string.size() >= 2 && static_cast<std::uint8_t>(string[0]) == 0xFE &&
       static_cast<std::uint8_t>(string[1]) == 0xFF) {
@@ -45,7 +135,8 @@ std::string decode_text_string(const std::string &string) {
   }
   std::string result;
   for (const char c : string) {
-    util::string::append_c32(static_cast<std::uint8_t>(c), result);
+    util::string::append_c32(
+        pdf_doc_encoding_to_unicode(static_cast<std::uint8_t>(c)), result);
   }
   return result;
 }

--- a/src/odr/internal/pdf/pdf_page_text.cpp
+++ b/src/odr/internal/pdf/pdf_page_text.cpp
@@ -6,7 +6,9 @@
 #include <odr/internal/pdf/pdf_graphics_operator.hpp>
 #include <odr/internal/pdf/pdf_graphics_operator_parser.hpp>
 #include <odr/internal/pdf/pdf_graphics_state.hpp>
+#include <odr/internal/util/string_util.hpp>
 
+#include <optional>
 #include <set>
 #include <sstream>
 
@@ -23,6 +25,77 @@ Font *lookup_font(const Resources &resources, const std::string &name,
                             "', emitting raw codes");
   }
   return nullptr;
+}
+
+/// Decode a PDF text string (ISO 32000-1 7.9.2.2) to UTF-8: UTF-16BE when it
+/// opens with the `FE FF` byte-order mark, otherwise PDFDocEncoding —
+/// approximated here as Latin-1, which is exact over ASCII and the common
+/// `/ActualText` payloads (the few upper-half divergences are rare).
+std::string decode_text_string(const std::string &string) {
+  if (string.size() >= 2 && static_cast<unsigned char>(string[0]) == 0xFE &&
+      static_cast<unsigned char>(string[1]) == 0xFF) {
+    std::u16string units;
+    units.reserve((string.size() - 2) / 2);
+    for (std::size_t i = 2; i + 1 < string.size(); i += 2) {
+      units.push_back(
+          static_cast<char16_t>((static_cast<unsigned char>(string[i]) << 8) |
+                                static_cast<unsigned char>(string[i + 1])));
+    }
+    return util::string::u16string_to_string(units);
+  }
+  std::string result;
+  for (const char c : string) {
+    util::string::append_c32(static_cast<unsigned char>(c), result);
+  }
+  return result;
+}
+
+/// `/ActualText` of a `BDC` property-list dictionary, decoded to UTF-8, or
+/// `nullopt` when the dictionary carries none.
+std::optional<std::string> actual_text(const Dictionary &properties) {
+  if (properties.has_key("ActualText") &&
+      properties["ActualText"].is_string()) {
+    return decode_text_string(properties["ActualText"].as_string());
+  }
+  return std::nullopt;
+}
+
+/// One open marked-content sequence (`BMC`/`BDC` … `EMC`). Only `/ActualText`
+/// is modelled: when present it overrides the per-glyph Unicode of the whole
+/// sequence (ISO 32000-1 14.9.4), emitted once (`consumed`) then suppressed.
+struct MarkedContent {
+  std::optional<std::string> actual_text;
+  bool consumed{false};
+};
+using MarkedContentStack = std::vector<MarkedContent>;
+
+/// Resolve the extraction text of a shown segment. The nearest enclosing
+/// `/ActualText` sequence, if any, governs: its text is emitted for the first
+/// segment and the rest of the sequence is suppressed (empty). Otherwise the
+/// font's code -> Unicode chain applies; an empty result for non-empty codes is
+/// reported as `no_unicode` (the run is not extractable until stage 3).
+struct ResolvedText {
+  std::string text;
+  bool no_unicode{false};
+};
+
+ResolvedText resolve_text(MarkedContentStack &marked, const Font *font,
+                          const std::string &codes) {
+  for (auto it = marked.rbegin(); it != marked.rend(); ++it) {
+    if (it->actual_text.has_value()) {
+      if (it->consumed) {
+        return {};
+      }
+      it->consumed = true;
+      return {*it->actual_text, false};
+    }
+  }
+  if (font == nullptr) {
+    return {codes, false}; // unknown font: historic raw-code passthrough
+  }
+  std::string unicode = font->to_unicode(codes);
+  const bool no_unicode = unicode.empty() && !codes.empty();
+  return {std::move(unicode), no_unicode};
 }
 
 /// Per-code advances of a shown string and their total, in text-space units.
@@ -60,7 +133,7 @@ SegmentAdvances segment_advances(const GraphicsState::Text &text,
 
 /// Emit one placed segment and advance the text matrix by its width.
 void show(std::vector<TextElement> &out, GraphicsState &state,
-          std::string codes, Font *font) {
+          MarkedContentStack &marked, std::string codes, Font *font) {
   const GraphicsState::Text &text = state.current().text;
 
   TextElement element;
@@ -72,7 +145,9 @@ void show(std::vector<TextElement> &out, GraphicsState &state,
   element.horizontal_scaling = text.horizontal_scaling;
   element.rise = text.rise;
   element.rendering_mode = text.rendering_mode;
-  element.text = font != nullptr ? font->to_unicode(codes) : codes;
+  ResolvedText resolved = resolve_text(marked, font, codes);
+  element.text = std::move(resolved.text);
+  element.no_unicode = resolved.no_unicode;
   element.codes = std::move(codes);
   if (font != nullptr) {
     auto [advances, total] = segment_advances(text, *font, element.codes);
@@ -94,7 +169,29 @@ using ActiveForms = std::set<const XObject *>;
 void run_content(const std::string &content, const Resources &resources,
                  GraphicsState &state, std::vector<TextElement> &out,
                  const Logger &logger, std::set<std::string> &warned,
-                 ActiveForms &active);
+                 ActiveForms &active, MarkedContentStack &marked);
+
+/// Open a marked-content sequence (`BMC`/`BDC`), recording its `/ActualText`
+/// when one is present. `BDC`'s property list is either an inline dictionary or
+/// a name into the `/Properties` resource subdictionary (ISO 32000-1 14.6.1).
+void begin_marked_content(const GraphicsOperator &op,
+                          const Resources &resources,
+                          MarkedContentStack &marked) {
+  MarkedContent entry;
+  if (op.type == GraphicsOperatorType::begin_marked_content_seq_props &&
+      op.arguments.size() >= 2) {
+    const Object &props = op.arguments.at(1);
+    if (props.is_dictionary()) {
+      entry.actual_text = actual_text(props.as_dictionary());
+    } else if (props.is_name()) {
+      if (const auto it = resources.properties.find(props.as_name());
+          it != resources.properties.end() && it->second.is_dictionary()) {
+        entry.actual_text = actual_text(it->second.as_dictionary());
+      }
+    }
+  }
+  marked.push_back(std::move(entry));
+}
 
 /// Invoke a form XObject named by `Do`: save the state, concatenate the form's
 /// `/Matrix` onto the CTM, run its content with the form's own `/Resources`
@@ -104,7 +201,7 @@ void run_content(const std::string &content, const Resources &resources,
 void invoke_x_object(const std::string &name, const Resources &resources,
                      GraphicsState &state, std::vector<TextElement> &out,
                      const Logger &logger, std::set<std::string> &warned,
-                     ActiveForms &active) {
+                     ActiveForms &active, MarkedContentStack &marked) {
   const auto it = resources.x_object.find(name);
   if (it == resources.x_object.end()) {
     if (warned.insert("xobject:" + name).second) {
@@ -126,7 +223,12 @@ void invoke_x_object(const std::string &name, const Resources &resources,
   state.concat_matrix(x_object->matrix);
   const Resources &scope =
       x_object->resources != nullptr ? *x_object->resources : resources;
-  run_content(x_object->content, scope, state, out, logger, warned, active);
+  // A form's marked content must be self-balanced; truncate back to the entry
+  // depth afterwards so an unbalanced form cannot corrupt the enclosing scope.
+  const std::size_t depth = marked.size();
+  run_content(x_object->content, scope, state, out, logger, warned, active,
+              marked);
+  marked.resize(depth);
   state.restore();
   active.erase(x_object);
 }
@@ -134,7 +236,7 @@ void invoke_x_object(const std::string &name, const Resources &resources,
 void run_content(const std::string &content, const Resources &resources,
                  GraphicsState &state, std::vector<TextElement> &out,
                  const Logger &logger, std::set<std::string> &warned,
-                 ActiveForms &active) {
+                 ActiveForms &active, MarkedContentStack &marked) {
   std::istringstream ss(content);
   GraphicsOperatorParser parser(ss);
 
@@ -147,7 +249,7 @@ void run_content(const std::string &content, const Resources &resources,
     case GraphicsOperatorType::show_text_next_line: { // Tj, '
       Font *font =
           lookup_font(resources, state.current().text.font, logger, warned);
-      show(out, state, op.arguments.at(0).as_string(), font);
+      show(out, state, marked, op.arguments.at(0).as_string(), font);
     } break;
     case GraphicsOperatorType::show_text_manual_spacing: { // TJ
       Font *font =
@@ -155,7 +257,7 @@ void run_content(const std::string &content, const Resources &resources,
       const GraphicsState::Text &text = state.current().text;
       for (const Object &item : op.arguments.at(0).as_array()) {
         if (item.is_string()) {
-          show(out, state, item.as_string(), font);
+          show(out, state, marked, item.as_string(), font);
         } else if (item.is_real()) {
           // a number translates the next glyph left by adj/1000 text-space
           // units, scaled by the font size and horizontal scaling (9.4.3).
@@ -168,11 +270,20 @@ void run_content(const std::string &content, const Resources &resources,
     case GraphicsOperatorType::show_text_next_line_set_spacing: { // "
       Font *font =
           lookup_font(resources, state.current().text.font, logger, warned);
-      show(out, state, op.arguments.at(2).as_string(), font);
+      show(out, state, marked, op.arguments.at(2).as_string(), font);
     } break;
     case GraphicsOperatorType::draw_object: // Do
       invoke_x_object(op.arguments.at(0).as_string(), resources, state, out,
-                      logger, warned, active);
+                      logger, warned, active, marked);
+      break;
+    case GraphicsOperatorType::begin_marked_content_seq:       // BMC
+    case GraphicsOperatorType::begin_marked_content_seq_props: // BDC
+      begin_marked_content(op, resources, marked);
+      break;
+    case GraphicsOperatorType::end_marked_content_seq: // EMC
+      if (!marked.empty()) {
+        marked.pop_back();
+      }
       break;
     default:
       break;
@@ -192,9 +303,11 @@ std::vector<pdf::TextElement> pdf::extract_text(const std::string &content,
   std::vector<TextElement> result;
   std::set<std::string> warned;
   ActiveForms active;
+  MarkedContentStack marked;
   GraphicsState state;
 
-  run_content(content, resources, state, result, logger, warned, active);
+  run_content(content, resources, state, result, logger, warned, active,
+              marked);
 
   return result;
 }

--- a/src/odr/internal/pdf/pdf_page_text.hpp
+++ b/src/odr/internal/pdf/pdf_page_text.hpp
@@ -34,8 +34,18 @@ struct TextElement {
   /// `TJ` array).
   std::string codes;
   /// Unicode representation of `codes`; may lack spaces the producer cannot
-  /// infer (space inference is stage 2.5).
+  /// infer (space inference is stage 2.5). Empty when the segment carries no
+  /// extractable text — either the code -> Unicode chain yielded nothing (see
+  /// `no_unicode`) or an enclosing `/ActualText` already emitted the run's
+  /// text.
   std::string text;
+  /// True when the font's code -> Unicode chain yielded nothing for this
+  /// segment (a composite font with no `/ToUnicode` or usable predefined
+  /// encoding is the common case), so `text` is empty. The glyphs still display
+  /// once the embedded font lands (stage 3), which re-encodes them to the
+  /// Private Use Area and marks the run non-extractable; until then the run is
+  /// simply not selectable. An `/ActualText` override clears this.
+  bool no_unicode{false};
   /// Total advance of this segment, in text-space units (the displacement
   /// applied to the text matrix after it — already scaled by the font size and
   /// including char/word spacing and horizontal scaling). 0 when the font is

--- a/test/src/internal/pdf/pdf_page_text.cpp
+++ b/test/src/internal/pdf/pdf_page_text.cpp
@@ -326,8 +326,6 @@ TEST(PdfPageText, form_xobject_self_cycle_terminates) {
   EXPECT_EQ(texts[0].codes, "a");
 }
 
-// --- Stage 2.4: render modes & extraction refinements ---
-
 // The text rendering mode (`Tr`) rides along on each element; the HTML layer
 // turns the unpainted modes (3 invisible, 7 clip-only) into transparent but
 // still selectable spans.

--- a/test/src/internal/pdf/pdf_page_text.cpp
+++ b/test/src/internal/pdf/pdf_page_text.cpp
@@ -372,6 +372,15 @@ TEST(PdfPageText, actual_text_utf16be) {
   EXPECT_EQ(texts[0].text, "AB");
 }
 
+// A non-BOM `/ActualText` is PDFDocEncoding, not Latin-1: the upper-half bytes
+// 0x83/0x84 decode to ellipsis/em dash, not the C1 controls Latin-1 would give.
+TEST(PdfPageText, actual_text_pdfdocencoding) {
+  const auto texts = run("BT /F1 10 Tf 0 0 Td /Span <</ActualText "
+                         "<8384>>> BDC (zz) Tj EMC ET");
+  ASSERT_EQ(texts.size(), 1);
+  EXPECT_EQ(texts[0].text, "…—"); // U+2026 U+2014
+}
+
 // `/ActualText` covers the whole sequence: it is emitted once, and the
 // remaining shows in the sequence carry no extractable text of their own.
 TEST(PdfPageText, actual_text_emitted_once_then_suppressed) {

--- a/test/src/internal/pdf/pdf_page_text.cpp
+++ b/test/src/internal/pdf/pdf_page_text.cpp
@@ -325,3 +325,90 @@ TEST(PdfPageText, form_xobject_self_cycle_terminates) {
   ASSERT_EQ(texts.size(), 1); // body emitted once, the cycle is cut
   EXPECT_EQ(texts[0].codes, "a");
 }
+
+// --- Stage 2.4: render modes & extraction refinements ---
+
+// The text rendering mode (`Tr`) rides along on each element; the HTML layer
+// turns the unpainted modes (3 invisible, 7 clip-only) into transparent but
+// still selectable spans.
+TEST(PdfPageText, rendering_mode_propagates) {
+  const auto texts = run("BT /F1 10 Tf 3 Tr 0 0 Td (x) Tj ET");
+  ASSERT_EQ(texts.size(), 1);
+  EXPECT_EQ(texts[0].rendering_mode, 3);
+}
+
+// A composite font with no `/ToUnicode` and no usable predefined encoding has
+// no recoverable Unicode: the segment is marked `no_unicode` with empty text
+// (the glyphs render once the embedded font lands in stage 3).
+TEST(PdfPageText, no_unicode_marks_composite_without_tounicode) {
+  Font font;
+  font.composite = true; // 2-byte codes, empty cmap, no cid_encoding_name
+  Resources res;
+  res.font["F1"] = &font;
+
+  const auto texts = run("BT /F1 10 Tf 0 0 Td <0001> Tj ET", res);
+  ASSERT_EQ(texts.size(), 1);
+  EXPECT_TRUE(texts[0].text.empty());
+  EXPECT_TRUE(texts[0].no_unicode);
+  EXPECT_EQ(texts[0].codes, std::string("\x00\x01", 2));
+}
+
+// `/ActualText` on a marked-content sequence overrides the per-glyph text for
+// extraction (ligatures, reordered glyphs); a literal string is taken as-is.
+TEST(PdfPageText, actual_text_overrides_segment) {
+  const auto texts =
+      run("BT /F1 10 Tf 0 0 Td /Span <</ActualText (OK)>> BDC (xyz) Tj EMC ET");
+  ASSERT_EQ(texts.size(), 1);
+  EXPECT_EQ(texts[0].text, "OK");
+  EXPECT_EQ(texts[0].codes, "xyz"); // glyphs unchanged, only the text differs
+  EXPECT_FALSE(texts[0].no_unicode);
+}
+
+// A UTF-16BE `/ActualText` (the common form, opening with the FE FF BOM) is
+// decoded to UTF-8.
+TEST(PdfPageText, actual_text_utf16be) {
+  // <FEFF 0041 0042> = "AB"
+  const auto texts = run("BT /F1 10 Tf 0 0 Td /Span <</ActualText "
+                         "<FEFF00410042>>> BDC (zz) Tj EMC ET");
+  ASSERT_EQ(texts.size(), 1);
+  EXPECT_EQ(texts[0].text, "AB");
+}
+
+// `/ActualText` covers the whole sequence: it is emitted once, and the
+// remaining shows in the sequence carry no extractable text of their own.
+TEST(PdfPageText, actual_text_emitted_once_then_suppressed) {
+  const auto texts = run("BT /F1 10 Tf 0 0 Td /Span <</ActualText (Sum)>> BDC "
+                         "(a) Tj (b) Tj EMC ET");
+  ASSERT_EQ(texts.size(), 2);
+  EXPECT_EQ(texts[0].text, "Sum");
+  EXPECT_TRUE(texts[1].text.empty());
+}
+
+// A named property list (`BDC /Tag /Name`) resolves `/ActualText` through the
+// `/Properties` resource subdictionary.
+TEST(PdfPageText, actual_text_named_property) {
+  Dictionary props;
+  props["ActualText"] = Object(StandardString("Z"));
+  Resources res;
+  res.properties["MC0"] = Object(props);
+
+  const auto texts =
+      run("BT /F1 10 Tf 0 0 Td /Span /MC0 BDC (q) Tj EMC ET", res);
+  ASSERT_EQ(texts.size(), 1);
+  EXPECT_EQ(texts[0].text, "Z");
+}
+
+// Marked content without `/ActualText` (a plain `BMC`, or a `BDC` whose
+// property list carries none) leaves extraction untouched.
+TEST(PdfPageText, marked_content_without_actual_text_passthrough) {
+  const auto texts = run("BT /F1 10 Tf 0 0 Td /Tag BMC (hi) Tj EMC ET");
+  ASSERT_EQ(texts.size(), 1);
+  EXPECT_EQ(texts[0].text, "hi"); // no font -> raw codes, no override
+}
+
+// A stray `EMC` (more ends than begins) is tolerated, not a crash.
+TEST(PdfPageText, stray_emc_tolerated) {
+  const auto texts = run("BT /F1 10 Tf 0 0 Td EMC (ok) Tj ET");
+  ASSERT_EQ(texts.size(), 1);
+  EXPECT_EQ(texts[0].text, "ok");
+}


### PR DESCRIPTION
Stage 2.4 of the in-house PDF renderer: text render modes plus extraction refinements.

## What's in it
- **Text render modes (`Tr`)**: invisible modes 3 (OCR-over-scan) and 7 (clip-only) stay in the DOM for selection/search but paint transparent (new `.i` CSS class); the stroke/fill+stroke/clip modes (1–2, 4–6) degrade gracefully to a painted fill. The mode rides on every `TextElement`.
- **No-Unicode marking**: a segment whose code → Unicode chain yields nothing (a composite font with no `/ToUnicode` or usable predefined encoding) is flagged `no_unicode` with empty `text`, so stage 3 can re-encode its glyphs to the PUA. Until then such runs simply render nothing and aren't selectable (no display regression — empty before too).
- **`/ActualText`**: a `BMC`/`BDC … EMC` marked-content sequence carrying `/ActualText` (inline property dictionary, or a name resolved through the new `/Properties` resource table) overrides the per-glyph Unicode of its enclosed shows — decoded (UTF-16BE BOM or PDFDocEncoding), emitted once for the sequence then suppressed. Marked content is balanced per stream and reset across form invocation.

Empty-text segments emit no span for now.

## Tests
6 new assertion-based cases in `pdf_page_text.cpp` (inline content streams): render-mode propagation, the no-Unicode marking, and `/ActualText` (literal, UTF-16BE, suppress-after-first, named `/Properties`, no-`/ActualText` passthrough, tolerated stray `EMC`). Full suite green.

`AGENTS.md` updated (scope, *What works*, module layout, tests, roadmap 2.4 → done).

🤖 Generated with [Claude Code](https://claude.com/claude-code)