### PR TITLE
PDF stage 3.0: Font interface + SFNT/TrueType reader

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -198,6 +198,7 @@ set(ODR_SOURCE_FILES
         "src/odr/internal/pdf/pdf_page_text.cpp"
 
         "src/odr/internal/font/sfnt_font.cpp"
+        "src/odr/internal/font/sfnt_parser.cpp"
 
         "src/odr/internal/svm/svm_file.cpp"
         "src/odr/internal/svm/svm_format.cpp"

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -197,6 +197,8 @@ set(ODR_SOURCE_FILES
         "src/odr/internal/pdf/pdf_object_parser.cpp"
         "src/odr/internal/pdf/pdf_page_text.cpp"
 
+        "src/odr/internal/font/sfnt_font.cpp"
+
         "src/odr/internal/svm/svm_file.cpp"
         "src/odr/internal/svm/svm_format.cpp"
         "src/odr/internal/svm/svm_to_svg.cpp"

--- a/src/odr/font.hpp
+++ b/src/odr/font.hpp
@@ -1,0 +1,24 @@
+#pragma once
+
+#include <cstdint>
+
+namespace odr {
+
+/// @brief Source flavor of a font program.
+enum class FontFormat {
+  unknown,
+  truetype,     ///< SFNT with `glyf` outlines (incl. CIDFontType2)
+  opentype_cff, ///< SFNT wrapping a `CFF ` table (`OTTO`)
+  cff,          ///< bare CFF / Type1C (stage 3.4)
+  type1,        ///< Type1 / `eexec` (stage 3.5)
+};
+
+/// @brief Glyph-space bounding box, in font design units.
+struct FontBBox {
+  std::int16_t x_min{};
+  std::int16_t y_min{};
+  std::int16_t x_max{};
+  std::int16_t y_max{};
+};
+
+} // namespace odr

--- a/src/odr/internal/abstract/font.hpp
+++ b/src/odr/internal/abstract/font.hpp
@@ -1,27 +1,12 @@
 #pragma once
 
+#include <odr/font.hpp>
+
 #include <cstdint>
 #include <optional>
 #include <string>
 
-namespace odr::internal::font {
-
-/// @brief Source flavor of a font program.
-enum class FontFormat {
-  unknown,
-  truetype,     ///< SFNT with `glyf` outlines (incl. CIDFontType2)
-  opentype_cff, ///< SFNT wrapping a `CFF ` table (`OTTO`)
-  cff,          ///< bare CFF / Type1C (stage 3.4)
-  type1,        ///< Type1 / `eexec` (stage 3.5)
-};
-
-/// @brief Glyph-space bounding box, in font design units.
-struct FontBBox {
-  std::int16_t x_min{};
-  std::int16_t y_min{};
-  std::int16_t x_max{};
-  std::int16_t y_max{};
-};
+namespace odr::internal::abstract {
 
 /// @brief Read-only view over a font program, exposing the *facts* every
 /// stage-3 consumer needs while the raw glyph bytes pass through untouched.
@@ -31,9 +16,9 @@ struct FontBBox {
 /// back the original bytes. The embedded-font reverse map reads Unicode from
 /// it (3.3), the OTF wrap synthesizes the SFNT skeleton from it (3.1/3.4), and
 /// the PUA re-encoder assigns code points from its glyph count.
-class FontProgram {
+class Font {
 public:
-  virtual ~FontProgram() = default;
+  virtual ~Font() = default;
 
   [[nodiscard]] virtual FontFormat format() const noexcept = 0;
 
@@ -71,4 +56,4 @@ public:
   [[nodiscard]] virtual const std::string &data() const noexcept = 0;
 };
 
-} // namespace odr::internal::font
+} // namespace odr::internal::abstract

--- a/src/odr/internal/abstract/font.hpp
+++ b/src/odr/internal/abstract/font.hpp
@@ -51,9 +51,6 @@ public:
   /// the stage-1 extraction gap (3.3); `nullopt` when no code point maps.
   [[nodiscard]] virtual std::optional<char32_t>
   code_point_for_glyph(std::uint16_t glyph) const = 0;
-
-  /// The original, unmodified font bytes (pass-through for the OTF wrap).
-  [[nodiscard]] virtual const std::string &data() const noexcept = 0;
 };
 
 } // namespace odr::internal::abstract

--- a/src/odr/internal/font/font_program.hpp
+++ b/src/odr/internal/font/font_program.hpp
@@ -1,0 +1,74 @@
+#pragma once
+
+#include <cstdint>
+#include <optional>
+#include <string>
+
+namespace odr::internal::font {
+
+/// @brief Source flavor of a font program.
+enum class FontFormat {
+  unknown,
+  truetype,     ///< SFNT with `glyf` outlines (incl. CIDFontType2)
+  opentype_cff, ///< SFNT wrapping a `CFF ` table (`OTTO`)
+  cff,          ///< bare CFF / Type1C (stage 3.4)
+  type1,        ///< Type1 / `eexec` (stage 3.5)
+};
+
+/// @brief Glyph-space bounding box, in font design units.
+struct FontBBox {
+  std::int16_t x_min{};
+  std::int16_t y_min{};
+  std::int16_t x_max{};
+  std::int16_t y_max{};
+};
+
+/// @brief Read-only view over a font program, exposing the *facts* every
+/// stage-3 consumer needs while the raw glyph bytes pass through untouched.
+///
+/// Per the stage-3 architecture ("IR for facts, pass-through for glyphs") this
+/// never decompiles outlines: it reports counts / metrics / names and hands
+/// back the original bytes. The embedded-font reverse map reads Unicode from
+/// it (3.3), the OTF wrap synthesizes the SFNT skeleton from it (3.1/3.4), and
+/// the PUA re-encoder assigns code points from its glyph count.
+class FontProgram {
+public:
+  virtual ~FontProgram() = default;
+
+  [[nodiscard]] virtual FontFormat format() const noexcept = 0;
+
+  /// PostScript name (`name` ID 6) when available, else the full font name
+  /// (ID 4); empty when the font names nothing.
+  [[nodiscard]] virtual std::string name() const = 0;
+
+  /// Number of glyphs; valid glyph ids are `[0, glyph_count())`.
+  [[nodiscard]] virtual std::uint16_t glyph_count() const noexcept = 0;
+
+  /// Font design units per em (typically 1000 or 2048).
+  [[nodiscard]] virtual std::uint16_t units_per_em() const noexcept = 0;
+
+  /// Whether the font declares a symbolic (non-standard) character set.
+  [[nodiscard]] virtual bool symbolic() const noexcept = 0;
+
+  [[nodiscard]] virtual FontBBox bounding_box() const noexcept = 0;
+
+  /// Advance width of @p glyph in design units, 0 when unknown.
+  [[nodiscard]] virtual std::uint16_t
+  advance_width(std::uint16_t glyph) const = 0;
+
+  /// The font's own forward map: Unicode code point -> glyph id, 0 (`.notdef`)
+  /// when unmapped. Seeds the specimen page and the PUA re-encode.
+  [[nodiscard]] virtual std::uint16_t
+  glyph_for_code_point(char32_t code_point) const = 0;
+
+  /// The reverse map: glyph id -> Unicode code point, when the font's character
+  /// map reaches the glyph. This is the embedded-font reverse map that closes
+  /// the stage-1 extraction gap (3.3); `nullopt` when no code point maps.
+  [[nodiscard]] virtual std::optional<char32_t>
+  code_point_for_glyph(std::uint16_t glyph) const = 0;
+
+  /// The original, unmodified font bytes (pass-through for the OTF wrap).
+  [[nodiscard]] virtual const std::string &data() const noexcept = 0;
+};
+
+} // namespace odr::internal::font

--- a/src/odr/internal/font/sfnt_font.cpp
+++ b/src/odr/internal/font/sfnt_font.cpp
@@ -109,7 +109,7 @@ void append_utf8(std::string &out, const char32_t cp) {
 
 } // namespace
 
-SfntFontProgram::SfntFontProgram(std::string data) : m_data(std::move(data)) {
+SfntFont::SfntFont(std::string data) : m_data(std::move(data)) {
   const std::string tag = tag_at(m_data, 0);
   std::uint32_t sfnt_offset = 0;
   if (tag == "ttcf") {
@@ -125,7 +125,7 @@ SfntFontProgram::SfntFontProgram(std::string data) : m_data(std::move(data)) {
   parse_name();
 }
 
-bool SfntFontProgram::is_sfnt(const std::string_view data) {
+bool SfntFont::is_sfnt(const std::string_view data) {
   if (data.size() < 4) {
     return false;
   }
@@ -134,7 +134,7 @@ bool SfntFontProgram::is_sfnt(const std::string_view data) {
          tag == "true" || tag == "ttcf" || tag == "typ1";
 }
 
-void SfntFontProgram::parse_directory(std::uint32_t sfnt_offset) {
+void SfntFont::parse_directory(std::uint32_t sfnt_offset) {
   const std::string version = tag_at(m_data, sfnt_offset);
   m_format =
       version == "OTTO" ? FontFormat::opentype_cff : FontFormat::truetype;
@@ -147,7 +147,7 @@ void SfntFontProgram::parse_directory(std::uint32_t sfnt_offset) {
   }
 }
 
-void SfntFontProgram::parse_head() {
+void SfntFont::parse_head() {
   const auto head = table("head");
   if (!head) {
     return; // tolerate; keep the unitsPerEm default
@@ -157,7 +157,7 @@ void SfntFontProgram::parse_head() {
             s16(m_data, head->offset + 40), s16(m_data, head->offset + 42)};
 }
 
-void SfntFontProgram::parse_maxp() {
+void SfntFont::parse_maxp() {
   const auto maxp = table("maxp");
   if (!maxp) {
     return;
@@ -165,7 +165,7 @@ void SfntFontProgram::parse_maxp() {
   m_glyph_count = u16(m_data, maxp->offset + 4);
 }
 
-void SfntFontProgram::parse_hhea() {
+void SfntFont::parse_hhea() {
   const auto hhea = table("hhea");
   if (!hhea) {
     return;
@@ -173,7 +173,7 @@ void SfntFontProgram::parse_hhea() {
   m_number_of_h_metrics = u16(m_data, hhea->offset + 34);
 }
 
-void SfntFontProgram::parse_hmtx() {
+void SfntFont::parse_hmtx() {
   const auto hmtx = table("hmtx");
   if (!hmtx) {
     return;
@@ -184,7 +184,7 @@ void SfntFontProgram::parse_hmtx() {
   }
 }
 
-void SfntFontProgram::parse_cmap() {
+void SfntFont::parse_cmap() {
   const auto cmap = table("cmap");
   if (!cmap) {
     return;
@@ -209,7 +209,7 @@ void SfntFontProgram::parse_cmap() {
   }
 }
 
-void SfntFontProgram::parse_cmap_subtable(const std::uint32_t offset) {
+void SfntFont::parse_cmap_subtable(const std::uint32_t offset) {
   const auto map = [this](const char32_t code, const std::uint16_t glyph) {
     if (glyph == 0) {
       return;
@@ -284,7 +284,7 @@ void SfntFontProgram::parse_cmap_subtable(const std::uint32_t offset) {
   }
 }
 
-void SfntFontProgram::parse_name() {
+void SfntFont::parse_name() {
   const auto name = table("name");
   if (!name) {
     return;
@@ -317,23 +317,19 @@ void SfntFontProgram::parse_name() {
   }
 }
 
-FontFormat SfntFontProgram::format() const noexcept { return m_format; }
+FontFormat SfntFont::format() const noexcept { return m_format; }
 
-std::string SfntFontProgram::name() const { return m_name; }
+std::string SfntFont::name() const { return m_name; }
 
-std::uint16_t SfntFontProgram::glyph_count() const noexcept {
-  return m_glyph_count;
-}
+std::uint16_t SfntFont::glyph_count() const noexcept { return m_glyph_count; }
 
-std::uint16_t SfntFontProgram::units_per_em() const noexcept {
-  return m_units_per_em;
-}
+std::uint16_t SfntFont::units_per_em() const noexcept { return m_units_per_em; }
 
-bool SfntFontProgram::symbolic() const noexcept { return m_symbolic; }
+bool SfntFont::symbolic() const noexcept { return m_symbolic; }
 
-FontBBox SfntFontProgram::bounding_box() const noexcept { return m_bbox; }
+FontBBox SfntFont::bounding_box() const noexcept { return m_bbox; }
 
-std::uint16_t SfntFontProgram::advance_width(const std::uint16_t glyph) const {
+std::uint16_t SfntFont::advance_width(const std::uint16_t glyph) const {
   if (m_advance_widths.empty()) {
     return 0;
   }
@@ -344,14 +340,13 @@ std::uint16_t SfntFontProgram::advance_width(const std::uint16_t glyph) const {
   return m_advance_widths[glyph];
 }
 
-std::uint16_t
-SfntFontProgram::glyph_for_code_point(const char32_t code_point) const {
+std::uint16_t SfntFont::glyph_for_code_point(const char32_t code_point) const {
   const auto it = m_cmap.find(code_point);
   return it == m_cmap.end() ? 0 : it->second;
 }
 
 std::optional<char32_t>
-SfntFontProgram::code_point_for_glyph(const std::uint16_t glyph) const {
+SfntFont::code_point_for_glyph(const std::uint16_t glyph) const {
   const auto it = m_reverse.find(glyph);
   if (it == m_reverse.end()) {
     return std::nullopt;
@@ -359,10 +354,10 @@ SfntFontProgram::code_point_for_glyph(const std::uint16_t glyph) const {
   return it->second;
 }
 
-const std::string &SfntFontProgram::data() const noexcept { return m_data; }
+const std::string &SfntFont::data() const noexcept { return m_data; }
 
-std::optional<SfntFontProgram::Table>
-SfntFontProgram::table(const std::string_view tag) const {
+std::optional<SfntFont::Table>
+SfntFont::table(const std::string_view tag) const {
   const auto it = m_tables.find(tag);
   if (it == m_tables.end()) {
     return std::nullopt;

--- a/src/odr/internal/font/sfnt_font.cpp
+++ b/src/odr/internal/font/sfnt_font.cpp
@@ -1,5 +1,6 @@
 #include <odr/internal/font/sfnt_font.hpp>
 
+#include <algorithm>
 #include <istream>
 #include <memory>
 #include <utility>

--- a/src/odr/internal/font/sfnt_font.cpp
+++ b/src/odr/internal/font/sfnt_font.cpp
@@ -8,33 +8,34 @@ namespace {
 
 // All SFNT integers are big-endian; these read with bounds checks so a
 // truncated/garbage font throws rather than reads out of bounds.
-[[nodiscard]] std::uint8_t u8(const std::string &d, std::size_t o) {
+
+[[nodiscard]] std::uint8_t u8(const std::string &d, const std::size_t o) {
   if (o + 1 > d.size()) {
     throw std::runtime_error("sfnt: read past end");
   }
   return static_cast<std::uint8_t>(d[o]);
 }
 
-[[nodiscard]] std::uint16_t u16(const std::string &d, std::size_t o) {
+[[nodiscard]] std::uint16_t u16(const std::string &d, const std::size_t o) {
   return static_cast<std::uint16_t>(u8(d, o) << 8 | u8(d, o + 1));
 }
 
-[[nodiscard]] std::int16_t s16(const std::string &d, std::size_t o) {
+[[nodiscard]] std::int16_t s16(const std::string &d, const std::size_t o) {
   return static_cast<std::int16_t>(u16(d, o));
 }
 
-[[nodiscard]] std::uint32_t u32(const std::string &d, std::size_t o) {
+[[nodiscard]] std::uint32_t u32(const std::string &d, const std::size_t o) {
   return static_cast<std::uint32_t>(u16(d, o)) << 16 | u16(d, o + 2);
 }
 
-[[nodiscard]] std::string tag_at(const std::string &d, std::size_t o) {
+[[nodiscard]] std::string tag_at(const std::string &d, const std::size_t o) {
   if (o + 4 > d.size()) {
     throw std::runtime_error("sfnt: read past end");
   }
   return d.substr(o, 4);
 }
 
-void append_utf8(std::string &out, char32_t cp) {
+void append_utf8(std::string &out, const char32_t cp) {
   if (cp < 0x80) {
     out += static_cast<char>(cp);
   } else if (cp < 0x800) {
@@ -54,8 +55,9 @@ void append_utf8(std::string &out, char32_t cp) {
 
 // Decode a UTF-16BE `name` string (Windows/Unicode platforms), surrogate pairs
 // included, into UTF-8.
-[[nodiscard]] std::string decode_utf16be(const std::string &d, std::size_t o,
-                                         std::size_t len) {
+[[nodiscard]] std::string decode_utf16be(const std::string &d,
+                                         const std::size_t o,
+                                         const std::size_t len) {
   std::string out;
   for (std::size_t i = 0; i + 1 < len; i += 2) {
     char32_t cp = u16(d, o + i);
@@ -72,8 +74,9 @@ void append_utf8(std::string &out, char32_t cp) {
 }
 
 // Decode a single-byte (Mac/Latin-1) `name` string into UTF-8.
-[[nodiscard]] std::string decode_latin1(const std::string &d, std::size_t o,
-                                        std::size_t len) {
+[[nodiscard]] std::string decode_latin1(const std::string &d,
+                                        const std::size_t o,
+                                        const std::size_t len) {
   std::string out;
   for (std::size_t i = 0; i < len; ++i) {
     append_utf8(out, u8(d, o + i));
@@ -122,7 +125,7 @@ SfntFontProgram::SfntFontProgram(std::string data) : m_data(std::move(data)) {
   parse_name();
 }
 
-bool SfntFontProgram::is_sfnt(std::string_view data) noexcept {
+bool SfntFontProgram::is_sfnt(const std::string_view data) {
   if (data.size() < 4) {
     return false;
   }
@@ -206,8 +209,8 @@ void SfntFontProgram::parse_cmap() {
   }
 }
 
-void SfntFontProgram::parse_cmap_subtable(std::uint32_t offset) {
-  const auto map = [this](char32_t code, std::uint16_t glyph) {
+void SfntFontProgram::parse_cmap_subtable(const std::uint32_t offset) {
+  const auto map = [this](const char32_t code, const std::uint16_t glyph) {
     if (glyph == 0) {
       return;
     }
@@ -218,7 +221,8 @@ void SfntFontProgram::parse_cmap_subtable(std::uint32_t offset) {
     }
   };
 
-  switch (const std::uint16_t format = u16(m_data, offset)) {
+  const std::uint16_t format = u16(m_data, offset);
+  switch (format) {
   case 0: { // byte encoding table
     for (std::uint32_t code = 0; code < 256; ++code) {
       map(code, u8(m_data, offset + 6 + code));
@@ -329,7 +333,7 @@ bool SfntFontProgram::symbolic() const noexcept { return m_symbolic; }
 
 FontBBox SfntFontProgram::bounding_box() const noexcept { return m_bbox; }
 
-std::uint16_t SfntFontProgram::advance_width(std::uint16_t glyph) const {
+std::uint16_t SfntFontProgram::advance_width(const std::uint16_t glyph) const {
   if (m_advance_widths.empty()) {
     return 0;
   }
@@ -340,13 +344,14 @@ std::uint16_t SfntFontProgram::advance_width(std::uint16_t glyph) const {
   return m_advance_widths[glyph];
 }
 
-std::uint16_t SfntFontProgram::glyph_for_code_point(char32_t code_point) const {
+std::uint16_t
+SfntFontProgram::glyph_for_code_point(const char32_t code_point) const {
   const auto it = m_cmap.find(code_point);
   return it == m_cmap.end() ? 0 : it->second;
 }
 
 std::optional<char32_t>
-SfntFontProgram::code_point_for_glyph(std::uint16_t glyph) const {
+SfntFontProgram::code_point_for_glyph(const std::uint16_t glyph) const {
   const auto it = m_reverse.find(glyph);
   if (it == m_reverse.end()) {
     return std::nullopt;
@@ -357,7 +362,7 @@ SfntFontProgram::code_point_for_glyph(std::uint16_t glyph) const {
 const std::string &SfntFontProgram::data() const noexcept { return m_data; }
 
 std::optional<SfntFontProgram::Table>
-SfntFontProgram::table(std::string_view tag) const {
+SfntFontProgram::table(const std::string_view tag) const {
   const auto it = m_tables.find(tag);
   if (it == m_tables.end()) {
     return std::nullopt;

--- a/src/odr/internal/font/sfnt_font.cpp
+++ b/src/odr/internal/font/sfnt_font.cpp
@@ -1,0 +1,368 @@
+#include <odr/internal/font/sfnt_font.hpp>
+
+#include <stdexcept>
+
+namespace odr::internal::font {
+
+namespace {
+
+// All SFNT integers are big-endian; these read with bounds checks so a
+// truncated/garbage font throws rather than reads out of bounds.
+[[nodiscard]] std::uint8_t u8(const std::string &d, std::size_t o) {
+  if (o + 1 > d.size()) {
+    throw std::runtime_error("sfnt: read past end");
+  }
+  return static_cast<std::uint8_t>(d[o]);
+}
+
+[[nodiscard]] std::uint16_t u16(const std::string &d, std::size_t o) {
+  return static_cast<std::uint16_t>(u8(d, o) << 8 | u8(d, o + 1));
+}
+
+[[nodiscard]] std::int16_t s16(const std::string &d, std::size_t o) {
+  return static_cast<std::int16_t>(u16(d, o));
+}
+
+[[nodiscard]] std::uint32_t u32(const std::string &d, std::size_t o) {
+  return static_cast<std::uint32_t>(u16(d, o)) << 16 | u16(d, o + 2);
+}
+
+[[nodiscard]] std::string tag_at(const std::string &d, std::size_t o) {
+  if (o + 4 > d.size()) {
+    throw std::runtime_error("sfnt: read past end");
+  }
+  return d.substr(o, 4);
+}
+
+void append_utf8(std::string &out, char32_t cp) {
+  if (cp < 0x80) {
+    out += static_cast<char>(cp);
+  } else if (cp < 0x800) {
+    out += static_cast<char>(0xc0 | (cp >> 6));
+    out += static_cast<char>(0x80 | (cp & 0x3f));
+  } else if (cp < 0x10000) {
+    out += static_cast<char>(0xe0 | (cp >> 12));
+    out += static_cast<char>(0x80 | ((cp >> 6) & 0x3f));
+    out += static_cast<char>(0x80 | (cp & 0x3f));
+  } else {
+    out += static_cast<char>(0xf0 | (cp >> 18));
+    out += static_cast<char>(0x80 | ((cp >> 12) & 0x3f));
+    out += static_cast<char>(0x80 | ((cp >> 6) & 0x3f));
+    out += static_cast<char>(0x80 | (cp & 0x3f));
+  }
+}
+
+// Decode a UTF-16BE `name` string (Windows/Unicode platforms), surrogate pairs
+// included, into UTF-8.
+[[nodiscard]] std::string decode_utf16be(const std::string &d, std::size_t o,
+                                         std::size_t len) {
+  std::string out;
+  for (std::size_t i = 0; i + 1 < len; i += 2) {
+    char32_t cp = u16(d, o + i);
+    if (cp >= 0xd800 && cp <= 0xdbff && i + 3 < len) {
+      const char32_t lo = u16(d, o + i + 2);
+      if (lo >= 0xdc00 && lo <= 0xdfff) {
+        cp = 0x10000 + ((cp - 0xd800) << 10) + (lo - 0xdc00);
+        i += 2;
+      }
+    }
+    append_utf8(out, cp);
+  }
+  return out;
+}
+
+// Decode a single-byte (Mac/Latin-1) `name` string into UTF-8.
+[[nodiscard]] std::string decode_latin1(const std::string &d, std::size_t o,
+                                        std::size_t len) {
+  std::string out;
+  for (std::size_t i = 0; i < len; ++i) {
+    append_utf8(out, u8(d, o + i));
+  }
+  return out;
+}
+
+// Preference among `cmap` subtables: Unicode full > Unicode BMP > symbol > Mac.
+[[nodiscard]] int cmap_score(std::uint16_t platform, std::uint16_t encoding) {
+  if (platform == 3 && encoding == 10) {
+    return 5;
+  }
+  if (platform == 0 && (encoding == 4 || encoding == 6)) {
+    return 5;
+  }
+  if (platform == 3 && encoding == 1) {
+    return 4;
+  }
+  if (platform == 0) {
+    return 3;
+  }
+  if (platform == 3 && encoding == 0) {
+    return 2; // symbol
+  }
+  if (platform == 1 && encoding == 0) {
+    return 1; // Mac Roman (treated as Latin-1 — correct for ASCII)
+  }
+  return 0;
+}
+
+} // namespace
+
+SfntFontProgram::SfntFontProgram(std::string data) : m_data(std::move(data)) {
+  const std::string tag = tag_at(m_data, 0);
+  std::uint32_t sfnt_offset = 0;
+  if (tag == "ttcf") {
+    // TrueType Collection: read the first member's offset table.
+    sfnt_offset = u32(m_data, 12);
+  }
+  parse_directory(sfnt_offset);
+  parse_head();
+  parse_maxp();
+  parse_hhea();
+  parse_hmtx();
+  parse_cmap();
+  parse_name();
+}
+
+bool SfntFontProgram::is_sfnt(std::string_view data) noexcept {
+  if (data.size() < 4) {
+    return false;
+  }
+  const std::string_view tag = data.substr(0, 4);
+  return tag == std::string_view("\x00\x01\x00\x00", 4) || tag == "OTTO" ||
+         tag == "true" || tag == "ttcf" || tag == "typ1";
+}
+
+void SfntFontProgram::parse_directory(std::uint32_t sfnt_offset) {
+  const std::string version = tag_at(m_data, sfnt_offset);
+  m_format =
+      version == "OTTO" ? FontFormat::opentype_cff : FontFormat::truetype;
+
+  const std::uint16_t num_tables = u16(m_data, sfnt_offset + 4);
+  std::size_t record = sfnt_offset + 12;
+  for (std::uint16_t i = 0; i < num_tables; ++i, record += 16) {
+    m_tables.emplace(tag_at(m_data, record),
+                     Table{u32(m_data, record + 8), u32(m_data, record + 12)});
+  }
+}
+
+void SfntFontProgram::parse_head() {
+  const auto head = table("head");
+  if (!head) {
+    return; // tolerate; keep the unitsPerEm default
+  }
+  m_units_per_em = u16(m_data, head->offset + 18);
+  m_bbox = {s16(m_data, head->offset + 36), s16(m_data, head->offset + 38),
+            s16(m_data, head->offset + 40), s16(m_data, head->offset + 42)};
+}
+
+void SfntFontProgram::parse_maxp() {
+  const auto maxp = table("maxp");
+  if (!maxp) {
+    return;
+  }
+  m_glyph_count = u16(m_data, maxp->offset + 4);
+}
+
+void SfntFontProgram::parse_hhea() {
+  const auto hhea = table("hhea");
+  if (!hhea) {
+    return;
+  }
+  m_number_of_h_metrics = u16(m_data, hhea->offset + 34);
+}
+
+void SfntFontProgram::parse_hmtx() {
+  const auto hmtx = table("hmtx");
+  if (!hmtx) {
+    return;
+  }
+  m_advance_widths.reserve(m_number_of_h_metrics);
+  for (std::uint16_t i = 0; i < m_number_of_h_metrics; ++i) {
+    m_advance_widths.push_back(u16(m_data, hmtx->offset + i * 4U));
+  }
+}
+
+void SfntFontProgram::parse_cmap() {
+  const auto cmap = table("cmap");
+  if (!cmap) {
+    return;
+  }
+  const std::uint16_t count = u16(m_data, cmap->offset + 2);
+  int best_score = 0;
+  std::uint32_t best_offset = 0;
+  for (std::uint16_t i = 0; i < count; ++i) {
+    const std::size_t record = cmap->offset + 4 + i * 8U;
+    const std::uint16_t platform = u16(m_data, record);
+    const std::uint16_t encoding = u16(m_data, record + 2);
+    if (platform == 3 && encoding == 0) {
+      m_symbolic = true;
+    }
+    if (const int score = cmap_score(platform, encoding); score > best_score) {
+      best_score = score;
+      best_offset = cmap->offset + u32(m_data, record + 4);
+    }
+  }
+  if (best_score > 0) {
+    parse_cmap_subtable(best_offset);
+  }
+}
+
+void SfntFontProgram::parse_cmap_subtable(std::uint32_t offset) {
+  const auto map = [this](char32_t code, std::uint16_t glyph) {
+    if (glyph == 0) {
+      return;
+    }
+    m_cmap[code] = glyph;
+    if (const auto it = m_reverse.find(glyph);
+        it == m_reverse.end() || code < it->second) {
+      m_reverse[glyph] = code;
+    }
+  };
+
+  switch (const std::uint16_t format = u16(m_data, offset)) {
+  case 0: { // byte encoding table
+    for (std::uint32_t code = 0; code < 256; ++code) {
+      map(code, u8(m_data, offset + 6 + code));
+    }
+    break;
+  }
+  case 4: { // segment mapping to delta values
+    const std::size_t segs = u16(m_data, offset + 6) / 2U;
+    const std::size_t end_codes = offset + 14;
+    const std::size_t start_codes = end_codes + segs * 2 + 2;
+    const std::size_t id_deltas = start_codes + segs * 2;
+    const std::size_t id_range_offsets = id_deltas + segs * 2;
+    for (std::size_t s = 0; s < segs; ++s) {
+      const std::uint16_t end = u16(m_data, end_codes + s * 2);
+      const std::uint16_t start = u16(m_data, start_codes + s * 2);
+      const std::int16_t delta = s16(m_data, id_deltas + s * 2);
+      const std::uint16_t range = u16(m_data, id_range_offsets + s * 2);
+      for (std::uint32_t code = start; code <= end && code != 0xffff; ++code) {
+        std::uint16_t glyph = 0;
+        if (range == 0) {
+          glyph = static_cast<std::uint16_t>(code + delta);
+        } else {
+          // idRangeOffset indexes into the glyphIdArray that follows.
+          const std::size_t at = id_range_offsets + s * 2 + range +
+                                 static_cast<std::size_t>(code - start) * 2;
+          glyph = u16(m_data, at);
+          if (glyph != 0) {
+            glyph = static_cast<std::uint16_t>(glyph + delta);
+          }
+        }
+        map(code, glyph);
+      }
+    }
+    break;
+  }
+  case 6: { // trimmed table mapping
+    const std::uint16_t first = u16(m_data, offset + 6);
+    const std::uint16_t entries = u16(m_data, offset + 8);
+    for (std::uint16_t i = 0; i < entries; ++i) {
+      map(first + i, u16(m_data, offset + 10 + i * 2U));
+    }
+    break;
+  }
+  case 12: { // segmented coverage
+    const std::uint32_t groups = u32(m_data, offset + 12);
+    for (std::uint32_t g = 0; g < groups; ++g) {
+      const std::size_t at = offset + 16 + g * 12U;
+      const std::uint32_t start = u32(m_data, at);
+      const std::uint32_t end = u32(m_data, at + 4);
+      const std::uint32_t start_glyph = u32(m_data, at + 8);
+      for (std::uint32_t code = start; code <= end; ++code) {
+        map(code, static_cast<std::uint16_t>(start_glyph + (code - start)));
+      }
+    }
+    break;
+  }
+  default:
+    break; // unsupported subtable format: leave the map empty
+  }
+}
+
+void SfntFontProgram::parse_name() {
+  const auto name = table("name");
+  if (!name) {
+    return;
+  }
+  const std::uint16_t count = u16(m_data, name->offset + 2);
+  const std::uint16_t string_offset = u16(m_data, name->offset + 4);
+  const std::size_t strings = name->offset + string_offset;
+
+  int best_score = 0;
+  for (std::uint16_t i = 0; i < count; ++i) {
+    const std::size_t record = name->offset + 6 + i * 12U;
+    const std::uint16_t platform = u16(m_data, record);
+    const std::uint16_t name_id = u16(m_data, record + 6);
+    if (name_id != 6 && name_id != 4) {
+      continue;
+    }
+    // Prefer the PostScript name (6) over the full name (4), and a decodable
+    // platform; higher score wins.
+    const int score =
+        (name_id == 6 ? 10 : 0) + (platform == 3 || platform == 0 ? 2 : 1);
+    if (score <= best_score) {
+      continue;
+    }
+    const std::uint16_t length = u16(m_data, record + 8);
+    const std::uint16_t local_offset = u16(m_data, record + 10);
+    m_name = (platform == 3 || platform == 0)
+                 ? decode_utf16be(m_data, strings + local_offset, length)
+                 : decode_latin1(m_data, strings + local_offset, length);
+    best_score = score;
+  }
+}
+
+FontFormat SfntFontProgram::format() const noexcept { return m_format; }
+
+std::string SfntFontProgram::name() const { return m_name; }
+
+std::uint16_t SfntFontProgram::glyph_count() const noexcept {
+  return m_glyph_count;
+}
+
+std::uint16_t SfntFontProgram::units_per_em() const noexcept {
+  return m_units_per_em;
+}
+
+bool SfntFontProgram::symbolic() const noexcept { return m_symbolic; }
+
+FontBBox SfntFontProgram::bounding_box() const noexcept { return m_bbox; }
+
+std::uint16_t SfntFontProgram::advance_width(std::uint16_t glyph) const {
+  if (m_advance_widths.empty()) {
+    return 0;
+  }
+  // Glyphs beyond `numberOfHMetrics` share the last advance (monospace tail).
+  if (glyph >= m_advance_widths.size()) {
+    return m_advance_widths.back();
+  }
+  return m_advance_widths[glyph];
+}
+
+std::uint16_t SfntFontProgram::glyph_for_code_point(char32_t code_point) const {
+  const auto it = m_cmap.find(code_point);
+  return it == m_cmap.end() ? 0 : it->second;
+}
+
+std::optional<char32_t>
+SfntFontProgram::code_point_for_glyph(std::uint16_t glyph) const {
+  const auto it = m_reverse.find(glyph);
+  if (it == m_reverse.end()) {
+    return std::nullopt;
+  }
+  return it->second;
+}
+
+const std::string &SfntFontProgram::data() const noexcept { return m_data; }
+
+std::optional<SfntFontProgram::Table>
+SfntFontProgram::table(std::string_view tag) const {
+  const auto it = m_tables.find(tag);
+  if (it == m_tables.end()) {
+    return std::nullopt;
+  }
+  return it->second;
+}
+
+} // namespace odr::internal::font

--- a/src/odr/internal/font/sfnt_font.cpp
+++ b/src/odr/internal/font/sfnt_font.cpp
@@ -1,129 +1,46 @@
 #include <odr/internal/font/sfnt_font.hpp>
 
-#include <stdexcept>
+#include <istream>
+#include <memory>
+#include <utility>
 
-namespace odr::internal::font {
+namespace odr::internal::font::sfnt {
 
 namespace {
 
-// All SFNT integers are big-endian; these read with bounds checks so a
-// truncated/garbage font throws rather than reads out of bounds.
-
-[[nodiscard]] std::uint8_t u8(const std::string &d, const std::size_t o) {
-  if (o + 1 > d.size()) {
-    throw std::runtime_error("sfnt: read past end");
-  }
-  return static_cast<std::uint8_t>(d[o]);
-}
-
-[[nodiscard]] std::uint16_t u16(const std::string &d, const std::size_t o) {
-  return static_cast<std::uint16_t>(u8(d, o) << 8 | u8(d, o + 1));
-}
-
-[[nodiscard]] std::int16_t s16(const std::string &d, const std::size_t o) {
-  return static_cast<std::int16_t>(u16(d, o));
-}
-
-[[nodiscard]] std::uint32_t u32(const std::string &d, const std::size_t o) {
-  return static_cast<std::uint32_t>(u16(d, o)) << 16 | u16(d, o + 2);
-}
-
-[[nodiscard]] std::string tag_at(const std::string &d, const std::size_t o) {
-  if (o + 4 > d.size()) {
-    throw std::runtime_error("sfnt: read past end");
-  }
-  return d.substr(o, 4);
-}
-
-void append_utf8(std::string &out, const char32_t cp) {
-  if (cp < 0x80) {
-    out += static_cast<char>(cp);
-  } else if (cp < 0x800) {
-    out += static_cast<char>(0xc0 | (cp >> 6));
-    out += static_cast<char>(0x80 | (cp & 0x3f));
-  } else if (cp < 0x10000) {
-    out += static_cast<char>(0xe0 | (cp >> 12));
-    out += static_cast<char>(0x80 | ((cp >> 6) & 0x3f));
-    out += static_cast<char>(0x80 | (cp & 0x3f));
-  } else {
-    out += static_cast<char>(0xf0 | (cp >> 18));
-    out += static_cast<char>(0x80 | ((cp >> 12) & 0x3f));
-    out += static_cast<char>(0x80 | ((cp >> 6) & 0x3f));
-    out += static_cast<char>(0x80 | (cp & 0x3f));
-  }
-}
-
-// Decode a UTF-16BE `name` string (Windows/Unicode platforms), surrogate pairs
-// included, into UTF-8.
-[[nodiscard]] std::string decode_utf16be(const std::string &d,
-                                         const std::size_t o,
-                                         const std::size_t len) {
-  std::string out;
-  for (std::size_t i = 0; i + 1 < len; i += 2) {
-    char32_t cp = u16(d, o + i);
-    if (cp >= 0xd800 && cp <= 0xdbff && i + 3 < len) {
-      const char32_t lo = u16(d, o + i + 2);
-      if (lo >= 0xdc00 && lo <= 0xdfff) {
-        cp = 0x10000 + ((cp - 0xd800) << 10) + (lo - 0xdc00);
-        i += 2;
-      }
+/// Preference among `cmap` subtables: Unicode full > Unicode BMP > symbol >
+/// Mac.
+[[nodiscard]] int cmap_score(const PlatformId platform,
+                             const std::uint16_t encoding) {
+  switch (platform) {
+  case PlatformId::windows:
+    switch (static_cast<WindowsEncoding>(encoding)) {
+    case WindowsEncoding::unicode_full:
+      return 5;
+    case WindowsEncoding::unicode_bmp:
+      return 4;
+    case WindowsEncoding::symbol:
+      return 2;
     }
-    append_utf8(out, cp);
-  }
-  return out;
-}
-
-// Decode a single-byte (Mac/Latin-1) `name` string into UTF-8.
-[[nodiscard]] std::string decode_latin1(const std::string &d,
-                                        const std::size_t o,
-                                        const std::size_t len) {
-  std::string out;
-  for (std::size_t i = 0; i < len; ++i) {
-    append_utf8(out, u8(d, o + i));
-  }
-  return out;
-}
-
-// Preference among `cmap` subtables: Unicode full > Unicode BMP > symbol > Mac.
-[[nodiscard]] int cmap_score(std::uint16_t platform, std::uint16_t encoding) {
-  if (platform == 3 && encoding == 10) {
-    return 5;
-  }
-  if (platform == 0 && (encoding == 4 || encoding == 6)) {
-    return 5;
-  }
-  if (platform == 3 && encoding == 1) {
-    return 4;
-  }
-  if (platform == 0) {
+    return 0;
+  case PlatformId::unicode:
+    if (static_cast<UnicodeEncoding>(encoding) ==
+            UnicodeEncoding::unicode_2_0_full ||
+        static_cast<UnicodeEncoding>(encoding) ==
+            UnicodeEncoding::unicode_full) {
+      return 5;
+    }
     return 3;
-  }
-  if (platform == 3 && encoding == 0) {
-    return 2; // symbol
-  }
-  if (platform == 1 && encoding == 0) {
-    return 1; // Mac Roman (treated as Latin-1 — correct for ASCII)
+  case PlatformId::macintosh:
+    // Mac Roman is treated as Latin-1 — correct for ASCII.
+    return static_cast<MacintoshEncoding>(encoding) == MacintoshEncoding::roman
+               ? 1
+               : 0;
   }
   return 0;
 }
 
 } // namespace
-
-SfntFont::SfntFont(std::string data) : m_data(std::move(data)) {
-  const std::string tag = tag_at(m_data, 0);
-  std::uint32_t sfnt_offset = 0;
-  if (tag == "ttcf") {
-    // TrueType Collection: read the first member's offset table.
-    sfnt_offset = u32(m_data, 12);
-  }
-  parse_directory(sfnt_offset);
-  parse_head();
-  parse_maxp();
-  parse_hhea();
-  parse_hmtx();
-  parse_cmap();
-  parse_name();
-}
 
 bool SfntFont::is_sfnt(const std::string_view data) {
   if (data.size() < 4) {
@@ -134,82 +51,122 @@ bool SfntFont::is_sfnt(const std::string_view data) {
          tag == "true" || tag == "ttcf" || tag == "typ1";
 }
 
-void SfntFont::parse_directory(std::uint32_t sfnt_offset) {
-  const std::string version = tag_at(m_data, sfnt_offset);
+SfntFont::SfntFont(std::unique_ptr<std::istream> stream)
+    : m_in{std::move(stream)}, m_parser{*m_in} {
+  if (m_in == nullptr) {
+    throw std::invalid_argument("sfnt: null input stream");
+  }
+
+  m_parser.seek(0);
+  const std::string tag = m_parser.read_tag();
+  std::uint32_t sfnt_offset = 0;
+  if (tag == "ttcf") {
+    // TrueType Collection: read the first member's offset table.
+    m_parser.seek(12);
+    sfnt_offset = m_parser.read_u32();
+  }
+  m_parser.seek(sfnt_offset);
+  read_directory();
+  read_head();
+  read_maxp();
+  read_hhea();
+  read_hmtx();
+  read_cmap();
+  read_name();
+}
+
+void SfntFont::read_directory() {
+  const std::string version = m_parser.read_tag();
   m_format =
       version == "OTTO" ? FontFormat::opentype_cff : FontFormat::truetype;
+  const std::uint16_t num_tables = m_parser.read_u16();
 
-  const std::uint16_t num_tables = u16(m_data, sfnt_offset + 4);
-  std::size_t record = sfnt_offset + 12;
-  for (std::uint16_t i = 0; i < num_tables; ++i, record += 16) {
-    m_tables.emplace(tag_at(m_data, record),
-                     Table{u32(m_data, record + 8), u32(m_data, record + 12)});
+  m_parser.ignore(6); // searchRange, entrySelector, rangeShift
+
+  for (std::uint16_t i = 0; i < num_tables; ++i) {
+    std::string tag = m_parser.read_tag();
+    m_parser.ignore(4); // checkSum
+    const std::uint32_t offset = m_parser.read_u32();
+    const std::uint32_t length = m_parser.read_u32();
+    m_tables.emplace(std::move(tag), Table{offset, length});
   }
 }
 
-void SfntFont::parse_head() {
+void SfntFont::read_head() {
   const auto head = table("head");
-  if (!head) {
+  if (!head.has_value()) {
     return; // tolerate; keep the unitsPerEm default
   }
-  m_units_per_em = u16(m_data, head->offset + 18);
-  m_bbox = {s16(m_data, head->offset + 36), s16(m_data, head->offset + 38),
-            s16(m_data, head->offset + 40), s16(m_data, head->offset + 42)};
+  m_parser.seek(head->offset + 18);
+  m_units_per_em = m_parser.read_u16();
+  m_parser.seek(head->offset + 36);
+  m_bbox = m_parser.read_bbox();
 }
 
-void SfntFont::parse_maxp() {
+void SfntFont::read_maxp() {
   const auto maxp = table("maxp");
-  if (!maxp) {
+  if (!maxp.has_value()) {
     return;
   }
-  m_glyph_count = u16(m_data, maxp->offset + 4);
+  m_parser.seek(maxp->offset + 4);
+  m_glyph_count = m_parser.read_u16();
 }
 
-void SfntFont::parse_hhea() {
+void SfntFont::read_hhea() {
   const auto hhea = table("hhea");
-  if (!hhea) {
+  if (!hhea.has_value()) {
     return;
   }
-  m_number_of_h_metrics = u16(m_data, hhea->offset + 34);
+  m_parser.seek(hhea->offset + 34);
+  m_number_of_h_metrics = m_parser.read_u16();
 }
 
-void SfntFont::parse_hmtx() {
+void SfntFont::read_hmtx() {
   const auto hmtx = table("hmtx");
-  if (!hmtx) {
+  if (!hmtx.has_value()) {
     return;
   }
+  m_parser.seek(hmtx->offset);
   m_advance_widths.reserve(m_number_of_h_metrics);
   for (std::uint16_t i = 0; i < m_number_of_h_metrics; ++i) {
-    m_advance_widths.push_back(u16(m_data, hmtx->offset + i * 4U));
+    m_advance_widths.push_back(m_parser.read_u16());
+    m_parser.ignore(2); // leftSideBearing
   }
 }
 
-void SfntFont::parse_cmap() {
+void SfntFont::read_cmap() {
   const auto cmap = table("cmap");
-  if (!cmap) {
+  if (!cmap.has_value()) {
     return;
   }
-  const std::uint16_t count = u16(m_data, cmap->offset + 2);
-  int best_score = 0;
-  std::uint32_t best_offset = 0;
+  m_parser.seek(cmap->offset + 2);
+  const std::uint16_t count = m_parser.read_u16();
+
+  std::vector<CmapEntry> entries;
+  entries.reserve(count);
   for (std::uint16_t i = 0; i < count; ++i) {
-    const std::size_t record = cmap->offset + 4 + i * 8U;
-    const std::uint16_t platform = u16(m_data, record);
-    const std::uint16_t encoding = u16(m_data, record + 2);
-    if (platform == 3 && encoding == 0) {
-      m_symbolic = true;
-    }
-    if (const int score = cmap_score(platform, encoding); score > best_score) {
-      best_score = score;
-      best_offset = cmap->offset + u32(m_data, record + 4);
-    }
+    entries.emplace_back(m_parser.read_cmap_entry());
   }
-  if (best_score > 0) {
-    parse_cmap_subtable(best_offset);
+
+  m_symbolic = std::ranges::any_of(entries, [](const CmapEntry &entry) {
+    return entry.platform == PlatformId::windows &&
+           static_cast<WindowsEncoding>(entry.encoding) ==
+               WindowsEncoding::symbol;
+  });
+
+  const auto best_entry =
+      std::ranges::max_element(entries, {}, [](const CmapEntry &entry) {
+        return cmap_score(entry.platform, entry.encoding);
+      });
+
+  if (best_entry != entries.end() &&
+      cmap_score(best_entry->platform, best_entry->encoding) > 0) {
+    m_parser.seek(cmap->offset + best_entry->offset);
+    read_cmap_subtable();
   }
 }
 
-void SfntFont::parse_cmap_subtable(const std::uint32_t offset) {
+void SfntFont::read_cmap_subtable() {
   const auto map = [this](const char32_t code, const std::uint16_t glyph) {
     if (glyph == 0) {
       return;
@@ -220,35 +177,58 @@ void SfntFont::parse_cmap_subtable(const std::uint32_t offset) {
       m_reverse[glyph] = code;
     }
   };
+  const auto read_u16_vector = [this](const std::size_t count) {
+    std::vector<std::uint16_t> out;
+    out.reserve(count);
+    for (std::size_t i = 0; i < count; ++i) {
+      out.push_back(m_parser.read_u16());
+    }
+    return out;
+  };
 
-  const std::uint16_t format = u16(m_data, offset);
-  switch (format) {
-  case 0: { // byte encoding table
+  const std::uint16_t format = m_parser.read_u16();
+  switch (static_cast<CmapFormat>(format)) {
+  case CmapFormat::byte_encoding: {
+    m_parser.ignore(4); // length, language
     for (std::uint32_t code = 0; code < 256; ++code) {
-      map(code, u8(m_data, offset + 6 + code));
+      map(code, m_parser.read_u8());
     }
     break;
   }
-  case 4: { // segment mapping to delta values
-    const std::size_t segs = u16(m_data, offset + 6) / 2U;
-    const std::size_t end_codes = offset + 14;
-    const std::size_t start_codes = end_codes + segs * 2 + 2;
-    const std::size_t id_deltas = start_codes + segs * 2;
-    const std::size_t id_range_offsets = id_deltas + segs * 2;
+  case CmapFormat::segment_mapping: { // segment mapping to delta values
+    const std::uint16_t length = m_parser.read_u16();
+    m_parser.ignore(2); // language
+    const std::size_t segs = m_parser.read_u16() / 2U;
+    m_parser.ignore(6); // searchRange, entrySelector, rangeShift
+    const std::vector<std::uint16_t> end_codes = read_u16_vector(segs);
+    m_parser.ignore(2); // reservedPad
+    const std::vector<std::uint16_t> start_codes = read_u16_vector(segs);
+    const std::vector<std::uint16_t> id_deltas = read_u16_vector(segs);
+    const std::vector<std::uint16_t> id_range_offsets = read_u16_vector(segs);
+    // Whatever remains of the subtable is the glyphIdArray that non-zero
+    // idRangeOffsets index into; preload it so the inner loop is a plain
+    // lookup. The header up to this point is 16 + 8*segs bytes.
+    const std::size_t header = 16 + 8 * segs;
+    if (length < header) {
+      throw std::runtime_error("sfnt: cmap format 4 subtable too short");
+    }
+    const std::vector<std::uint16_t> glyph_ids =
+        read_u16_vector((length - header) / 2);
     for (std::size_t s = 0; s < segs; ++s) {
-      const std::uint16_t end = u16(m_data, end_codes + s * 2);
-      const std::uint16_t start = u16(m_data, start_codes + s * 2);
-      const std::int16_t delta = s16(m_data, id_deltas + s * 2);
-      const std::uint16_t range = u16(m_data, id_range_offsets + s * 2);
+      const std::uint16_t start = start_codes.at(s);
+      const std::uint16_t end = end_codes.at(s);
+      const std::uint16_t delta = id_deltas.at(s);
+      const std::uint16_t range = id_range_offsets.at(s);
       for (std::uint32_t code = start; code <= end && code != 0xffff; ++code) {
         std::uint16_t glyph = 0;
         if (range == 0) {
           glyph = static_cast<std::uint16_t>(code + delta);
         } else {
-          // idRangeOffset indexes into the glyphIdArray that follows.
-          const std::size_t at = id_range_offsets + s * 2 + range +
-                                 static_cast<std::size_t>(code - start) * 2;
-          glyph = u16(m_data, at);
+          // idRangeOffset is a self-relative byte offset from
+          // &idRangeOffset[s]; as an index into glyphIdArray it is range/2 +
+          // (code-start) - (segs-s).
+          const std::size_t index = range / 2U + (code - start) - (segs - s);
+          glyph = glyph_ids.at(index);
           if (glyph != 0) {
             glyph = static_cast<std::uint16_t>(glyph + delta);
           }
@@ -258,21 +238,22 @@ void SfntFont::parse_cmap_subtable(const std::uint32_t offset) {
     }
     break;
   }
-  case 6: { // trimmed table mapping
-    const std::uint16_t first = u16(m_data, offset + 6);
-    const std::uint16_t entries = u16(m_data, offset + 8);
+  case CmapFormat::trimmed_mapping: {
+    m_parser.ignore(4); // length, language
+    const std::uint16_t first = m_parser.read_u16();
+    const std::uint16_t entries = m_parser.read_u16();
     for (std::uint16_t i = 0; i < entries; ++i) {
-      map(first + i, u16(m_data, offset + 10 + i * 2U));
+      map(first + i, m_parser.read_u16());
     }
     break;
   }
-  case 12: { // segmented coverage
-    const std::uint32_t groups = u32(m_data, offset + 12);
+  case CmapFormat::segmented_coverage: {
+    m_parser.ignore(10); // reserved, length, language
+    const std::uint32_t groups = m_parser.read_u32();
     for (std::uint32_t g = 0; g < groups; ++g) {
-      const std::size_t at = offset + 16 + g * 12U;
-      const std::uint32_t start = u32(m_data, at);
-      const std::uint32_t end = u32(m_data, at + 4);
-      const std::uint32_t start_glyph = u32(m_data, at + 8);
+      const std::uint32_t start = m_parser.read_u32();
+      const std::uint32_t end = m_parser.read_u32();
+      const std::uint32_t start_glyph = m_parser.read_u32();
       for (std::uint32_t code = start; code <= end; ++code) {
         map(code, static_cast<std::uint16_t>(start_glyph + (code - start)));
       }
@@ -284,36 +265,40 @@ void SfntFont::parse_cmap_subtable(const std::uint32_t offset) {
   }
 }
 
-void SfntFont::parse_name() {
+void SfntFont::read_name() {
   const auto name = table("name");
-  if (!name) {
+  if (!name.has_value()) {
     return;
   }
-  const std::uint16_t count = u16(m_data, name->offset + 2);
-  const std::uint16_t string_offset = u16(m_data, name->offset + 4);
+  m_parser.seek(name->offset + 2);
+  const std::uint16_t count = m_parser.read_u16();
+  const std::uint16_t string_offset = m_parser.read_u16();
   const std::size_t strings = name->offset + string_offset;
 
-  int best_score = 0;
+  std::vector<NameEntry> entries;
+  entries.reserve(count);
   for (std::uint16_t i = 0; i < count; ++i) {
-    const std::size_t record = name->offset + 6 + i * 12U;
-    const std::uint16_t platform = u16(m_data, record);
-    const std::uint16_t name_id = u16(m_data, record + 6);
-    if (name_id != 6 && name_id != 4) {
-      continue;
+    entries.emplace_back(m_parser.read_name_entry());
+  }
+
+  const auto score_entry = [](const NameEntry &entry) {
+    // Only the full (4) and PostScript (6) names are usable; everything else
+    // scores below the empty default so it is never selected.
+    if (entry.name_id != NameId::full && entry.name_id != NameId::postscript) {
+      return 0;
     }
-    // Prefer the PostScript name (6) over the full name (4), and a decodable
-    // platform; higher score wins.
-    const int score =
-        (name_id == 6 ? 10 : 0) + (platform == 3 || platform == 0 ? 2 : 1);
-    if (score <= best_score) {
-      continue;
-    }
-    const std::uint16_t length = u16(m_data, record + 8);
-    const std::uint16_t local_offset = u16(m_data, record + 10);
-    m_name = (platform == 3 || platform == 0)
-                 ? decode_utf16be(m_data, strings + local_offset, length)
-                 : decode_latin1(m_data, strings + local_offset, length);
-    best_score = score;
+    const int score = (entry.name_id == NameId::postscript ? 10 : 0) +
+                      (entry.utf16() ? 2 : 1);
+    return score;
+  };
+
+  const auto best_entry = std::ranges::max_element(entries, {}, score_entry);
+
+  if (best_entry != entries.end() && score_entry(*best_entry) > 0) {
+    m_parser.seek(strings + best_entry->name_local_offset);
+    m_name = best_entry->utf16()
+                 ? m_parser.read_utf16be(best_entry->name_length)
+                 : m_parser.read_latin1(best_entry->name_length);
   }
 }
 
@@ -354,8 +339,6 @@ SfntFont::code_point_for_glyph(const std::uint16_t glyph) const {
   return it->second;
 }
 
-const std::string &SfntFont::data() const noexcept { return m_data; }
-
 std::optional<SfntFont::Table>
 SfntFont::table(const std::string_view tag) const {
   const auto it = m_tables.find(tag);
@@ -365,4 +348,4 @@ SfntFont::table(const std::string_view tag) const {
   return it->second;
 }
 
-} // namespace odr::internal::font
+} // namespace odr::internal::font::sfnt

--- a/src/odr/internal/font/sfnt_font.hpp
+++ b/src/odr/internal/font/sfnt_font.hpp
@@ -21,10 +21,10 @@ namespace odr::internal::font {
 /// `std::runtime_error` on a structurally invalid SFNT.
 class SfntFontProgram final : public FontProgram {
 public:
-  explicit SfntFontProgram(std::string data);
-
   /// Cheap magic test: a recognised SFNT version tag at the head of @p data.
-  [[nodiscard]] static bool is_sfnt(std::string_view data) noexcept;
+  [[nodiscard]] static bool is_sfnt(std::string_view data);
+
+  explicit SfntFontProgram(std::string data);
 
   [[nodiscard]] FontFormat format() const noexcept override;
   [[nodiscard]] std::string name() const override;

--- a/src/odr/internal/font/sfnt_font.hpp
+++ b/src/odr/internal/font/sfnt_font.hpp
@@ -1,18 +1,21 @@
 #pragma once
 
 #include <odr/internal/abstract/font.hpp>
+#include <odr/internal/font/sfnt_parser.hpp>
 
 #include <cstdint>
 #include <functional>
+#include <iosfwd>
 #include <map>
+#include <memory>
 #include <optional>
 #include <string>
 #include <string_view>
 #include <vector>
 
-namespace odr::internal::font {
+namespace odr::internal::font::sfnt {
 
-/// @brief `FontProgram` over an SFNT-wrapped font — TrueType (`glyf`) or
+/// @brief `abstract::Font` over an SFNT-wrapped font — TrueType (`glyf`) or
 /// OpenType/CFF (`OTTO`) — parsed from its raw bytes.
 ///
 /// Reads the table directory and the `head`/`maxp`/`hhea`/`hmtx`/`cmap`/`name`
@@ -24,7 +27,9 @@ public:
   /// Cheap magic test: a recognised SFNT version tag at the head of @p data.
   [[nodiscard]] static bool is_sfnt(std::string_view data);
 
-  explicit SfntFont(std::string data);
+  /// Takes ownership of @p in and parses the facts from it (seeking per table);
+  /// the raw bytes are materialized lazily for pass-through (see `data()`).
+  explicit SfntFont(std::unique_ptr<std::istream> stream);
 
   [[nodiscard]] FontFormat format() const noexcept override;
   [[nodiscard]] std::string name() const override;
@@ -37,7 +42,6 @@ public:
   glyph_for_code_point(char32_t code_point) const override;
   [[nodiscard]] std::optional<char32_t>
   code_point_for_glyph(std::uint16_t glyph) const override;
-  [[nodiscard]] const std::string &data() const noexcept override;
 
   /// A located table within the SFNT: byte offset + length into `data()`.
   struct Table {
@@ -49,16 +53,20 @@ public:
   [[nodiscard]] std::optional<Table> table(std::string_view tag) const;
 
 private:
-  void parse_directory(std::uint32_t sfnt_offset);
-  void parse_head();
-  void parse_maxp();
-  void parse_hhea();
-  void parse_hmtx();
-  void parse_cmap();
-  void parse_name();
-  void parse_cmap_subtable(std::uint32_t offset);
+  std::istream &in() const { return *m_in; }
 
-  std::string m_data;
+  void read_directory();
+  void read_head();
+  void read_maxp();
+  void read_hhea();
+  void read_hmtx();
+  void read_cmap();
+  void read_name();
+  void read_cmap_subtable();
+
+  std::unique_ptr<std::istream> m_in;
+  SfntParser m_parser;
+
   FontFormat m_format{FontFormat::unknown};
   std::map<std::string, Table, std::less<>> m_tables;
 
@@ -74,4 +82,4 @@ private:
   std::string m_name;
 };
 
-} // namespace odr::internal::font
+} // namespace odr::internal::font::sfnt

--- a/src/odr/internal/font/sfnt_font.hpp
+++ b/src/odr/internal/font/sfnt_font.hpp
@@ -1,6 +1,6 @@
 #pragma once
 
-#include <odr/internal/font/font_program.hpp>
+#include <odr/internal/abstract/font.hpp>
 
 #include <cstdint>
 #include <functional>
@@ -19,12 +19,12 @@ namespace odr::internal::font {
 /// tables needed for the stage-3 facts; glyph outlines are not touched. A
 /// TrueType Collection (`ttcf`) is read through its first font. Throws
 /// `std::runtime_error` on a structurally invalid SFNT.
-class SfntFontProgram final : public FontProgram {
+class SfntFont final : public abstract::Font {
 public:
   /// Cheap magic test: a recognised SFNT version tag at the head of @p data.
   [[nodiscard]] static bool is_sfnt(std::string_view data);
 
-  explicit SfntFontProgram(std::string data);
+  explicit SfntFont(std::string data);
 
   [[nodiscard]] FontFormat format() const noexcept override;
   [[nodiscard]] std::string name() const override;

--- a/src/odr/internal/font/sfnt_font.hpp
+++ b/src/odr/internal/font/sfnt_font.hpp
@@ -1,0 +1,77 @@
+#pragma once
+
+#include <odr/internal/font/font_program.hpp>
+
+#include <cstdint>
+#include <functional>
+#include <map>
+#include <optional>
+#include <string>
+#include <string_view>
+#include <vector>
+
+namespace odr::internal::font {
+
+/// @brief `FontProgram` over an SFNT-wrapped font — TrueType (`glyf`) or
+/// OpenType/CFF (`OTTO`) — parsed from its raw bytes.
+///
+/// Reads the table directory and the `head`/`maxp`/`hhea`/`hmtx`/`cmap`/`name`
+/// tables needed for the stage-3 facts; glyph outlines are not touched. A
+/// TrueType Collection (`ttcf`) is read through its first font. Throws
+/// `std::runtime_error` on a structurally invalid SFNT.
+class SfntFontProgram final : public FontProgram {
+public:
+  explicit SfntFontProgram(std::string data);
+
+  /// Cheap magic test: a recognised SFNT version tag at the head of @p data.
+  [[nodiscard]] static bool is_sfnt(std::string_view data) noexcept;
+
+  [[nodiscard]] FontFormat format() const noexcept override;
+  [[nodiscard]] std::string name() const override;
+  [[nodiscard]] std::uint16_t glyph_count() const noexcept override;
+  [[nodiscard]] std::uint16_t units_per_em() const noexcept override;
+  [[nodiscard]] bool symbolic() const noexcept override;
+  [[nodiscard]] FontBBox bounding_box() const noexcept override;
+  [[nodiscard]] std::uint16_t advance_width(std::uint16_t glyph) const override;
+  [[nodiscard]] std::uint16_t
+  glyph_for_code_point(char32_t code_point) const override;
+  [[nodiscard]] std::optional<char32_t>
+  code_point_for_glyph(std::uint16_t glyph) const override;
+  [[nodiscard]] const std::string &data() const noexcept override;
+
+  /// A located table within the SFNT: byte offset + length into `data()`.
+  struct Table {
+    std::uint32_t offset{};
+    std::uint32_t length{};
+  };
+  /// Table by 4-char tag (e.g. `"cmap"`), `nullopt` if absent. Exposed for the
+  /// OTF writer (3.1).
+  [[nodiscard]] std::optional<Table> table(std::string_view tag) const;
+
+private:
+  void parse_directory(std::uint32_t sfnt_offset);
+  void parse_head();
+  void parse_maxp();
+  void parse_hhea();
+  void parse_hmtx();
+  void parse_cmap();
+  void parse_name();
+  void parse_cmap_subtable(std::uint32_t offset);
+
+  std::string m_data;
+  FontFormat m_format{FontFormat::unknown};
+  std::map<std::string, Table, std::less<>> m_tables;
+
+  std::uint16_t m_glyph_count{};
+  std::uint16_t m_units_per_em{1000};
+  std::uint16_t m_number_of_h_metrics{};
+  FontBBox m_bbox{};
+  bool m_symbolic{};
+
+  std::vector<std::uint16_t> m_advance_widths;
+  std::map<char32_t, std::uint16_t> m_cmap;
+  std::map<std::uint16_t, char32_t> m_reverse;
+  std::string m_name;
+};
+
+} // namespace odr::internal::font

--- a/src/odr/internal/font/sfnt_parser.cpp
+++ b/src/odr/internal/font/sfnt_parser.cpp
@@ -1,0 +1,109 @@
+#include <odr/internal/font/sfnt_parser.hpp>
+
+#include <odr/internal/util/byte_stream_util.hpp>
+#include <odr/internal/util/stream_util.hpp>
+
+#include <istream>
+
+namespace odr::internal::font::sfnt {
+
+namespace {
+
+void append_utf8(std::string &out, const char32_t cp) {
+  if (cp < 0x80) {
+    out += static_cast<char>(cp);
+  } else if (cp < 0x800) {
+    out += static_cast<char>(0xc0 | (cp >> 6));
+    out += static_cast<char>(0x80 | (cp & 0x3f));
+  } else if (cp < 0x10000) {
+    out += static_cast<char>(0xe0 | (cp >> 12));
+    out += static_cast<char>(0x80 | ((cp >> 6) & 0x3f));
+    out += static_cast<char>(0x80 | (cp & 0x3f));
+  } else {
+    out += static_cast<char>(0xf0 | (cp >> 18));
+    out += static_cast<char>(0x80 | ((cp >> 12) & 0x3f));
+    out += static_cast<char>(0x80 | ((cp >> 6) & 0x3f));
+    out += static_cast<char>(0x80 | (cp & 0x3f));
+  }
+}
+
+} // namespace
+
+bool SfntParser::is_sfnt(const std::string_view data) {
+  if (data.size() < 4) {
+    return false;
+  }
+  const std::string_view tag = data.substr(0, 4);
+  return tag == std::string_view("\x00\x01\x00\x00", 4) || tag == "OTTO" ||
+         tag == "true" || tag == "ttcf" || tag == "typ1";
+}
+
+SfntParser::SfntParser(std::istream &in) : m_in{&in} {}
+
+void SfntParser::seek(const std::streampos offset) { in().seekg(offset); }
+
+std::streampos SfntParser::tell() { return in().tellg(); }
+
+void SfntParser::ignore(const std::streamsize count) { in().ignore(count); }
+
+std::uint8_t SfntParser::read_u8() { return util::byte_stream::read_u8(in()); }
+
+std::uint16_t SfntParser::read_u16() {
+  return util::byte_stream::read_u16_be(in());
+}
+
+std::uint32_t SfntParser::read_u32() {
+  return util::byte_stream::read_u32_be(in());
+}
+
+std::string SfntParser::read_tag() { return util::stream::read(in(), 4); }
+
+std::string SfntParser::read_utf16be(const std::size_t len) {
+  std::string out;
+  for (std::size_t i = 0; i + 1 < len; i += 2) {
+    char32_t cp = read_u16();
+    if (cp >= 0xd800 && cp <= 0xdbff && i + 3 < len) {
+      const char32_t lo = read_u16();
+      if (lo >= 0xdc00 && lo <= 0xdfff) {
+        cp = 0x10000 + ((cp - 0xd800) << 10) + (lo - 0xdc00);
+        i += 2;
+      }
+    }
+    append_utf8(out, cp);
+  }
+  return out;
+}
+
+std::string SfntParser::read_latin1(const std::size_t len) {
+  std::string out;
+  for (std::size_t i = 0; i < len; ++i) {
+    append_utf8(out, read_u8());
+  }
+  return out;
+}
+
+FontBBox SfntParser::read_bbox() {
+  const std::int16_t x_min = read_u16();
+  const std::int16_t y_min = read_u16();
+  const std::int16_t x_max = read_u16();
+  const std::int16_t y_max = read_u16();
+  return {x_min, y_min, x_max, y_max};
+}
+
+CmapEntry SfntParser::read_cmap_entry() {
+  const auto platform = static_cast<PlatformId>(read_u16());
+  const std::uint16_t encoding = read_u16();
+  const std::uint32_t offset = read_u32();
+  return {platform, encoding, offset};
+}
+
+NameEntry SfntParser::read_name_entry() {
+  const auto platform = static_cast<PlatformId>(read_u16());
+  ignore(4); // encodingID, languageID
+  const auto name_id = static_cast<NameId>(read_u16());
+  const std::uint16_t length = read_u16();
+  const std::uint16_t local_offset = read_u16();
+  return {platform, name_id, length, local_offset};
+}
+
+} // namespace odr::internal::font::sfnt

--- a/src/odr/internal/font/sfnt_parser.hpp
+++ b/src/odr/internal/font/sfnt_parser.hpp
@@ -1,0 +1,105 @@
+#pragma once
+
+#include <odr/internal/abstract/font.hpp>
+
+#include <cstdint>
+#include <functional>
+#include <iosfwd>
+#include <string>
+#include <string_view>
+#include <vector>
+
+namespace odr::internal::font::sfnt {
+
+// SFNT enumerations (OpenType spec). Values are the on-disk codes; casting a
+// raw `u16` to one and switching/comparing keeps the magic numbers in one
+// place.
+
+/// `cmap`/`name` platform IDs.
+enum class PlatformId : std::uint16_t {
+  unicode = 0,
+  macintosh = 1,
+  windows = 3,
+};
+
+/// Windows-platform (`PlatformId::windows`) encoding IDs.
+enum class WindowsEncoding : std::uint16_t {
+  symbol = 0,
+  unicode_bmp = 1,
+  unicode_full = 10,
+};
+
+/// Unicode-platform (`PlatformId::unicode`) encoding IDs that name a full
+/// (beyond-BMP) repertoire; the rest are treated as plain Unicode.
+enum class UnicodeEncoding : std::uint16_t {
+  unicode_2_0_full = 4,
+  unicode_full = 6,
+};
+
+/// Macintosh-platform (`PlatformId::macintosh`) encoding IDs.
+enum class MacintoshEncoding : std::uint16_t {
+  roman = 0,
+};
+
+/// `cmap` subtable format (the leading `u16` of a subtable).
+enum class CmapFormat : std::uint16_t {
+  byte_encoding = 0,      // format 0
+  segment_mapping = 4,    // format 4
+  trimmed_mapping = 6,    // format 6
+  segmented_coverage = 12 // format 12
+};
+
+/// `name` record IDs we extract a font name from.
+enum class NameId : std::uint16_t {
+  full = 4,
+  postscript = 6,
+};
+
+struct CmapEntry {
+  PlatformId platform;
+  std::uint16_t encoding;
+  std::uint32_t offset;
+};
+
+struct NameEntry {
+  PlatformId platform;
+  NameId name_id;
+  std::uint16_t name_length;
+  std::uint16_t name_local_offset;
+
+  [[nodiscard]] bool utf16() const {
+    return platform == PlatformId::windows || platform == PlatformId::unicode;
+  }
+};
+
+class SfntParser final {
+public:
+  /// Cheap magic test: a recognised SFNT version tag at the head of @p data.
+  [[nodiscard]] static bool is_sfnt(std::string_view data);
+
+  explicit SfntParser(std::istream &stream);
+
+  std::istream &in() const { return *m_in; }
+
+  void seek(std::streampos offset);
+  [[nodiscard]] std::streampos tell();
+  void ignore(std::streamsize count);
+
+  [[nodiscard]] std::uint8_t read_u8();
+  [[nodiscard]] std::uint16_t read_u16();
+  [[nodiscard]] std::uint32_t read_u32();
+  [[nodiscard]] std::string read_tag();
+  /// Decode a UTF-16BE `name` string (Windows/Unicode platforms), surrogate
+  /// pairs included, into UTF-8.
+  [[nodiscard]] std::string read_utf16be(std::size_t len);
+  /// Decode a single-byte (Mac/Latin-1) `name` string into UTF-8.
+  [[nodiscard]] std::string read_latin1(std::size_t len);
+  [[nodiscard]] FontBBox read_bbox();
+  [[nodiscard]] CmapEntry read_cmap_entry();
+  [[nodiscard]] NameEntry read_name_entry();
+
+private:
+  std::istream *m_in{};
+};
+
+} // namespace odr::internal::font::sfnt

--- a/src/odr/internal/pdf/AGENTS.md
+++ b/src/odr/internal/pdf/AGENTS.md
@@ -312,8 +312,10 @@ display is driven by the *glyph*, not the extracted Unicode, **text-extraction
 gaps degrade only selectability and search — never display.** Every deferred
 code → Unicode case (legacy CJK CID → Unicode tables, `Identity-H` without
 `/ToUnicode`, embedded-font reverse maps) still renders correctly once stage 3 lands:
-glyphs with no recoverable Unicode are re-encoded to the Private Use Area and the
-run is marked non-extractable (`user-select: none`, `aria-hidden`). So the
+all glyphs are re-encoded to the Private Use Area for display (stage 3's uniform
+re-encode, decision 2026-06-19), with the extracted Unicode carried separately to
+drive selection/search; runs with no recoverable Unicode are additionally marked
+non-extractable (`user-select: none`, `aria-hidden`). So the
 deferred CJK/legacy-CMap work is a *selectability* gap, not a rendering risk —
 such PDFs look right, their text just isn't selectable until the tables land.
 
@@ -550,48 +552,83 @@ alongside. The embedded-font reverse map (above) reads Unicode from it, the OTF 
 `head`/`hhea`/`hmtx`/`OS/2` from it, the re-encoder assigns PUA code points from
 its glyph count.
 
-**Intermediate milestone — fonts as first-class library citizens.** Before
-wiring fonts into PDF output, ship them standalone:
-- **Font files as a `DecodedFile` type** (precedent: `SvmFile`, `ImageFile`):
-  `FileType` entries + magic detection (SFNT `0x00010000`/`OTTO`/`wOFF`), a
-  `FontFile` category, and `html::translate(FontFile)` emitting a **specimen
-  page** — name/metrics header plus a glyph grid, font served via `@font-face`.
-  Keep the UI at "specimen page"; no font-editor scope creep.
-- The glyph grid must show **every** glyph, including ones no `cmap` reaches —
-  which forces building the PUA re-encoding, table-directory rebuild, and OTF
-  wrap *first*, against a directly viewable deliverable with font-only tests.
-- **In parallel: PDF as a container.** Expose embedded fonts as an
-  `abstract::Filesystem` (`/fonts/F1.ttf`, …) and reuse the filesystem HTML
-  service (as for ZIP/CFB). Doubles as the corpus harvester.
+**Decision (2026-06-19): standalone-first, uniform PUA, Type3 stays in-stage.**
+Three sequencing/scope choices fix the sub-stage plan below:
+- **Standalone-first.** Fonts ship as a library deliverable — a `FontFile`
+  `DecodedFile` plus a specimen-page HTML view, with font-only tests — *before*
+  being wired into PDF output. The specimen page's glyph grid must show *every*
+  glyph, which forces the PUA re-encode, table-directory rebuild and OTF wrap
+  first, against a directly viewable, independently testable artifact.
+- **Uniform PUA re-encode.** *Every* font is re-encoded to deterministic Private
+  Use Area code points (`U+E000 + glyph index`) for **display** — one pipeline,
+  no mapped-vs-unmapped branch (pdf2htmlEX's model), so display is always
+  glyph-exact. The extracted Unicode (the stage-1 chain, plus the new
+  embedded-font reverse map) is **not** discarded: it rides on the element as
+  today and the HTML layer surfaces it for **selection/search** — the
+  display/text decoupling holds (see *Design decisions*). Runs with no
+  recoverable Unicode are additionally marked non-extractable (`user-select:
+  none`, `aria-hidden`).
+- **Type3 stays in stage 3.** Type3 glyphs are drawing procedures, so they need
+  path → SVG rendering that otherwise belongs to stage 4; a minimal path → SVG
+  capability is pulled forward into sub-stage 3.6 rather than waiting on stage 4.
 
-Sub-stages, ordered by corpus frequency, each independently useful:
-1. **TrueType** (`FontFile2`, CIDFontType2 — bulk of modern PDFs): serve nearly
-   as-is via `@font-face`; implement the `cmap` rewrite (format-4/12 subtable,
-   splice the table directory, recompute `head.checkSumAdjustment`).
-2. **Bare CFF** (`FontFile3`/Type1C): wrap into an OTF container by synthesizing
-   the ~8 required tables; take advance widths from `/Widths`/`/W` rather than
-   interpreting charstrings.
-3. **Type1** (`FontFile` — older docs, pdfTeX/academic PDFs): `eexec`
-   decryption, Type1 → Type2 charstrings, build a CFF, reuse sub-stage 2. The
-   hardest single piece but precisely specified (Adobe T1 spec; pdf.js as
-   reference).
-4. **Type3** (drawing procedures, no font file — scientific plots) → SVG glyphs
-   reusing stage 4's path rendering; plus **non-embedded fonts**: substitute the
-   standard 14 + common names with CSS fallbacks + metrics from `/Widths`.
+**Sub-stages.** Ordered so each lands an independently testable (and, from 3.2,
+viewable) artifact; the risky core — read a font, produce a sanitizer-clean,
+fully re-encoded one — is proven by font-only tests before any PDF wiring. Sizing
+mirrors stage 2 (one PR each). Each gets its own detailed design before
+implementation.
 
-Mechanisms and guards:
-- **Re-encoding for unmapped glyphs** (the general workaround): rewrite the
-  `cmap` so deterministic PUA code points (`U+E000 + glyph index`) map to the
-  glyphs, emit those in the HTML, mark such runs non-extractable
-  (`user-select: none`, `aria-hidden`). Display correct; copy/search knowingly
-  garbage. Option: re-encode *all* fonts this way (pdf2htmlEX's choice) for one
-  uniform pipeline.
-- **Broken-font long tail**: real embedded fonts are routinely malformed, and
+- **3.0 — `FontProgram` interface + SFNT/TrueType reader (facts only).** The thin
+  per-flavor reader interface producing the facts every consumer needs (glyph
+  count, glyph → Unicode, advance widths, units-per-em, name, bbox, symbolic
+  flag), raw glyph bytes kept alongside. First implementation: SFNT/TrueType —
+  parse the table directory and `head`/`hhea`/`hmtx`/`maxp`/`cmap` (formats
+  4/12)/`name`/`post`/`OS/2`. Font-only unit tests; no HTML, no PDF wiring.
+- **3.1 — OTF wrap + uniform PUA re-encode + table-directory rebuild.** Given a
+  `FontProgram`, emit a browser-loadable, OTS-clean SFNT: rewrite `cmap` to the
+  deterministic PUA map over *every* glyph, splice/rebuild the table directory,
+  recompute `head.checkSumAdjustment`. The single riskiest piece — exercised by
+  font-only round-trip + OTS tests before any UI.
+- **3.2 — `FontFile` as a `DecodedFile` + specimen-page HTML (the standalone
+  deliverable).** Precedent: `SvmFile`, `ImageFile`. `FileType` entries + magic
+  detection (SFNT `0x00010000`/`OTTO`/`true`/`ttcf`, `wOFF`), a `FontFile`
+  `FileCategory`, and `html::translate(FontFile)` emitting a specimen page: a
+  name/metrics header plus a glyph grid that shows *every* glyph (incl.
+  `cmap`-unreachable ones — exactly what 3.1's re-encode makes addressable), the
+  font served via `@font-face`. Scope capped at "specimen page" — no font-editor
+  creep. *Optional parallel:* PDF as a container — expose embedded fonts as an
+  `abstract::Filesystem` (`/fonts/F1.ttf`, …) reusing the filesystem HTML service
+  (as for ZIP/CFB); doubles as the corpus harvester.
+- **3.3 — wire TrueType into PDF `@font-face` (first end-to-end PDF win).** Read
+  embedded `FontFile2`/`CIDFontType2` programs through the `FontProgram`
+  interface, run them through the 3.1 wrap/PUA pipeline, and emit `@font-face` +
+  PUA-encoded spans in the PDF HTML — replacing today's fallback-font span for the
+  bulk of modern PDFs. Also lands the **embedded-font reverse map**: code →
+  Unicode from the reversed TrueType `cmap`, surfaced for selection (closing the
+  stage-1 extraction gap for these fonts).
+- **3.4 — bare CFF (`FontFile3`/Type1C).** A CFF reader (charset, charstrings,
+  private dict) producing a `FontProgram`; wrap into OTF by synthesizing the ~8
+  required SFNT tables (advance widths from `/Widths`/`/W`, not by interpreting
+  charstrings). Reuses 3.1 (wrap/PUA), 3.2 (specimen) and 3.3 (PDF wiring)
+  unchanged.
+- **3.5 — Type1 (`FontFile`).** `eexec` decryption, Type1 → Type2 charstring
+  translation, build a CFF, reuse 3.4's CFF → OTF path. Reverse map via charstring
+  glyph names → AGL. The hardest single piece, but precisely specified (Adobe T1
+  spec; pdf.js as reference).
+- **3.6 — Type3 + non-embedded fonts.** Type3 glyph procedures (mini content
+  streams, already tokenized by the operator parser) → SVG glyphs via a minimal
+  path → SVG capability pulled forward from stage 4. Plus non-embedded fonts:
+  substitute the standard 14 + common names with CSS fallbacks and metrics from
+  `/Widths` (AFM widths for the standard-14 — closes stage 2's deferred item).
+
+**Mechanisms & guards (ride through 3.1–3.5).**
+- **Broken-font long tail.** Real embedded fonts are routinely malformed, and
   browsers run web fonts through a sanitizer (OTS) that silently rejects them.
-  Regenerating the table directory (which the re-encode/wrap does anyway) covers
-  most of it; start strict, add repair heuristics as real files demand. CI gate:
-  run **OTS** over every produced font (test-time only); optionally FreeType as
-  a second oracle. Neither ships in the product.
+  Regenerating the table directory (which the wrap/re-encode does anyway) covers
+  most of it; start strict, add repair heuristics as real files demand.
+- **Test oracles (never shipped).** CI gate: run **OTS** over every produced font
+  (test-time only); optionally FreeType as a second oracle. Neither is linked into
+  the product.
 
 ## Stage 4 — graphics
 

--- a/src/odr/internal/pdf/AGENTS.md
+++ b/src/odr/internal/pdf/AGENTS.md
@@ -545,7 +545,7 @@ decompiling and recompiling outlines is the FontForge model — loses hinting,
 risks fidelity, and with one output format (SFNT) the M×N payoff never
 materializes. Glyph data (outlines, hinting, charstrings) passes through
 byte-for-byte; even Type1 → Type2 charstrings is a direct sibling-format
-translation. What *is* shared: a thin `FontProgram`-style interface — per-flavor
+translation. What *is* shared: a thin `abstract::Font` interface — per-flavor
 readers producing the facts every consumer needs (glyph count, glyph → Unicode,
 advance widths, units-per-em, name, bbox, symbolic flag) with raw bytes kept
 alongside. The embedded-font reverse map (above) reads Unicode from it, the OTF wrap synthesizes
@@ -578,14 +578,18 @@ fully re-encoded one — is proven by font-only tests before any PDF wiring. Siz
 mirrors stage 2 (one PR each). Each gets its own detailed design before
 implementation.
 
-- **3.0 — `FontProgram` interface + SFNT/TrueType reader (facts only).** The thin
-  per-flavor reader interface producing the facts every consumer needs (glyph
+- **3.0 — `abstract::Font` interface + SFNT/TrueType reader (facts only).**
+  **Done.** The thin per-flavor reader interface (`abstract::Font`,
+  `internal/abstract/font.hpp`) producing the facts every consumer needs (glyph
   count, glyph → Unicode, advance widths, units-per-em, name, bbox, symbolic
-  flag), raw glyph bytes kept alongside. First implementation: SFNT/TrueType —
-  parse the table directory and `head`/`hhea`/`hmtx`/`maxp`/`cmap` (formats
-  4/12)/`name`/`post`/`OS/2`. Font-only unit tests; no HTML, no PDF wiring.
-- **3.1 — OTF wrap + uniform PUA re-encode + table-directory rebuild.** Given a
-  `FontProgram`, emit a browser-loadable, OTS-clean SFNT: rewrite `cmap` to the
+  flag), raw glyph bytes kept alongside. First implementation: `SfntFont`
+  (`internal/font/sfnt_font.{hpp,cpp}`) — reads the font from a `std::istream`
+  (seeking per table, the bytes materialized lazily for the pass-through `data()`),
+  parsing the table directory and `head`/`maxp`/`hhea`/`hmtx`/`cmap` (formats
+  0/4/6/12)/`name`; `post`/`OS/2` deferred until a consumer needs them. Font-only
+  unit tests; no HTML, no PDF wiring.
+- **3.1 — OTF wrap + uniform PUA re-encode + table-directory rebuild.** Given an
+  `abstract::Font`, emit a browser-loadable, OTS-clean SFNT: rewrite `cmap` to the
   deterministic PUA map over *every* glyph, splice/rebuild the table directory,
   recompute `head.checkSumAdjustment`. The single riskiest piece — exercised by
   font-only round-trip + OTS tests before any UI.
@@ -600,14 +604,14 @@ implementation.
   `abstract::Filesystem` (`/fonts/F1.ttf`, …) reusing the filesystem HTML service
   (as for ZIP/CFB); doubles as the corpus harvester.
 - **3.3 — wire TrueType into PDF `@font-face` (first end-to-end PDF win).** Read
-  embedded `FontFile2`/`CIDFontType2` programs through the `FontProgram`
+  embedded `FontFile2`/`CIDFontType2` programs through the `abstract::Font`
   interface, run them through the 3.1 wrap/PUA pipeline, and emit `@font-face` +
   PUA-encoded spans in the PDF HTML — replacing today's fallback-font span for the
   bulk of modern PDFs. Also lands the **embedded-font reverse map**: code →
   Unicode from the reversed TrueType `cmap`, surfaced for selection (closing the
   stage-1 extraction gap for these fonts).
 - **3.4 — bare CFF (`FontFile3`/Type1C).** A CFF reader (charset, charstrings,
-  private dict) producing a `FontProgram`; wrap into OTF by synthesizing the ~8
+  private dict) producing an `abstract::Font`; wrap into OTF by synthesizing the ~8
   required SFNT tables (advance widths from `/Widths`/`/W`, not by interpreting
   charstrings). Reuses 3.1 (wrap/PUA), 3.2 (specimen) and 3.3 (PDF wiring)
   unchanged.

--- a/src/odr/internal/pdf/pdf_object_parser.hpp
+++ b/src/odr/internal/pdf/pdf_object_parser.hpp
@@ -17,7 +17,7 @@ public:
   static constexpr int_type eof = std::streambuf::traits_type::eof();
   using pos_type = std::streambuf::pos_type;
 
-  explicit ObjectParser(std::istream &);
+  explicit ObjectParser(std::istream &in);
 
   [[nodiscard]] std::istream &in();
   [[nodiscard]] std::streambuf &sb();

--- a/src/odr/internal/util/byte_stream_util.cpp
+++ b/src/odr/internal/util/byte_stream_util.cpp
@@ -1,5 +1,7 @@
 #include <odr/internal/util/byte_stream_util.hpp>
 
+#include <odr/internal/util/byte_util.hpp>
+
 #include <iostream>
 
 namespace odr::internal::util {
@@ -21,6 +23,48 @@ void byte_stream::read(std::istream &in, char *out, std::size_t count) {
   if (!try_read(in, out, count)) {
     throw std::runtime_error("byte_stream: failed to read from stream");
   }
+}
+
+std::uint8_t byte_stream::read_u8(std::istream &in) {
+  const auto c = in.rdbuf()->sbumpc();
+  if (c == eof) {
+    in.setstate(std::ios::eofbit);
+    throw std::runtime_error("unexpected stream exhaust");
+  }
+  return static_cast<char_type>(c);
+}
+
+std::string byte_stream::read_u8s(std::istream &in, const std::size_t n) {
+  std::string result(n, '\0');
+  if (const auto m = static_cast<std::streamsize>(n);
+      in.rdbuf()->sgetn(result.data(), m) != m) {
+    throw std::runtime_error("unexpected stream exhaust");
+  }
+  return result;
+}
+
+std::uint16_t byte_stream::read_u16_le(std::istream &in) {
+  return byte::from_little_endian<std::uint16_t>(read_u8s<2>(in));
+}
+
+std::uint32_t byte_stream::read_u32_le(std::istream &in) {
+  return byte::from_little_endian<std::uint32_t>(read_u8s<4>(in));
+}
+
+std::uint64_t byte_stream::read_u64_le(std::istream &in) {
+  return byte::from_little_endian<std::uint64_t>(read_u8s<8>(in));
+}
+
+std::uint16_t byte_stream::read_u16_be(std::istream &in) {
+  return byte::from_big_endian<std::uint16_t>(read_u8s<2>(in));
+}
+
+std::uint32_t byte_stream::read_u32_be(std::istream &in) {
+  return byte::from_big_endian<std::uint32_t>(read_u8s<4>(in));
+}
+
+std::uint64_t byte_stream::read_u64_be(std::istream &in) {
+  return byte::from_big_endian<std::uint64_t>(read_u8s<8>(in));
 }
 
 } // namespace odr::internal::util

--- a/src/odr/internal/util/byte_stream_util.hpp
+++ b/src/odr/internal/util/byte_stream_util.hpp
@@ -1,6 +1,8 @@
 #pragma once
 
+#include <array>
 #include <cstddef>
+#include <cstdint>
 #include <iostream>
 #include <optional>
 #include <streambuf>

--- a/src/odr/internal/util/byte_stream_util.hpp
+++ b/src/odr/internal/util/byte_stream_util.hpp
@@ -1,10 +1,16 @@
 #pragma once
 
 #include <cstddef>
-#include <iosfwd>
+#include <iostream>
 #include <optional>
+#include <streambuf>
 
 namespace odr::internal::util::byte_stream {
+
+using char_type = std::streambuf::char_type;
+using int_type = std::streambuf::int_type;
+static constexpr int_type eof = std::streambuf::traits_type::eof();
+using pos_type = std::streambuf::pos_type;
 
 bool try_read(std::istream &in, char *out, std::size_t count);
 
@@ -32,5 +38,25 @@ template <typename T> T read(std::istream &in) {
   read(in, out);
   return out;
 }
+
+std::uint8_t read_u8(std::istream &in);
+
+template <std::uint32_t N> std::array<char, N> read_u8s(std::istream &in) {
+  std::array<char, N> result;
+  if (in.rdbuf()->sgetn(result.data(), result.size()) != result.size()) {
+    throw std::runtime_error("unexpected stream exhaust");
+  }
+  return result;
+}
+
+std::string read_u8s(std::istream &in, std::size_t n);
+
+std::uint16_t read_u16_le(std::istream &in);
+std::uint32_t read_u32_le(std::istream &in);
+std::uint64_t read_u64_le(std::istream &in);
+
+std::uint16_t read_u16_be(std::istream &in);
+std::uint32_t read_u32_be(std::istream &in);
+std::uint64_t read_u64_be(std::istream &in);
 
 } // namespace odr::internal::util::byte_stream

--- a/src/odr/internal/util/byte_util.hpp
+++ b/src/odr/internal/util/byte_util.hpp
@@ -1,6 +1,8 @@
 #pragma once
 
+#include <cassert>
 #include <memory>
+#include <ranges>
 #include <string>
 
 namespace odr::internal::util::byte {
@@ -18,19 +20,58 @@ void reverse_bytes(char32_t *string, std::size_t length);
 void reverse_bytes(std::u16string &string);
 void reverse_bytes(std::u32string &string);
 
-template <typename I, std::ranges::range O>
+template <typename I, std::ranges::random_access_range O>
 void to_little_endian(I in, O &out) {
+  assert(std::ranges::size(out) >= sizeof(in) &&
+         "output range too small for input type");
   for (unsigned int i = 0; i < sizeof(in); ++i) {
     out[i] = in & 0xff;
     in >>= 8;
   }
 }
 
-template <typename I, std::ranges::range O> void to_big_endian(I in, O &out) {
+template <typename I, std::ranges::random_access_range O>
+void to_big_endian(I in, O &out) {
+  assert(std::ranges::size(out) >= sizeof(in) &&
+         "output range too small for input type");
   for (int i = sizeof(in) - 1; i >= 0; --i) {
     out[i] = in & 0xff;
     in >>= 8;
   }
+}
+
+template <std::ranges::random_access_range I, typename O>
+void from_little_endian(const I &in, O &out) {
+  assert(std::ranges::size(in) >= sizeof(out) &&
+         "input range too small for output type");
+  out = 0;
+  for (unsigned int i = 0; i < sizeof(out); ++i) {
+    out |= (static_cast<O>(in[i]) & 0xff) << (i * 8);
+  }
+}
+
+template <typename O, std::ranges::random_access_range I>
+O from_little_endian(const I &in) {
+  O out{};
+  from_little_endian(in, out);
+  return out;
+}
+
+template <std::ranges::random_access_range I, typename O>
+void from_big_endian(const I &in, O &out) {
+  assert(std::ranges::size(in) >= sizeof(out) &&
+         "input range too small for output type");
+  out = 0;
+  for (unsigned int i = 0; i < sizeof(out); ++i) {
+    out = (out << 8) | (static_cast<O>(in[i]) & 0xff);
+  }
+}
+
+template <typename O, std::ranges::random_access_range I>
+O from_big_endian(const I &in) {
+  O out{};
+  from_big_endian(in, out);
+  return out;
 }
 
 std::string xor_bytes(const std::string &a, const std::string &b);

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -53,6 +53,8 @@ add_executable(odr_test
         "src/internal/pdf/pdf_page_text.cpp"
         "src/internal/pdf/pdf_test_file_builder.cpp"
 
+        "src/internal/font/sfnt_font.cpp"
+
         "src/internal/svm/svm_test.cpp"
 
         "src/internal/text/text_file_test.cpp"

--- a/test/src/internal/font/sfnt_font.cpp
+++ b/test/src/internal/font/sfnt_font.cpp
@@ -1,11 +1,14 @@
 #include <odr/internal/font/sfnt_font.hpp>
 
+#include <odr/font.hpp>
+
 #include <gtest/gtest.h>
 
 #include <cstdint>
 #include <string>
 #include <vector>
 
+using namespace odr;
 using namespace odr::internal::font;
 
 namespace {
@@ -168,9 +171,8 @@ std::string sample_font(const std::string &cmap) {
 
 } // namespace
 
-TEST(SfntFontProgram, reads_facts) {
-  const SfntFontProgram font(
-      sample_font(cmap_table(3, 1, cmap_format4('A', 3))));
+TEST(SfntFont, reads_facts) {
+  const SfntFont font(sample_font(cmap_table(3, 1, cmap_format4('A', 3))));
 
   EXPECT_EQ(font.format(), FontFormat::truetype);
   EXPECT_EQ(font.glyph_count(), 5);
@@ -185,9 +187,8 @@ TEST(SfntFontProgram, reads_facts) {
   EXPECT_EQ(bbox.y_max, 800);
 }
 
-TEST(SfntFontProgram, advance_widths_with_monospace_tail) {
-  const SfntFontProgram font(
-      sample_font(cmap_table(3, 1, cmap_format4('A', 3))));
+TEST(SfntFont, advance_widths_with_monospace_tail) {
+  const SfntFont font(sample_font(cmap_table(3, 1, cmap_format4('A', 3))));
 
   EXPECT_EQ(font.advance_width(0), 500);
   EXPECT_EQ(font.advance_width(3), 222);
@@ -196,9 +197,8 @@ TEST(SfntFontProgram, advance_widths_with_monospace_tail) {
   EXPECT_EQ(font.advance_width(99), 333);
 }
 
-TEST(SfntFontProgram, cmap_format4_forward_and_reverse) {
-  const SfntFontProgram font(
-      sample_font(cmap_table(3, 1, cmap_format4('A', 3))));
+TEST(SfntFont, cmap_format4_forward_and_reverse) {
+  const SfntFont font(sample_font(cmap_table(3, 1, cmap_format4('A', 3))));
 
   EXPECT_EQ(font.glyph_for_code_point('A'), 1);
   EXPECT_EQ(font.glyph_for_code_point('C'), 3);
@@ -209,8 +209,8 @@ TEST(SfntFontProgram, cmap_format4_forward_and_reverse) {
   EXPECT_FALSE(font.code_point_for_glyph(4).has_value()); // no code maps here
 }
 
-TEST(SfntFontProgram, cmap_format12_astral_plane) {
-  const SfntFontProgram font(
+TEST(SfntFont, cmap_format12_astral_plane) {
+  const SfntFont font(
       sample_font(cmap_table(3, 10, cmap_format12(0x1f600, 2))));
 
   EXPECT_EQ(font.glyph_for_code_point(0x1f600), 1);
@@ -218,33 +218,31 @@ TEST(SfntFontProgram, cmap_format12_astral_plane) {
   EXPECT_EQ(font.code_point_for_glyph(2), static_cast<char32_t>(0x1f601));
 }
 
-TEST(SfntFontProgram, symbolic_flag_from_platform_3_encoding_0) {
-  const SfntFontProgram font(
-      sample_font(cmap_table(3, 0, cmap_format4(0xf020, 3))));
+TEST(SfntFont, symbolic_flag_from_platform_3_encoding_0) {
+  const SfntFont font(sample_font(cmap_table(3, 0, cmap_format4(0xf020, 3))));
 
   EXPECT_TRUE(font.symbolic());
   EXPECT_EQ(font.glyph_for_code_point(0xf020), 1);
 }
 
-TEST(SfntFontProgram, table_lookup) {
-  const SfntFontProgram font(
-      sample_font(cmap_table(3, 1, cmap_format4('A', 3))));
+TEST(SfntFont, table_lookup) {
+  const SfntFont font(sample_font(cmap_table(3, 1, cmap_format4('A', 3))));
 
   EXPECT_TRUE(font.table("cmap").has_value());
   EXPECT_TRUE(font.table("head").has_value());
   EXPECT_FALSE(font.table("CFF ").has_value());
 }
 
-TEST(SfntFontProgram, is_sfnt) {
-  EXPECT_TRUE(SfntFontProgram::is_sfnt(std::string("\x00\x01\x00\x00", 4)));
-  EXPECT_TRUE(SfntFontProgram::is_sfnt("OTTO"));
-  EXPECT_TRUE(SfntFontProgram::is_sfnt("true"));
-  EXPECT_TRUE(SfntFontProgram::is_sfnt("ttcf"));
-  EXPECT_FALSE(SfntFontProgram::is_sfnt("%PDF"));
-  EXPECT_FALSE(SfntFontProgram::is_sfnt("ab"));
+TEST(SfntFont, is_sfnt) {
+  EXPECT_TRUE(SfntFont::is_sfnt(std::string("\x00\x01\x00\x00", 4)));
+  EXPECT_TRUE(SfntFont::is_sfnt("OTTO"));
+  EXPECT_TRUE(SfntFont::is_sfnt("true"));
+  EXPECT_TRUE(SfntFont::is_sfnt("ttcf"));
+  EXPECT_FALSE(SfntFont::is_sfnt("%PDF"));
+  EXPECT_FALSE(SfntFont::is_sfnt("ab"));
 }
 
-TEST(SfntFontProgram, throws_on_truncated) {
-  EXPECT_THROW(SfntFontProgram(std::string("\x00\x01\x00\x00", 4)),
+TEST(SfntFont, throws_on_truncated) {
+  EXPECT_THROW(SfntFont(std::string("\x00\x01\x00\x00", 4)),
                std::runtime_error);
 }

--- a/test/src/internal/font/sfnt_font.cpp
+++ b/test/src/internal/font/sfnt_font.cpp
@@ -1,0 +1,249 @@
+#include <odr/internal/font/sfnt_font.hpp>
+
+#include <gtest/gtest.h>
+
+#include <cstdint>
+#include <string>
+#include <vector>
+
+using namespace odr::internal::font;
+
+namespace {
+
+void put16(std::string &s, std::uint16_t v) {
+  s += static_cast<char>(v >> 8);
+  s += static_cast<char>(v & 0xff);
+}
+
+void put32(std::string &s, std::uint32_t v) {
+  put16(s, static_cast<std::uint16_t>(v >> 16));
+  put16(s, static_cast<std::uint16_t>(v & 0xffff));
+}
+
+// A `head` table: only unitsPerEm (offset 18) and the bbox (36..42) are read.
+std::string head_table() {
+  std::string t(54, '\0');
+  const auto u16 = [&](std::size_t o, std::uint16_t v) {
+    t[o] = static_cast<char>(v >> 8);
+    t[o + 1] = static_cast<char>(v & 0xff);
+  };
+  u16(18, 1000);                             // unitsPerEm
+  u16(36, static_cast<std::uint16_t>(-100)); // xMin
+  u16(38, static_cast<std::uint16_t>(-200)); // yMin
+  u16(40, 900);                              // xMax
+  u16(42, 800);                              // yMax
+  return t;
+}
+
+std::string maxp_table(std::uint16_t glyphs) {
+  std::string t;
+  put32(t, 0x00010000); // version 1.0
+  put16(t, glyphs);
+  t.resize(32, '\0');
+  return t;
+}
+
+std::string hhea_table(std::uint16_t number_of_h_metrics) {
+  std::string t(36, '\0');
+  t[34] = static_cast<char>(number_of_h_metrics >> 8);
+  t[35] = static_cast<char>(number_of_h_metrics & 0xff);
+  return t;
+}
+
+std::string hmtx_table(const std::vector<std::uint16_t> &advances) {
+  std::string t;
+  for (const std::uint16_t a : advances) {
+    put16(t, a); // advanceWidth
+    put16(t, 0); // leftSideBearing
+  }
+  return t;
+}
+
+// Format-4 subtable mapping the contiguous run [start, start+count) to glyph
+// ids [1, count] via a single idDelta segment, plus the required terminator.
+std::string cmap_format4(char16_t start, std::uint16_t count) {
+  std::string t;
+  put16(t, 4);  // format
+  put16(t, 32); // length
+  put16(t, 0);  // language
+  put16(t, 4);  // segCountX2 (2 segments)
+  put16(t, 0);  // searchRange
+  put16(t, 0);  // entrySelector
+  put16(t, 0);  // rangeShift
+  put16(t, static_cast<std::uint16_t>(start + count - 1)); // endCode[0]
+  put16(t, 0xffff);                                        // endCode[1]
+  put16(t, 0);                                             // reservedPad
+  put16(t, start);                                         // startCode[0]
+  put16(t, 0xffff);                                        // startCode[1]
+  put16(t, static_cast<std::uint16_t>(1 - start)); // idDelta[0] -> gid 1..count
+  put16(t, 1);                                     // idDelta[1]
+  put16(t, 0);                                     // idRangeOffset[0]
+  put16(t, 0);                                     // idRangeOffset[1]
+  return t;
+}
+
+// Format-12 subtable: one group mapping [start, start+count) to [1, count].
+std::string cmap_format12(char32_t start, std::uint32_t count) {
+  std::string t;
+  put16(t, 12); // format
+  put16(t, 0);  // reserved
+  put32(t, 28); // length
+  put32(t, 0);  // language
+  put32(t, 1);  // nGroups
+  put32(t, start);
+  put32(t, start + count - 1);
+  put32(t, 1); // startGlyphID
+  return t;
+}
+
+std::string cmap_table(std::uint16_t platform, std::uint16_t encoding,
+                       const std::string &subtable) {
+  std::string t;
+  put16(t, 0); // version
+  put16(t, 1); // numTables
+  put16(t, platform);
+  put16(t, encoding);
+  put32(t, 12); // offset to the single subtable
+  t += subtable;
+  return t;
+}
+
+// A `name` table with a single PostScript-name (id 6) record, UTF-16BE.
+std::string name_table(const std::string &ascii) {
+  std::string strings;
+  for (const char c : ascii) {
+    put16(strings, static_cast<std::uint8_t>(c));
+  }
+  std::string t;
+  put16(t, 0);     // format
+  put16(t, 1);     // count
+  put16(t, 18);    // stringOffset (6 header + 12 record)
+  put16(t, 3);     // platformID (Windows)
+  put16(t, 1);     // encodingID
+  put16(t, 0x409); // languageID
+  put16(t, 6);     // nameID (PostScript)
+  put16(t, static_cast<std::uint16_t>(strings.size()));
+  put16(t, 0); // offset within string storage
+  t += strings;
+  return t;
+}
+
+// Assemble a full SFNT from named tables, computing the table directory.
+std::string
+build_sfnt(const std::vector<std::pair<std::string, std::string>> &tables) {
+  const auto count = static_cast<std::uint16_t>(tables.size());
+  std::string out;
+  put32(out, 0x00010000); // sfntVersion (TrueType)
+  put16(out, count);
+  put16(out, 0); // searchRange
+  put16(out, 0); // entrySelector
+  put16(out, 0); // rangeShift
+
+  std::uint32_t offset = 12 + count * 16U;
+  std::string body;
+  for (const auto &[tag, data] : tables) {
+    out += tag;
+    put32(out, 0); // checksum (not validated by the reader)
+    put32(out, offset);
+    put32(out, static_cast<std::uint32_t>(data.size()));
+    body += data;
+    while (body.size() % 4 != 0) {
+      body += '\0';
+    }
+    offset = 12 + count * 16U + static_cast<std::uint32_t>(body.size());
+  }
+  return out + body;
+}
+
+std::string sample_font(const std::string &cmap) {
+  // Tables are stored in tag-sorted order, as required by the spec.
+  return build_sfnt({{"cmap", cmap},
+                     {"head", head_table()},
+                     {"hhea", hhea_table(5)},
+                     {"hmtx", hmtx_table({500, 600, 700, 222, 333})},
+                     {"maxp", maxp_table(5)},
+                     {"name", name_table("TestFont")}});
+}
+
+} // namespace
+
+TEST(SfntFontProgram, reads_facts) {
+  const SfntFontProgram font(
+      sample_font(cmap_table(3, 1, cmap_format4('A', 3))));
+
+  EXPECT_EQ(font.format(), FontFormat::truetype);
+  EXPECT_EQ(font.glyph_count(), 5);
+  EXPECT_EQ(font.units_per_em(), 1000);
+  EXPECT_FALSE(font.symbolic());
+  EXPECT_EQ(font.name(), "TestFont");
+
+  const FontBBox bbox = font.bounding_box();
+  EXPECT_EQ(bbox.x_min, -100);
+  EXPECT_EQ(bbox.y_min, -200);
+  EXPECT_EQ(bbox.x_max, 900);
+  EXPECT_EQ(bbox.y_max, 800);
+}
+
+TEST(SfntFontProgram, advance_widths_with_monospace_tail) {
+  const SfntFontProgram font(
+      sample_font(cmap_table(3, 1, cmap_format4('A', 3))));
+
+  EXPECT_EQ(font.advance_width(0), 500);
+  EXPECT_EQ(font.advance_width(3), 222);
+  EXPECT_EQ(font.advance_width(4), 333);
+  // Glyphs beyond numberOfHMetrics share the last advance.
+  EXPECT_EQ(font.advance_width(99), 333);
+}
+
+TEST(SfntFontProgram, cmap_format4_forward_and_reverse) {
+  const SfntFontProgram font(
+      sample_font(cmap_table(3, 1, cmap_format4('A', 3))));
+
+  EXPECT_EQ(font.glyph_for_code_point('A'), 1);
+  EXPECT_EQ(font.glyph_for_code_point('C'), 3);
+  EXPECT_EQ(font.glyph_for_code_point('Z'), 0); // unmapped -> .notdef
+
+  EXPECT_EQ(font.code_point_for_glyph(1), U'A');
+  EXPECT_EQ(font.code_point_for_glyph(3), U'C');
+  EXPECT_FALSE(font.code_point_for_glyph(4).has_value()); // no code maps here
+}
+
+TEST(SfntFontProgram, cmap_format12_astral_plane) {
+  const SfntFontProgram font(
+      sample_font(cmap_table(3, 10, cmap_format12(0x1f600, 2))));
+
+  EXPECT_EQ(font.glyph_for_code_point(0x1f600), 1);
+  EXPECT_EQ(font.glyph_for_code_point(0x1f601), 2);
+  EXPECT_EQ(font.code_point_for_glyph(2), static_cast<char32_t>(0x1f601));
+}
+
+TEST(SfntFontProgram, symbolic_flag_from_platform_3_encoding_0) {
+  const SfntFontProgram font(
+      sample_font(cmap_table(3, 0, cmap_format4(0xf020, 3))));
+
+  EXPECT_TRUE(font.symbolic());
+  EXPECT_EQ(font.glyph_for_code_point(0xf020), 1);
+}
+
+TEST(SfntFontProgram, table_lookup) {
+  const SfntFontProgram font(
+      sample_font(cmap_table(3, 1, cmap_format4('A', 3))));
+
+  EXPECT_TRUE(font.table("cmap").has_value());
+  EXPECT_TRUE(font.table("head").has_value());
+  EXPECT_FALSE(font.table("CFF ").has_value());
+}
+
+TEST(SfntFontProgram, is_sfnt) {
+  EXPECT_TRUE(SfntFontProgram::is_sfnt(std::string("\x00\x01\x00\x00", 4)));
+  EXPECT_TRUE(SfntFontProgram::is_sfnt("OTTO"));
+  EXPECT_TRUE(SfntFontProgram::is_sfnt("true"));
+  EXPECT_TRUE(SfntFontProgram::is_sfnt("ttcf"));
+  EXPECT_FALSE(SfntFontProgram::is_sfnt("%PDF"));
+  EXPECT_FALSE(SfntFontProgram::is_sfnt("ab"));
+}
+
+TEST(SfntFontProgram, throws_on_truncated) {
+  EXPECT_THROW(SfntFontProgram(std::string("\x00\x01\x00\x00", 4)),
+               std::runtime_error);
+}

--- a/test/src/internal/font/sfnt_font.cpp
+++ b/test/src/internal/font/sfnt_font.cpp
@@ -5,13 +5,21 @@
 #include <gtest/gtest.h>
 
 #include <cstdint>
+#include <memory>
+#include <sstream>
 #include <string>
 #include <vector>
 
 using namespace odr;
-using namespace odr::internal::font;
+using namespace odr::internal::font::sfnt;
 
 namespace {
+
+/// Parse a font from its in-memory bytes (the reader consumes an
+/// `std::istream`).
+SfntFont sfnt_font_from_string(std::string bytes) {
+  return SfntFont(std::make_unique<std::istringstream>(std::move(bytes)));
+}
 
 void put16(std::string &s, const std::uint16_t v) {
   s += static_cast<char>(v >> 8);
@@ -23,7 +31,7 @@ void put32(std::string &s, const std::uint32_t v) {
   put16(s, static_cast<std::uint16_t>(v & 0xffff));
 }
 
-// A `head` table: only unitsPerEm (offset 18) and the bbox (36..42) are read.
+/// A `head` table: only unitsPerEm (offset 18) and the bbox (36..42) are read.
 std::string head_table() {
   std::string t(54, '\0');
   const auto u16 = [&](std::size_t o, std::uint16_t v) {
@@ -62,8 +70,8 @@ std::string hmtx_table(const std::vector<std::uint16_t> &advances) {
   return t;
 }
 
-// Format-4 subtable mapping the contiguous run [start, start+count) to glyph
-// ids [1, count] via a single idDelta segment, plus the required terminator.
+/// Format-4 subtable mapping the contiguous run [start, start+count) to glyph
+/// ids [1, count] via a single idDelta segment, plus the required terminator.
 std::string cmap_format4(const char16_t start, const std::uint16_t count) {
   std::string t;
   put16(t, 4);  // format
@@ -82,6 +90,36 @@ std::string cmap_format4(const char16_t start, const std::uint16_t count) {
   put16(t, 1);                                     // idDelta[1]
   put16(t, 0);                                     // idRangeOffset[0]
   put16(t, 0);                                     // idRangeOffset[1]
+  return t;
+}
+
+/// Format-4 subtable mapping [start, start+count) to glyph ids [1, count] via a
+/// non-zero idRangeOffset[0] that indexes the glyphIdArray, plus the
+/// terminator. idRangeOffset[0] == 4 points at glyphIdArray[0] (past the one
+/// remaining idRangeOffset entry), and idDelta[0] == 0 takes the glyph id
+/// straight from the array.
+std::string cmap_format4_glyph_array(const char16_t start,
+                                     const std::uint16_t count) {
+  std::string t;
+  put16(t, 4);                                             // format
+  put16(t, static_cast<std::uint16_t>(32 + 2 * count));    // length
+  put16(t, 0);                                             // language
+  put16(t, 4);                                             // segCountX2
+  put16(t, 0);                                             // searchRange
+  put16(t, 0);                                             // entrySelector
+  put16(t, 0);                                             // rangeShift
+  put16(t, static_cast<std::uint16_t>(start + count - 1)); // endCode[0]
+  put16(t, 0xffff);                                        // endCode[1]
+  put16(t, 0);                                             // reservedPad
+  put16(t, start);                                         // startCode[0]
+  put16(t, 0xffff);                                        // startCode[1]
+  put16(t, 0);                                             // idDelta[0]
+  put16(t, 1);                                             // idDelta[1]
+  put16(t, 4); // idRangeOffset[0] -> glyphIdArray[0]
+  put16(t, 0); // idRangeOffset[1]
+  for (std::uint16_t i = 0; i < count; ++i) {
+    put16(t, static_cast<std::uint16_t>(i + 1)); // glyphIdArray
+  }
   return t;
 }
 
@@ -172,7 +210,8 @@ std::string sample_font(const std::string &cmap) {
 } // namespace
 
 TEST(SfntFont, reads_facts) {
-  const SfntFont font(sample_font(cmap_table(3, 1, cmap_format4('A', 3))));
+  const SfntFont font = sfnt_font_from_string(
+      sample_font(cmap_table(3, 1, cmap_format4('A', 3))));
 
   EXPECT_EQ(font.format(), FontFormat::truetype);
   EXPECT_EQ(font.glyph_count(), 5);
@@ -188,7 +227,8 @@ TEST(SfntFont, reads_facts) {
 }
 
 TEST(SfntFont, advance_widths_with_monospace_tail) {
-  const SfntFont font(sample_font(cmap_table(3, 1, cmap_format4('A', 3))));
+  const SfntFont font = sfnt_font_from_string(
+      sample_font(cmap_table(3, 1, cmap_format4('A', 3))));
 
   EXPECT_EQ(font.advance_width(0), 500);
   EXPECT_EQ(font.advance_width(3), 222);
@@ -198,7 +238,8 @@ TEST(SfntFont, advance_widths_with_monospace_tail) {
 }
 
 TEST(SfntFont, cmap_format4_forward_and_reverse) {
-  const SfntFont font(sample_font(cmap_table(3, 1, cmap_format4('A', 3))));
+  const SfntFont font = sfnt_font_from_string(
+      sample_font(cmap_table(3, 1, cmap_format4('A', 3))));
 
   EXPECT_EQ(font.glyph_for_code_point('A'), 1);
   EXPECT_EQ(font.glyph_for_code_point('C'), 3);
@@ -209,8 +250,20 @@ TEST(SfntFont, cmap_format4_forward_and_reverse) {
   EXPECT_FALSE(font.code_point_for_glyph(4).has_value()); // no code maps here
 }
 
+TEST(SfntFont, cmap_format4_glyph_id_array) {
+  const SfntFont font = sfnt_font_from_string(
+      sample_font(cmap_table(3, 1, cmap_format4_glyph_array('A', 3))));
+
+  EXPECT_EQ(font.glyph_for_code_point('A'), 1);
+  EXPECT_EQ(font.glyph_for_code_point('B'), 2);
+  EXPECT_EQ(font.glyph_for_code_point('C'), 3);
+  EXPECT_EQ(font.glyph_for_code_point('D'), 0); // outside the segment
+
+  EXPECT_EQ(font.code_point_for_glyph(2), U'B');
+}
+
 TEST(SfntFont, cmap_format12_astral_plane) {
-  const SfntFont font(
+  const SfntFont font = sfnt_font_from_string(
       sample_font(cmap_table(3, 10, cmap_format12(0x1f600, 2))));
 
   EXPECT_EQ(font.glyph_for_code_point(0x1f600), 1);
@@ -219,14 +272,16 @@ TEST(SfntFont, cmap_format12_astral_plane) {
 }
 
 TEST(SfntFont, symbolic_flag_from_platform_3_encoding_0) {
-  const SfntFont font(sample_font(cmap_table(3, 0, cmap_format4(0xf020, 3))));
+  const SfntFont font = sfnt_font_from_string(
+      sample_font(cmap_table(3, 0, cmap_format4(0xf020, 3))));
 
   EXPECT_TRUE(font.symbolic());
   EXPECT_EQ(font.glyph_for_code_point(0xf020), 1);
 }
 
 TEST(SfntFont, table_lookup) {
-  const SfntFont font(sample_font(cmap_table(3, 1, cmap_format4('A', 3))));
+  const SfntFont font = sfnt_font_from_string(
+      sample_font(cmap_table(3, 1, cmap_format4('A', 3))));
 
   EXPECT_TRUE(font.table("cmap").has_value());
   EXPECT_TRUE(font.table("head").has_value());
@@ -243,6 +298,6 @@ TEST(SfntFont, is_sfnt) {
 }
 
 TEST(SfntFont, throws_on_truncated) {
-  EXPECT_THROW(SfntFont(std::string("\x00\x01\x00\x00", 4)),
+  EXPECT_THROW(sfnt_font_from_string(std::string("\x00\x01\x00\x00", 4)),
                std::runtime_error);
 }

--- a/test/src/internal/font/sfnt_font.cpp
+++ b/test/src/internal/font/sfnt_font.cpp
@@ -10,12 +10,12 @@ using namespace odr::internal::font;
 
 namespace {
 
-void put16(std::string &s, std::uint16_t v) {
+void put16(std::string &s, const std::uint16_t v) {
   s += static_cast<char>(v >> 8);
   s += static_cast<char>(v & 0xff);
 }
 
-void put32(std::string &s, std::uint32_t v) {
+void put32(std::string &s, const std::uint32_t v) {
   put16(s, static_cast<std::uint16_t>(v >> 16));
   put16(s, static_cast<std::uint16_t>(v & 0xffff));
 }
@@ -35,7 +35,7 @@ std::string head_table() {
   return t;
 }
 
-std::string maxp_table(std::uint16_t glyphs) {
+std::string maxp_table(const std::uint16_t glyphs) {
   std::string t;
   put32(t, 0x00010000); // version 1.0
   put16(t, glyphs);
@@ -43,7 +43,7 @@ std::string maxp_table(std::uint16_t glyphs) {
   return t;
 }
 
-std::string hhea_table(std::uint16_t number_of_h_metrics) {
+std::string hhea_table(const std::uint16_t number_of_h_metrics) {
   std::string t(36, '\0');
   t[34] = static_cast<char>(number_of_h_metrics >> 8);
   t[35] = static_cast<char>(number_of_h_metrics & 0xff);
@@ -61,7 +61,7 @@ std::string hmtx_table(const std::vector<std::uint16_t> &advances) {
 
 // Format-4 subtable mapping the contiguous run [start, start+count) to glyph
 // ids [1, count] via a single idDelta segment, plus the required terminator.
-std::string cmap_format4(char16_t start, std::uint16_t count) {
+std::string cmap_format4(const char16_t start, const std::uint16_t count) {
   std::string t;
   put16(t, 4);  // format
   put16(t, 32); // length
@@ -83,7 +83,7 @@ std::string cmap_format4(char16_t start, std::uint16_t count) {
 }
 
 // Format-12 subtable: one group mapping [start, start+count) to [1, count].
-std::string cmap_format12(char32_t start, std::uint32_t count) {
+std::string cmap_format12(const char32_t start, const std::uint32_t count) {
   std::string t;
   put16(t, 12); // format
   put16(t, 0);  // reserved
@@ -96,7 +96,8 @@ std::string cmap_format12(char32_t start, std::uint32_t count) {
   return t;
 }
 
-std::string cmap_table(std::uint16_t platform, std::uint16_t encoding,
+std::string cmap_table(const std::uint16_t platform,
+                       const std::uint16_t encoding,
                        const std::string &subtable) {
   std::string t;
   put16(t, 0); // version


### PR DESCRIPTION
First piece of **stage 3 (fonts in HTML)**. Stacked on `main`.

Adds an internal `font/` module exposing a font program's **facts** — the read-only surface every later sub-stage reuses — parsed directly from a byte stream (the "IR for facts" architecture from the roadmap).

### What's here
- **`abstract::Font`** (`internal/abstract/font.hpp`) — abstract facts interface: format, name, glyph count, units-per-em, symbolic flag, bbox, advance width, and the forward (code point → glyph) / reverse (glyph → code point) cmap views.
- **`SfntFont`** (`internal/font/sfnt_font.{hpp,cpp}`) — parses an SFNT-wrapped font (TrueType `glyf` / OpenType `OTTO`, TTC via the first member) from a `std::istream`, seeking per table: table directory + `head`/`maxp`/`hhea`/`hmtx`/`cmap`/`name`. cmap subtable formats 0/4/6/12 with Unicode-preferring subtable selection. The **reverse map** here is the embedded-font reverse map stage 1 deferred. Structural errors throw; missing optional tables are tolerated.
- **`SfntParser`** (`internal/font/sfnt_parser.{hpp,cpp}`) — the stream cursor: big-endian `u8`/`u16`/`u32` reads, tag/bbox/name/cmap-record decoders, and UTF-16BE/Latin-1 `name` decoding, all with bounds-checked reads.
- **`util::byte_stream` / `util::byte`** — stream-oriented big-/little-endian integer readers (`read_u16_be`, …) and `from_big_endian`/`from_little_endian` range helpers backing the parser.

### Not here (later in the stack)
- OTF wrap + uniform PUA re-encode + table-directory/checksum rebuild → **3.1**
- `FontFile` `DecodedFile` + magic + specimen-page HTML → **3.2**
- Wiring into PDF `@font-face` + the reverse map into extraction → **3.3**

The roadmap commit also lands here: stage 3 fleshed out into sub-stages 3.0–3.6 in `pdf/AGENTS.md`.

### Tests
9 unit tests over inline synthetic SFNTs: facts, the monospace advance tail, format-4 forward/reverse (both `idDelta` and `idRangeOffset`/glyphIdArray paths), format-12 astral-plane, the symbol-cmap flag, table lookup, magic, and the truncated-font throw. Builds clean (clang-tidy warnings-as-errors).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
