### PR TITLE
pdf: nullable Object accessors + unit tests

### DIFF
--- a/src/odr/internal/pdf/pdf_object.cpp
+++ b/src/odr/internal/pdf/pdf_object.cpp
@@ -4,6 +4,7 @@
 #include <odr/internal/util/hash_util.hpp>
 
 #include <iomanip>
+#include <optional>
 #include <ostream>
 #include <sstream>
 #include <stdexcept>
@@ -67,7 +68,7 @@ Object::Object(Array array) : m_holder{std::move(array)} {}
 
 Object::Object(Dictionary dictionary) : m_holder{std::move(dictionary)} {}
 
-const std::string &Object::as_string() const {
+const std::string &Object::as_string() const & {
   if (is_standard_string()) {
     return as_standard_string();
   }
@@ -75,6 +76,39 @@ const std::string &Object::as_string() const {
     return as_hex_string();
   }
   return as_name();
+}
+
+std::string &Object::as_string() & {
+  if (is_standard_string()) {
+    return as_standard_string();
+  }
+  if (is_hex_string()) {
+    return as_hex_string();
+  }
+  return as_name();
+}
+
+std::string &&Object::as_string() && {
+  if (is_standard_string()) {
+    return std::move(*this).as_standard_string();
+  }
+  if (is_hex_string()) {
+    return std::move(*this).as_hex_string();
+  }
+  return std::move(*this).as_name();
+}
+
+std::optional<std::string> Object::as_string_opt() && {
+  if (is_standard_string()) {
+    return std::move(*this).as_standard_string_opt();
+  }
+  if (is_hex_string()) {
+    return std::move(*this).as_hex_string_opt();
+  }
+  if (is_name()) {
+    return std::move(*this).as_name_opt();
+  }
+  return std::nullopt;
 }
 
 void Object::to_stream(std::ostream &out) const {

--- a/src/odr/internal/pdf/pdf_object.hpp
+++ b/src/odr/internal/pdf/pdf_object.hpp
@@ -106,19 +106,19 @@ public:
     return std::any_cast<T &&>(std::move(m_holder));
   }
   template <ObjectType T> [[nodiscard]] const T *as_ptr() const & {
-    return std::any_cast<const T *>(m_holder);
+    return std::any_cast<T>(&m_holder);
   }
   template <ObjectType T> [[nodiscard]] T *as_ptr() & {
-    return std::any_cast<T>(m_holder);
+    return std::any_cast<T>(&m_holder);
   }
   template <ObjectType T> [[nodiscard]] std::optional<T> as_opt() const & {
-    if (const T *ptr = std::any_cast<const T *>(&m_holder)) {
+    if (const T *ptr = std::any_cast<T>(&m_holder)) {
       return *ptr;
     }
     return std::nullopt;
   }
   template <ObjectType T> [[nodiscard]] std::optional<T> as_opt() && {
-    if (T *ptr = std::any_cast<T *>(&m_holder)) {
+    if (T *ptr = std::any_cast<T>(&m_holder)) {
       return std::move(*ptr);
     }
     return std::nullopt;
@@ -143,14 +143,16 @@ public:
   [[nodiscard]] Real as_real() const {
     return is<Real>() ? as<Real>() : static_cast<Real>(as_integer());
   }
-  [[nodiscard]] const std::string &as_standard_string() const {
+  [[nodiscard]] const std::string &as_standard_string() const & {
     return as<StandardString>().string;
   }
-  [[nodiscard]] const std::string &as_hex_string() const {
+  [[nodiscard]] const std::string &as_hex_string() const & {
     return as<HexString>().string;
   }
-  [[nodiscard]] const std::string &as_name() const { return as<Name>().string; }
-  [[nodiscard]] const std::string &as_string() const;
+  [[nodiscard]] const std::string &as_name() const & {
+    return as<Name>().string;
+  }
+  [[nodiscard]] const std::string &as_string() const &;
   [[nodiscard]] const Array &as_array() const & { return as<Array>(); }
   [[nodiscard]] const Dictionary &as_dictionary() const & {
     return as<Dictionary>();
@@ -159,16 +161,80 @@ public:
     return as<ObjectReference>();
   }
 
+  [[nodiscard]] std::string &as_standard_string() & {
+    return as<StandardString>().string;
+  }
+  [[nodiscard]] std::string &as_hex_string() & {
+    return as<HexString>().string;
+  }
+  [[nodiscard]] std::string &as_name() & { return as<Name>().string; }
+  [[nodiscard]] std::string &as_string() &;
   Array &as_array() & { return as<Array>(); }
   Dictionary &as_dictionary() & { return as<Dictionary>(); }
 
+  [[nodiscard]] std::string &&as_standard_string() && {
+    return std::move(*this).as<StandardString>().string;
+  }
+  [[nodiscard]] std::string &&as_hex_string() && {
+    return std::move(*this).as<HexString>().string;
+  }
+  [[nodiscard]] std::string &&as_name() && {
+    return std::move(*this).as<Name>().string;
+  }
+  [[nodiscard]] std::string &&as_string() &&;
   Array &&as_array() && { return std::move(*this).as<Array>(); }
   Dictionary &&as_dictionary() && { return std::move(*this).as<Dictionary>(); }
+
+  [[nodiscard]] std::optional<Boolean> as_bool_opt() const {
+    return as_opt<Boolean>();
+  }
+  [[nodiscard]] std::optional<Integer> as_integer_opt() const {
+    return as_opt<Integer>();
+  }
+  [[nodiscard]] std::optional<Real> as_real_opt() const {
+    if (is<Real>()) {
+      return as<Real>();
+    }
+    if (const Integer *integer = as_ptr<Integer>()) {
+      return static_cast<Real>(*integer);
+    }
+    return std::nullopt;
+  }
+  [[nodiscard]] std::optional<ObjectReference> as_reference_opt() const {
+    return as_opt<ObjectReference>();
+  }
+
+  [[nodiscard]] std::optional<std::string> as_standard_string_opt() && {
+    return std::move(*this).string_opt<StandardString>();
+  }
+  [[nodiscard]] std::optional<std::string> as_hex_string_opt() && {
+    return std::move(*this).string_opt<HexString>();
+  }
+  [[nodiscard]] std::optional<std::string> as_name_opt() && {
+    return std::move(*this).string_opt<Name>();
+  }
+  [[nodiscard]] std::optional<std::string> as_string_opt() &&;
+
+  [[nodiscard]] const Array *as_array_ptr() const & { return as_ptr<Array>(); }
+  [[nodiscard]] const Dictionary *as_dictionary_ptr() const & {
+    return as_ptr<Dictionary>();
+  }
+
+  Array *as_array_ptr() & { return as_ptr<Array>(); }
+  Dictionary *as_dictionary_ptr() & { return as_ptr<Dictionary>(); }
 
   void to_stream(std::ostream &) const;
   [[nodiscard]] std::string to_string() const;
 
 private:
+  template <ObjectType T>
+  [[nodiscard]] std::optional<std::string> string_opt() && {
+    if (T *string = as_ptr<T>()) {
+      return std::move(string->string);
+    }
+    return std::nullopt;
+  }
+
   Holder m_holder;
 };
 

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -48,6 +48,7 @@ add_executable(odr_test
         "src/internal/pdf/pdf_file_parser.cpp"
         "src/internal/pdf/pdf_filter.cpp"
         "src/internal/util/math_util_test.cpp"
+        "src/internal/pdf/pdf_object.cpp"
         "src/internal/pdf/pdf_object_parser.cpp"
         "src/internal/pdf/pdf_page_text.cpp"
         "src/internal/pdf/pdf_test_file_builder.cpp"

--- a/test/src/internal/pdf/pdf_object.cpp
+++ b/test/src/internal/pdf/pdf_object.cpp
@@ -1,0 +1,168 @@
+#include <odr/internal/pdf/pdf_object.hpp>
+
+#include <optional>
+#include <string>
+
+#include <gtest/gtest.h>
+
+using namespace odr::internal::pdf;
+
+// A default-constructed Object holds nothing and is the canonical null.
+TEST(PdfObject, null) {
+  const Object object;
+  EXPECT_TRUE(object.is_null());
+  EXPECT_FALSE(object.is_bool());
+  EXPECT_FALSE(object.is_integer());
+  EXPECT_FALSE(object.is_string());
+  EXPECT_TRUE(Object::null().is_null());
+}
+
+TEST(PdfObject, type_predicates_are_exclusive) {
+  EXPECT_TRUE(Object(Boolean{true}).is_bool());
+  EXPECT_TRUE(Object(Integer{1}).is_integer());
+  EXPECT_TRUE(Object(Real{1.5}).is_real());
+  EXPECT_TRUE(Object(StandardString{"x"}).is_standard_string());
+  EXPECT_TRUE(Object(HexString{"x"}).is_hex_string());
+  EXPECT_TRUE(Object(Name{"x"}).is_name());
+  EXPECT_TRUE(Object(Array{}).is_array());
+  EXPECT_TRUE(Object(Dictionary{}).is_dictionary());
+  EXPECT_TRUE(Object(ObjectReference(1, 0)).is_reference());
+
+  // a bool is not an integer and an integer is not a bool
+  EXPECT_FALSE(Object(Boolean{true}).is_integer());
+  EXPECT_FALSE(Object(Integer{1}).is_bool());
+}
+
+// is_real() and as_real() accept an integer; is_integer() does not accept a
+// real.
+TEST(PdfObject, integer_promotes_to_real) {
+  const Object integer(Integer{42});
+  EXPECT_TRUE(integer.is_real());
+  EXPECT_DOUBLE_EQ(integer.as_real(), 42.0);
+
+  const Object real(Real{1.5});
+  EXPECT_FALSE(real.is_integer());
+}
+
+TEST(PdfObject, as_throws_on_type_mismatch) {
+  const Object object(Integer{1});
+  EXPECT_EQ(object.as_integer(), 1);
+  EXPECT_ANY_THROW((void)object.as_bool());
+  EXPECT_ANY_THROW((void)object.as_array());
+}
+
+// as_string() and is_string() span all three string-like types.
+TEST(PdfObject, as_string_spans_string_types) {
+  EXPECT_EQ(Object(StandardString{"a"}).as_string(), "a");
+  EXPECT_EQ(Object(HexString{"b"}).as_string(), "b");
+  EXPECT_EQ(Object(Name{"c"}).as_string(), "c");
+
+  const Object integer(Integer{1});
+  EXPECT_FALSE(integer.is_string());
+}
+
+// as_<T>_opt() returns the value on an exact type match and nullopt otherwise.
+TEST(PdfObject, value_opt_matches_exact_type) {
+  EXPECT_EQ(Object(Boolean{true}).as_bool_opt(), std::optional<Boolean>{true});
+  EXPECT_EQ(Object(Integer{7}).as_integer_opt(), std::optional<Integer>{7});
+  EXPECT_EQ(Object(ObjectReference(3, 1)).as_reference_opt(),
+            std::optional<ObjectReference>{ObjectReference(3, 1)});
+
+  EXPECT_FALSE(Object(Integer{1}).as_bool_opt().has_value());
+  EXPECT_FALSE(Object().as_integer_opt().has_value());
+}
+
+// as_real_opt() mirrors as_real(): it accepts an integer but yields nullopt for
+// unrelated types.
+TEST(PdfObject, real_opt_accepts_integer) {
+  EXPECT_EQ(Object(Real{1.5}).as_real_opt(), std::optional<Real>{1.5});
+  EXPECT_EQ(Object(Integer{2}).as_real_opt(), std::optional<Real>{2.0});
+  EXPECT_FALSE(Object(Name{"x"}).as_real_opt().has_value());
+  EXPECT_FALSE(Object().as_real_opt().has_value());
+}
+
+// The string _opt accessors are rvalue-only: they move the held string out.
+TEST(PdfObject, string_opt_matches_exact_type) {
+  EXPECT_EQ(Object(StandardString{"a"}).as_standard_string_opt(),
+            std::optional<std::string>{"a"});
+  EXPECT_EQ(Object(HexString{"b"}).as_hex_string_opt(),
+            std::optional<std::string>{"b"});
+  EXPECT_EQ(Object(Name{"c"}).as_name_opt(), std::optional<std::string>{"c"});
+
+  // a hex string is not a standard string
+  EXPECT_FALSE(Object(HexString{"b"}).as_standard_string_opt().has_value());
+}
+
+// as_string_opt() spans all three string types, like as_string().
+TEST(PdfObject, as_string_opt_spans_string_types) {
+  EXPECT_EQ(Object(StandardString{"a"}).as_string_opt(),
+            std::optional<std::string>{"a"});
+  EXPECT_EQ(Object(HexString{"b"}).as_string_opt(),
+            std::optional<std::string>{"b"});
+  EXPECT_EQ(Object(Name{"c"}).as_string_opt(), std::optional<std::string>{"c"});
+
+  EXPECT_FALSE(Object(Integer{1}).as_string_opt().has_value());
+}
+
+// The container accessors return a pointer (nullptr on mismatch) to avoid
+// copying the array/dictionary.
+TEST(PdfObject, container_ptr_matches_exact_type) {
+  Array array;
+  array.holder().emplace_back(Integer{1});
+  const Object object(std::move(array));
+
+  const Array *array_ptr = object.as_array_ptr();
+  ASSERT_NE(array_ptr, nullptr);
+  EXPECT_EQ(array_ptr->size(), 1u);
+
+  EXPECT_EQ(object.as_dictionary_ptr(), nullptr);
+  EXPECT_EQ(Object().as_array_ptr(), nullptr);
+}
+
+// The generic as_ptr<T>()/as_opt<T>() back the named accessors.
+TEST(PdfObject, generic_nullable_accessors) {
+  const Object object(Integer{5});
+  ASSERT_NE(object.as_ptr<Integer>(), nullptr);
+  EXPECT_EQ(*object.as_ptr<Integer>(), 5);
+  EXPECT_EQ(object.as_ptr<Boolean>(), nullptr);
+
+  EXPECT_EQ(object.as_opt<Integer>(), std::optional<Integer>{5});
+  EXPECT_FALSE(object.as_opt<Boolean>().has_value());
+}
+
+TEST(PdfObject, object_reference_ordering_and_equality) {
+  EXPECT_EQ(ObjectReference(1, 0), ObjectReference(1, 0));
+  EXPECT_FALSE(ObjectReference(1, 0) == ObjectReference(1, 1));
+  // ordered by id first, then generation
+  EXPECT_TRUE(ObjectReference(1, 5) < ObjectReference(2, 0));
+  EXPECT_TRUE(ObjectReference(1, 0) < ObjectReference(1, 1));
+
+  std::hash<ObjectReference> hash;
+  EXPECT_EQ(hash(ObjectReference(1, 0)), hash(ObjectReference(1, 0)));
+}
+
+// get() returns the default for a missing key without inserting it; has_value()
+// treats an explicit null as absent.
+TEST(PdfObject, dictionary_lookup) {
+  Dictionary dictionary;
+  dictionary["A"] = Object(Integer{1});
+  dictionary["B"] = Object();
+
+  EXPECT_TRUE(dictionary.has_key("A"));
+  EXPECT_TRUE(dictionary.has_value("A"));
+  EXPECT_TRUE(dictionary.has_key("B"));
+  EXPECT_FALSE(dictionary.has_value("B"));
+  EXPECT_FALSE(dictionary.has_key("C"));
+
+  EXPECT_EQ(dictionary.get("A").as_integer(), 1);
+  EXPECT_TRUE(dictionary.get("C").is_null());
+  EXPECT_FALSE(dictionary.has_key("C"));
+}
+
+TEST(PdfObject, to_string) {
+  EXPECT_EQ(Object().to_string(), "null");
+  EXPECT_EQ(Object(Boolean{true}).to_string(), "true");
+  EXPECT_EQ(Object(Integer{42}).to_string(), "42");
+  EXPECT_EQ(Object(Name{"Type"}).to_string(), "/Type");
+  EXPECT_EQ(Object(ObjectReference(12, 0)).to_string(), "12 0 R");
+}


### PR DESCRIPTION
## Summary
- Fix the `as_ptr<T>()`/`as_opt<T>()` template helpers on `pdf::Object`. They misused `std::any_cast` (wrong overload/type) and only compiled because nothing instantiated them. They now use the nullable pointer overload `std::any_cast<T>(&holder)`, returning `nullptr`/`nullopt` on a type mismatch instead of throwing.
- Add concrete nullable accessors built on those helpers, split by cost:
  - **`_opt`** for the cheap value/string types — `as_bool_opt`, `as_integer_opt`, `as_real_opt` (keeps the integer→real fallback), `as_reference_opt`, the three string `_opt`s + unified `as_string_opt`.
  - **`_ptr`** for the heavyweight containers — `as_array_ptr`, `as_dictionary_ptr` — returning a nullable `const*` to avoid copying.
- Add ref-qualified string accessors so `as_string()`/`as_*_string()` can move the held string out of an rvalue `Object` (the string `_opt`s are rvalue-only).
- Add `test/src/internal/pdf/pdf_object.cpp` (14 tests) covering type predicates, throwing and nullable accessors, integer→real promotion, `ObjectReference` ordering/equality/hash, dictionary lookup, and `to_string`.

These collapse the common check-then-access double-lookup, e.g. `encrypt.get("CF").as_dictionary_ptr()` instead of `is_dictionary()` + `as_dictionary()`, and `.as_integer_opt().value_or(0)` instead of the `has_key(...) ? ... : default` ternary.

## Test plan
- `cmake --build cmake-build-relwithdebinfo --target odr_test`
- `./test/odr_test --gtest_filter='PdfObject.*'` — 14/14 pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)