### PR TITLE
PDF stage 3.2: FontFile as a DecodedFile + specimen-page HTML

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -129,6 +129,7 @@ set(ODR_SOURCE_FILES
         "src/odr/internal/html/document_style.cpp"
         "src/odr/internal/html/document_element.cpp"
         "src/odr/internal/html/filesystem.cpp"
+        "src/odr/internal/html/font_file.cpp"
         "src/odr/internal/html/html_service.cpp"
         "src/odr/internal/html/html_writer.cpp"
         "src/odr/internal/html/image_file.cpp"
@@ -200,6 +201,7 @@ set(ODR_SOURCE_FILES
         "src/odr/internal/font/sfnt_font.cpp"
         "src/odr/internal/font/sfnt_parser.cpp"
         "src/odr/internal/font/sfnt_transform.cpp"
+        "src/odr/internal/font/font_file.cpp"
 
         "src/odr/internal/svm/svm_file.cpp"
         "src/odr/internal/svm/svm_format.cpp"

--- a/src/odr/exceptions.cpp
+++ b/src/odr/exceptions.cpp
@@ -69,6 +69,8 @@ NoOfficeOpenXmlFile::NoOfficeOpenXmlFile()
 
 NoPdfFile::NoPdfFile() : std::runtime_error("not a pdf file") {}
 
+NoFontFile::NoFontFile() : std::runtime_error("not a font file") {}
+
 NoLegacyMicrosoftFile::NoLegacyMicrosoftFile()
     : std::runtime_error("not a legacy microsoft office file") {}
 

--- a/src/odr/exceptions.hpp
+++ b/src/odr/exceptions.hpp
@@ -127,6 +127,11 @@ struct NoPdfFile final : std::runtime_error {
   NoPdfFile();
 };
 
+/// @brief No font file exception
+struct NoFontFile final : std::runtime_error {
+  NoFontFile();
+};
+
 /// @brief No legacy Microsoft Office file
 struct NoLegacyMicrosoftFile final : std::runtime_error {
   NoLegacyMicrosoftFile();

--- a/src/odr/file.cpp
+++ b/src/odr/file.cpp
@@ -166,6 +166,11 @@ bool DecodedFile::is_pdf_file() const {
          nullptr;
 }
 
+bool DecodedFile::is_font_file() const {
+  return std::dynamic_pointer_cast<internal::abstract::FontFile>(m_impl) !=
+         nullptr;
+}
+
 TextFile DecodedFile::as_text_file() const {
   if (const std::shared_ptr text_file =
           std::dynamic_pointer_cast<internal::abstract::TextFile>(m_impl);
@@ -209,6 +214,15 @@ PdfFile DecodedFile::as_pdf_file() const {
     return PdfFile(pdf_file);
   }
   throw NoPdfFile();
+}
+
+FontFile DecodedFile::as_font_file() const {
+  if (const std::shared_ptr font_file =
+          std::dynamic_pointer_cast<internal::abstract::FontFile>(m_impl);
+      font_file != nullptr) {
+    return FontFile(font_file);
+  }
+  throw NoFontFile();
 }
 
 TextFile::TextFile(std::shared_ptr<internal::abstract::TextFile> impl)
@@ -280,6 +294,17 @@ PdfFile PdfFile::decrypt(const std::string &password) const {
 }
 
 std::shared_ptr<internal::abstract::PdfFile> PdfFile::impl() const {
+  return m_impl;
+}
+
+FontFile::FontFile(std::shared_ptr<internal::abstract::FontFile> impl)
+    : DecodedFile(impl), m_impl{std::move(impl)} {}
+
+std::unique_ptr<std::istream> FontFile::stream() const {
+  return m_impl->file()->stream();
+}
+
+std::shared_ptr<internal::abstract::FontFile> FontFile::impl() const {
   return m_impl;
 }
 

--- a/src/odr/file.hpp
+++ b/src/odr/file.hpp
@@ -16,6 +16,7 @@ class ImageFile;
 class ArchiveFile;
 class DocumentFile;
 class PdfFile;
+class FontFile;
 } // namespace odr::internal::abstract
 
 namespace odr {
@@ -24,6 +25,7 @@ class ImageFile;
 class ArchiveFile;
 class DocumentFile;
 class PdfFile;
+class FontFile;
 
 class Archive;
 class Document;
@@ -78,6 +80,11 @@ enum class FileType {
   bitmap_image_file,
 
   starview_metafile,
+
+  // https://en.wikipedia.org/wiki/TrueType
+  truetype_font,
+  // https://en.wikipedia.org/wiki/OpenType
+  opentype_font,
 };
 
 /// @brief Collection of file categories.
@@ -87,6 +94,7 @@ enum class FileCategory {
   image,
   archive,
   document,
+  font,
 };
 
 /// @brief Collection of file locations.
@@ -215,12 +223,14 @@ public:
   [[nodiscard]] bool is_archive_file() const;
   [[nodiscard]] bool is_document_file() const;
   [[nodiscard]] bool is_pdf_file() const;
+  [[nodiscard]] bool is_font_file() const;
 
   [[nodiscard]] TextFile as_text_file() const;
   [[nodiscard]] ImageFile as_image_file() const;
   [[nodiscard]] ArchiveFile as_archive_file() const;
   [[nodiscard]] DocumentFile as_document_file() const;
   [[nodiscard]] PdfFile as_pdf_file() const;
+  [[nodiscard]] FontFile as_font_file() const;
 
 protected:
   std::shared_ptr<internal::abstract::DecodedFile> m_impl;
@@ -296,6 +306,19 @@ public:
 
 private:
   std::shared_ptr<internal::abstract::PdfFile> m_impl;
+};
+
+/// @brief Represents a font file.
+class FontFile final : public DecodedFile {
+public:
+  explicit FontFile(std::shared_ptr<internal::abstract::FontFile>);
+
+  [[nodiscard]] std::unique_ptr<std::istream> stream() const;
+
+  [[nodiscard]] std::shared_ptr<internal::abstract::FontFile> impl() const;
+
+private:
+  std::shared_ptr<internal::abstract::FontFile> m_impl;
 };
 
 } // namespace odr

--- a/src/odr/html.cpp
+++ b/src/odr/html.cpp
@@ -11,6 +11,7 @@
 #include <odr/internal/common/path.hpp>
 #include <odr/internal/html/document.hpp>
 #include <odr/internal/html/filesystem.hpp>
+#include <odr/internal/html/font_file.hpp>
 #include <odr/internal/html/html_writer.hpp>
 #include <odr/internal/html/image_file.hpp>
 #include <odr/internal/html/pdf2htmlex_wrapper.hpp>
@@ -231,6 +232,10 @@ HtmlService html::translate(const DecodedFile &file,
   if (file.is_pdf_file()) {
     return translate(file.as_pdf_file(), cache_path, config, std::move(logger));
   }
+  if (file.is_font_file()) {
+    return translate(file.as_font_file(), cache_path, config,
+                     std::move(logger));
+  }
 
   throw UnsupportedFileType(file.file_type());
 }
@@ -326,6 +331,15 @@ HtmlService html::translate(const PdfFile &pdf_file,
 
   return internal::html::create_pdf_service(pdf_file, cache_path, config,
                                             std::move(logger));
+}
+
+HtmlService html::translate(const FontFile &font_file,
+                            const std::string &cache_path,
+                            const HtmlConfig &config,
+                            std::shared_ptr<Logger> logger) {
+  std::filesystem::create_directories(cache_path);
+  return internal::html::create_font_service(font_file, cache_path, config,
+                                             std::move(logger));
 }
 
 HtmlService html::translate(const Filesystem &filesystem,

--- a/src/odr/html.hpp
+++ b/src/odr/html.hpp
@@ -260,6 +260,17 @@ HtmlService translate(const PdfFile &pdf_file, const std::string &cache_path,
                       const HtmlConfig &config,
                       std::shared_ptr<Logger> logger = Logger::create_null());
 
+/// @brief Translates a font file to HTML (a specimen page).
+///
+/// @param font_file Font file to translate.
+/// @param cache_path Directory path for temporary output.
+/// @param config Configuration for the HTML output.
+/// @param logger Logger to use for logging.
+/// @return HTML output.
+HtmlService translate(const FontFile &font_file, const std::string &cache_path,
+                      const HtmlConfig &config,
+                      std::shared_ptr<Logger> logger = Logger::create_null());
+
 /// @brief Translates a filesystem to HTML.
 ///
 /// @param filesystem Filesystem to translate.

--- a/src/odr/internal/abstract/file.hpp
+++ b/src/odr/internal/abstract/file.hpp
@@ -15,6 +15,7 @@ namespace odr::internal::abstract {
 class Image;
 class Archive;
 class Document;
+class Font;
 
 class File {
 public:
@@ -103,6 +104,17 @@ public:
   [[nodiscard]] std::string_view mimetype() const noexcept final {
     return "application/pdf";
   }
+};
+
+class FontFile : public DecodedFile {
+public:
+  [[nodiscard]] FileCategory file_category() const noexcept final {
+    return FileCategory::font;
+  }
+
+  /// The parsed font program, exposing the stage-3 facts and the bytes to
+  /// re-encode for `@font-face`.
+  [[nodiscard]] virtual std::shared_ptr<Font> font_program() const = 0;
 };
 
 } // namespace odr::internal::abstract

--- a/src/odr/internal/font/font_file.cpp
+++ b/src/odr/internal/font/font_file.cpp
@@ -1,0 +1,42 @@
+#include <odr/internal/font/font_file.hpp>
+
+#include <odr/internal/abstract/font.hpp>
+#include <odr/internal/font/sfnt_font.hpp>
+
+#include <utility>
+
+namespace odr::internal::font {
+
+FontFile::FontFile(std::shared_ptr<abstract::File> file,
+                   const FileType file_type)
+    : m_file{std::move(file)}, m_file_type{file_type} {
+  // Parse eagerly: a parse failure is how detection rejects a non-font, so the
+  // open-strategy try/catch can fall through.
+  m_program = std::make_shared<sfnt::SfntFont>(m_file->stream());
+}
+
+std::shared_ptr<abstract::File> FontFile::file() const noexcept {
+  return m_file;
+}
+
+DecoderEngine FontFile::decoder_engine() const noexcept {
+  return DecoderEngine::odr;
+}
+
+FileType FontFile::file_type() const noexcept { return m_file_type; }
+
+std::string_view FontFile::mimetype() const noexcept {
+  return m_file_type == FileType::opentype_font ? "font/otf" : "font/ttf";
+}
+
+FileMeta FontFile::file_meta() const noexcept {
+  return {file_type(), mimetype(), false, std::nullopt};
+}
+
+bool FontFile::is_decodable() const noexcept { return true; }
+
+std::shared_ptr<abstract::Font> FontFile::font_program() const {
+  return m_program;
+}
+
+} // namespace odr::internal::font

--- a/src/odr/internal/font/font_file.hpp
+++ b/src/odr/internal/font/font_file.hpp
@@ -1,0 +1,38 @@
+#pragma once
+
+#include <odr/file.hpp>
+#include <odr/internal/abstract/file.hpp>
+
+#include <memory>
+
+namespace odr::internal::abstract {
+class Font;
+}
+
+namespace odr::internal::font {
+
+/// @brief A standalone font file (`.ttf`/`.otf`) as a `DecodedFile`, so a font
+/// can be opened and rendered (specimen page) on its own — the standalone-first
+/// deliverable of stage 3 (decision 2026-06-19).
+class FontFile final : public abstract::FontFile {
+public:
+  FontFile(std::shared_ptr<abstract::File> file, FileType file_type);
+
+  [[nodiscard]] std::shared_ptr<abstract::File> file() const noexcept override;
+
+  [[nodiscard]] DecoderEngine decoder_engine() const noexcept override;
+  [[nodiscard]] FileType file_type() const noexcept override;
+  [[nodiscard]] std::string_view mimetype() const noexcept override;
+  [[nodiscard]] FileMeta file_meta() const noexcept override;
+
+  [[nodiscard]] bool is_decodable() const noexcept override;
+
+  [[nodiscard]] std::shared_ptr<abstract::Font> font_program() const override;
+
+private:
+  std::shared_ptr<abstract::File> m_file;
+  FileType m_file_type;
+  std::shared_ptr<abstract::Font> m_program;
+};
+
+} // namespace odr::internal::font

--- a/src/odr/internal/html/font_file.cpp
+++ b/src/odr/internal/html/font_file.cpp
@@ -1,0 +1,188 @@
+#include <odr/internal/html/font_file.hpp>
+
+#include <odr/exceptions.hpp>
+#include <odr/file.hpp>
+#include <odr/html.hpp>
+
+#include <odr/internal/abstract/file.hpp>
+#include <odr/internal/abstract/font.hpp>
+#include <odr/internal/font/otf_writer.hpp>
+#include <odr/internal/font/sfnt_font.hpp>
+#include <odr/internal/html/common.hpp>
+#include <odr/internal/html/html_service.hpp>
+#include <odr/internal/html/html_writer.hpp>
+
+#include <algorithm>
+#include <memory>
+#include <string>
+
+namespace odr::internal::html {
+namespace {
+
+constexpr std::uint16_t max_grid_glyphs = 4096;
+
+std::string escape(const std::string &text) {
+  std::string out;
+  for (const char c : text) {
+    switch (c) {
+    case '&':
+      out += "&amp;";
+      break;
+    case '<':
+      out += "&lt;";
+      break;
+    case '>':
+      out += "&gt;";
+      break;
+    default:
+      out += c;
+    }
+  }
+  return out;
+}
+
+class HtmlServiceImpl final : public HtmlService {
+public:
+  HtmlServiceImpl(FontFile font_file, HtmlConfig config,
+                  std::shared_ptr<Logger> logger)
+      : HtmlService(std::move(config), std::move(logger)),
+        m_font_file{std::move(font_file)} {
+    m_views.emplace_back(
+        std::make_shared<HtmlView>(*this, "font", 0, "font.html"));
+  }
+
+  void warmup() const override {}
+
+  [[nodiscard]] const HtmlViews &list_views() const override { return m_views; }
+
+  [[nodiscard]] bool exists(const std::string &path) const override {
+    return path == "font.html";
+  }
+
+  [[nodiscard]] std::string mimetype(const std::string &path) const override {
+    if (path == "font.html") {
+      return "text/html";
+    }
+    throw FileNotFound("Unknown path: " + path);
+  }
+
+  void write(const std::string &path, std::ostream &out) const override {
+    if (path == "font.html") {
+      HtmlWriter writer(out, config());
+      write_font(writer);
+      return;
+    }
+    throw FileNotFound("Unknown path: " + path);
+  }
+
+  HtmlResources write_html(const std::string &path,
+                           HtmlWriter &out) const override {
+    if (path == "font.html") {
+      return write_font(out);
+    }
+    throw FileNotFound("Unknown path: " + path);
+  }
+
+  HtmlResources write_font(HtmlWriter &out) const {
+    HtmlResources resources;
+
+    const auto program = std::dynamic_pointer_cast<font::sfnt::SfntFont>(
+        m_font_file.impl()->font_program());
+
+    out.write_begin();
+    out.write_header_begin();
+    out.write_header_charset("UTF-8");
+    out.write_header_target("_blank");
+    out.write_header_title("odr");
+    out.write_header_viewport(
+        "width=device-width,initial-scale=1.0,user-scalable=yes");
+    out.write_header_end();
+
+    out.write_body_begin();
+
+    if (program == nullptr) {
+      out.out() << "<p>unsupported font</p>";
+      out.write_body_end();
+      out.write_end();
+      return resources;
+    }
+
+    // Re-encode for the browser and embed it; every glyph is then addressable
+    // at its deterministic PUA code point.
+    std::string reencoded;
+    try {
+      reencoded = font::reencode_to_pua(*program);
+    } catch (...) {
+      out.out() << "<p>font has too many glyphs to display</p>";
+      out.write_body_end();
+      out.write_end();
+      return resources;
+    }
+    const std::string mime = m_font_file.file_type() == FileType::opentype_font
+                                 ? "font/otf"
+                                 : "font/ttf";
+    const std::string url = file_to_url(reencoded, mime);
+
+    out.out() << "<style>";
+    out.out() << "@font-face{font-family:'odr-specimen';src:url(" << url
+              << ");}";
+    out.out() << "body{font-family:sans-serif;}";
+    out.out() << ".grid{display:flex;flex-wrap:wrap;}";
+    out.out() << ".cell{width:4em;height:4em;border:1px solid #ddd;margin:2px;"
+                 "display:flex;flex-direction:column;align-items:center;"
+                 "justify-content:center;}";
+    out.out()
+        << ".glyph{font-family:'odr-specimen';font-size:2em;line-height:1;}";
+    out.out() << ".gid{font-size:.6em;color:#888;}";
+    out.out() << "</style>";
+
+    out.out() << "<h1>" << escape(program->name()) << "</h1>";
+    out.out() << "<p>glyphs: " << program->glyph_count()
+              << " &middot; units/em: " << program->units_per_em()
+              << " &middot; format: "
+              << (program->format() == FontFormat::opentype_cff ? "OpenType/CFF"
+                                                                : "TrueType")
+              << (program->symbolic() ? " &middot; symbolic" : "") << "</p>";
+
+    const std::uint16_t shown =
+        std::min<std::uint16_t>(program->glyph_count(), max_grid_glyphs);
+    out.out() << "<div class=\"grid\">";
+    for (std::uint16_t gid = 1; gid < shown; ++gid) {
+      out.out() << "<div class=\"cell\"><span class=\"glyph\">&#x" << std::hex
+                << static_cast<std::uint32_t>(font::pua_code_point(gid))
+                << std::dec << ";</span><span class=\"gid\">" << gid;
+      if (const auto cp = program->code_point_for_glyph(gid)) {
+        out.out() << " U+" << std::hex << std::uppercase
+                  << static_cast<std::uint32_t>(*cp) << std::nouppercase
+                  << std::dec;
+      }
+      out.out() << "</span></div>";
+    }
+    out.out() << "</div>";
+
+    if (program->glyph_count() > shown) {
+      out.out() << "<p>(showing first " << shown << " glyphs)</p>";
+    }
+
+    out.write_body_end();
+    out.write_end();
+
+    return resources;
+  }
+
+protected:
+  FontFile m_font_file;
+  HtmlViews m_views;
+};
+
+} // namespace
+
+odr::HtmlService create_font_service(const FontFile &font_file,
+                                     const std::string & /*cache_path*/,
+                                     HtmlConfig config,
+                                     std::shared_ptr<Logger> logger) {
+  return odr::HtmlService(std::make_unique<HtmlServiceImpl>(
+      font_file, std::move(config), std::move(logger)));
+}
+
+} // namespace odr::internal::html

--- a/src/odr/internal/html/font_file.cpp
+++ b/src/odr/internal/html/font_file.cpp
@@ -6,14 +6,15 @@
 
 #include <odr/internal/abstract/file.hpp>
 #include <odr/internal/abstract/font.hpp>
-#include <odr/internal/font/otf_writer.hpp>
 #include <odr/internal/font/sfnt_font.hpp>
+#include <odr/internal/font/sfnt_transform.hpp>
 #include <odr/internal/html/common.hpp>
 #include <odr/internal/html/html_service.hpp>
 #include <odr/internal/html/html_writer.hpp>
 
 #include <algorithm>
 #include <memory>
+#include <sstream>
 #include <string>
 
 namespace odr::internal::html {
@@ -111,7 +112,14 @@ public:
     // at its deterministic PUA code point.
     std::string reencoded;
     try {
-      reencoded = font::reencode_to_pua(*program);
+      // Re-encode a fresh parse: reencode_to_pua mutates the cmap in place, and
+      // the grid below still reads each glyph's original Unicode from
+      // `program`.
+      font::sfnt::SfntFont embed(m_font_file.impl()->file()->stream());
+      font::reencode_to_pua(embed);
+      std::ostringstream sfnt_out;
+      embed.write(sfnt_out);
+      reencoded = sfnt_out.str();
     } catch (...) {
       out.out() << "<p>font has too many glyphs to display</p>";
       out.write_body_end();

--- a/src/odr/internal/html/font_file.hpp
+++ b/src/odr/internal/html/font_file.hpp
@@ -1,0 +1,24 @@
+#pragma once
+
+#include <memory>
+#include <string>
+
+namespace odr {
+class FontFile;
+struct HtmlConfig;
+class HtmlService;
+class Logger;
+} // namespace odr
+
+namespace odr::internal::html {
+
+/// @brief A specimen-page HTML service for a standalone font file: a
+/// name/metrics header plus a glyph grid showing *every* glyph (including ones
+/// the original `cmap` never reached), the font served via `@font-face` after
+/// the uniform PUA re-encode.
+HtmlService create_font_service(const FontFile &font_file,
+                                const std::string &cache_path,
+                                HtmlConfig config,
+                                std::shared_ptr<Logger> logger);
+
+} // namespace odr::internal::html

--- a/src/odr/internal/magic.cpp
+++ b/src/odr/internal/magic.cpp
@@ -66,6 +66,14 @@ FileType magic::file_type(const std::string &magic) {
   if (match_magic(magic, "FF 57 50 43")) {
     return FileType::word_perfect;
   }
+  if (match_magic(magic, "4F 54 54 4F")) { // 'OTTO' — OpenType with CFF
+    return FileType::opentype_font;
+  }
+  if (match_magic(magic, "00 01 00 00") || // TrueType outlines (sfnt 1.0)
+      match_magic(magic, "74 72 75 65") || // 'true'
+      match_magic(magic, "74 74 63 66")) { // 'ttcf' — TrueType Collection
+    return FileType::truetype_font;
+  }
   return FileType::unknown;
 }
 

--- a/src/odr/internal/open_strategy.cpp
+++ b/src/odr/internal/open_strategy.cpp
@@ -10,6 +10,7 @@
 #include <odr/internal/common/file.hpp>
 #include <odr/internal/common/image_file.hpp>
 #include <odr/internal/csv/csv_file.hpp>
+#include <odr/internal/font/font_file.hpp>
 #include <odr/internal/json/json_file.hpp>
 #include <odr/internal/magic.hpp>
 #include <odr/internal/odf/odf_file.hpp>
@@ -242,6 +243,11 @@ open_strategy::open_file(const std::shared_ptr<abstract::File> &file,
     ODR_VERBOSE(logger, "open as svm");
     return std::make_unique<svm::SvmFile>(file);
   }
+  if (file_type == FileType::truetype_font ||
+      file_type == FileType::opentype_font) {
+    ODR_VERBOSE(logger, "open as font");
+    return std::make_unique<font::FontFile>(file, file_type);
+  }
   if (file_type == FileType::unknown) {
     ODR_VERBOSE(logger, "handle unknown file type");
 
@@ -437,6 +443,22 @@ open_strategy::open_file(const std::shared_ptr<abstract::File> &file,
       throw NoSvmFile();
     }
     ODR_ERROR(logger, "unsupported decoder engine for svm "
+                          << decoder_engine_to_string(with));
+    throw UnsupportedDecoderEngine(with);
+  }
+
+  if (as == FileType::truetype_font || as == FileType::opentype_font) {
+    ODR_VERBOSE(logger, "open as font");
+    if (with == DecoderEngine::odr) {
+      ODR_VERBOSE(logger, "using odr engine");
+      try {
+        return std::make_unique<font::FontFile>(file, as);
+      } catch (...) {
+        ODR_VERBOSE(logger, "failed to open as font with odr engine");
+      }
+      throw NoFontFile();
+    }
+    ODR_ERROR(logger, "unsupported decoder engine for font "
                           << decoder_engine_to_string(with));
     throw UnsupportedDecoderEngine(with);
   }

--- a/src/odr/odr.cpp
+++ b/src/odr/odr.cpp
@@ -126,6 +126,9 @@ odr::file_category_by_file_type(const FileType type) noexcept {
   case FileType::javascript_object_notation:
   case FileType::markdown:
     return FileCategory::text;
+  case FileType::truetype_font:
+  case FileType::opentype_font:
+    return FileCategory::font;
   default:
     return FileCategory::unknown;
   }
@@ -203,6 +206,10 @@ std::string odr::file_type_to_string(const FileType type) {
     return "bmp";
   case FileType::starview_metafile:
     return "svm";
+  case FileType::truetype_font:
+    return "ttf";
+  case FileType::opentype_font:
+    return "otf";
   case FileType::text_file:
     return "txt";
   case FileType::comma_separated_values:
@@ -226,6 +233,8 @@ std::string odr::file_category_to_string(const FileCategory type) {
     return "image";
   case FileCategory::text:
     return "text";
+  case FileCategory::font:
+    return "font";
   default:
     return "unnamed";
   }
@@ -381,6 +390,12 @@ std::string_view odr::mimetype_by_file_type(const FileType type) {
   }
   if (type == FileType::bitmap_image_file) {
     return "image/bmp";
+  }
+  if (type == FileType::truetype_font) {
+    return "font/ttf";
+  }
+  if (type == FileType::opentype_font) {
+    return "font/otf";
   }
   throw UnsupportedFileType(type);
 }

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -55,6 +55,7 @@ add_executable(odr_test
 
         "src/internal/font/sfnt_font.cpp"
         "src/internal/font/sfnt_transform.cpp"
+        "src/internal/font/font_file.cpp"
 
         "src/internal/svm/svm_test.cpp"
 

--- a/test/src/internal/font/font_file.cpp
+++ b/test/src/internal/font/font_file.cpp
@@ -5,7 +5,7 @@
 
 #include <odr/internal/abstract/font.hpp>
 #include <odr/internal/common/file.hpp>
-#include <odr/internal/font/otf_writer.hpp>
+#include <odr/internal/font/sfnt_transform.hpp>
 #include <odr/internal/magic.hpp>
 
 #include <gtest/gtest.h>
@@ -15,6 +15,7 @@
 #include <memory>
 #include <sstream>
 #include <string>
+#include <utility>
 #include <vector>
 
 using namespace odr;
@@ -112,13 +113,22 @@ std::string name_table(const std::string &ascii) {
   return t;
 }
 
+std::string
+build_sfnt_bytes(std::uint32_t version,
+                 std::vector<std::pair<std::string, std::string>> tables) {
+  std::ostringstream out;
+  build_sfnt(out, version, std::move(tables));
+  return out.str();
+}
+
 std::string sample_ttf() {
-  return build_sfnt(0x00010000, {{"cmap", cmap_table()},
-                                 {"head", head_table()},
-                                 {"hhea", hhea_table(4)},
-                                 {"hmtx", hmtx_table({500, 600, 700, 800})},
-                                 {"maxp", maxp_table(4)},
-                                 {"name", name_table("TestFont")}});
+  return build_sfnt_bytes(0x00010000,
+                          {{"cmap", cmap_table()},
+                           {"head", head_table()},
+                           {"hhea", hhea_table(4)},
+                           {"hmtx", hmtx_table({500, 600, 700, 800})},
+                           {"maxp", maxp_table(4)},
+                           {"name", name_table("TestFont")}});
 }
 
 } // namespace

--- a/test/src/internal/font/font_file.cpp
+++ b/test/src/internal/font/font_file.cpp
@@ -1,0 +1,172 @@
+#include <odr/internal/font/font_file.hpp>
+
+#include <odr/file.hpp>
+#include <odr/html.hpp>
+
+#include <odr/internal/abstract/font.hpp>
+#include <odr/internal/common/file.hpp>
+#include <odr/internal/font/otf_writer.hpp>
+#include <odr/internal/magic.hpp>
+
+#include <gtest/gtest.h>
+
+#include <cstdint>
+#include <filesystem>
+#include <memory>
+#include <sstream>
+#include <string>
+#include <vector>
+
+using namespace odr;
+using namespace odr::internal;
+using namespace odr::internal::font;
+
+namespace {
+
+void put16(std::string &s, std::uint16_t v) {
+  s += static_cast<char>(v >> 8);
+  s += static_cast<char>(v & 0xff);
+}
+
+void put32(std::string &s, std::uint32_t v) {
+  put16(s, static_cast<std::uint16_t>(v >> 16));
+  put16(s, static_cast<std::uint16_t>(v & 0xffff));
+}
+
+std::string head_table() {
+  std::string t(54, '\0');
+  t[18] = 0x03; // unitsPerEm = 1000
+  t[19] = static_cast<char>(0xe8);
+  return t;
+}
+
+std::string maxp_table(std::uint16_t glyphs) {
+  std::string t;
+  put32(t, 0x00010000);
+  put16(t, glyphs);
+  t.resize(32, '\0');
+  return t;
+}
+
+std::string hhea_table(std::uint16_t metrics) {
+  std::string t(36, '\0');
+  t[34] = static_cast<char>(metrics >> 8);
+  t[35] = static_cast<char>(metrics & 0xff);
+  return t;
+}
+
+std::string hmtx_table(const std::vector<std::uint16_t> &advances) {
+  std::string t;
+  for (const std::uint16_t a : advances) {
+    put16(t, a);
+    put16(t, 0);
+  }
+  return t;
+}
+
+std::string cmap_table() {
+  std::string sub;
+  put16(sub, 4);
+  put16(sub, 32);
+  put16(sub, 0);
+  put16(sub, 4);
+  put16(sub, 0);
+  put16(sub, 0);
+  put16(sub, 0);
+  put16(sub, 'C');    // endCode[0]
+  put16(sub, 0xffff); // endCode[1]
+  put16(sub, 0);
+  put16(sub, 'A');                                 // startCode[0]
+  put16(sub, 0xffff);                              // startCode[1]
+  put16(sub, static_cast<std::uint16_t>(1 - 'A')); // idDelta[0]: A->1,B->2,C->3
+  put16(sub, 1);                                   // idDelta[1]
+  put16(sub, 0);
+  put16(sub, 0);
+
+  std::string t;
+  put16(t, 0);
+  put16(t, 1);
+  put16(t, 3);
+  put16(t, 1);
+  put32(t, 12);
+  t += sub;
+  return t;
+}
+
+std::string name_table(const std::string &ascii) {
+  std::string strings;
+  for (const char c : ascii) {
+    put16(strings, static_cast<std::uint8_t>(c));
+  }
+  std::string t;
+  put16(t, 0);
+  put16(t, 1);
+  put16(t, 18);
+  put16(t, 3);
+  put16(t, 1);
+  put16(t, 0x409);
+  put16(t, 6);
+  put16(t, static_cast<std::uint16_t>(strings.size()));
+  put16(t, 0);
+  t += strings;
+  return t;
+}
+
+std::string sample_ttf() {
+  return build_sfnt(0x00010000, {{"cmap", cmap_table()},
+                                 {"head", head_table()},
+                                 {"hhea", hhea_table(4)},
+                                 {"hmtx", hmtx_table({500, 600, 700, 800})},
+                                 {"maxp", maxp_table(4)},
+                                 {"name", name_table("TestFont")}});
+}
+
+} // namespace
+
+TEST(FontFileTest, magic_detects_sfnt_flavors) {
+  EXPECT_EQ(magic::file_type(sample_ttf()), FileType::truetype_font);
+  EXPECT_EQ(magic::file_type(std::string("OTTO\0\0\0\0\0\0\0\0", 12)),
+            FileType::opentype_font);
+  EXPECT_EQ(magic::file_type(std::string("ttcf\0\0\0\0\0\0\0\0", 12)),
+            FileType::truetype_font);
+}
+
+TEST(FontFileTest, font_file_facts) {
+  const font::FontFile font_file(std::make_shared<MemoryFile>(sample_ttf()),
+                                 FileType::truetype_font);
+
+  EXPECT_EQ(font_file.file_type(), FileType::truetype_font);
+  EXPECT_EQ(font_file.file_category(), FileCategory::font);
+  EXPECT_TRUE(font_file.is_decodable());
+
+  const auto program = font_file.font_program();
+  ASSERT_NE(program, nullptr);
+  EXPECT_EQ(program->name(), "TestFont");
+  EXPECT_EQ(program->glyph_count(), 4);
+  EXPECT_EQ(program->glyph_for_code_point('A'), 1);
+}
+
+TEST(FontFileTest, specimen_page_embeds_font_and_glyph_grid) {
+  const odr::FontFile font_file(std::make_shared<font::FontFile>(
+      std::make_shared<MemoryFile>(sample_ttf()), FileType::truetype_font));
+
+  const std::string cache_path =
+      (std::filesystem::temp_directory_path() / "odr_font_test").string();
+  const HtmlConfig config;
+  const HtmlService service = html::translate(font_file, cache_path, config);
+
+  const HtmlViews &views = service.list_views();
+  ASSERT_EQ(views.size(), 1);
+  EXPECT_EQ(views.at(0).name(), "font");
+
+  std::ostringstream out;
+  service.write_html("font.html", out);
+  const std::string html = out.str();
+
+  EXPECT_NE(html.find("@font-face"), std::string::npos);
+  EXPECT_NE(html.find("odr-specimen"), std::string::npos);
+  EXPECT_NE(html.find("TestFont"), std::string::npos);
+  // Glyph 1 ('A') is shown at its PUA code point with its recovered Unicode.
+  EXPECT_NE(html.find("&#xe001;"), std::string::npos);
+  EXPECT_NE(html.find("U+41"), std::string::npos);
+}


### PR DESCRIPTION
Third piece of **stage 3** — the standalone-first deliverable (decision 2026-06-19). Stacked on #547 (3.1).

A font now opens and renders on its own, *before* any PDF wiring. The glyph grid (which shows **every** glyph, including ones the original `cmap` never reached) forces the 3.0 reader and 3.1 re-encode to work end to end against a directly viewable artifact.

### What's here
- **Public API**: `FileType::truetype_font`/`opentype_font`, a `FileCategory::font`, `odr::FontFile` with `is_font_file()`/`as_font_file()`, a `NoFontFile` exception — mirroring the other `DecodedFile` types.
- **Detection**: magic for sfnt `00010000`, `true`, `ttcf`, `OTTO`; `odr.cpp` string/category/mimetype mappings extended; wired into both open-strategy paths.
- **`abstract::FontFile`** (`font_program()`) + concrete `font::FontFile`, parsed eagerly so detection falls through on a non-font.
- **`html::translate(FontFile)`** → a specimen page: name/metrics header + a glyph grid, each glyph shown at its deterministic PUA code point (with any recovered Unicode), the font embedded via `@font-face` after the 3.1 uniform re-encode.

### Scope / limits
- Specimen page only — no font-editor scope creep.
- Grid capped at 4096 cells; fonts beyond the 6400-glyph PUA capacity (the 3.1 limit) fall back to a message.
- **wOFF** and the **PDF-as-container** (embedded-font `Filesystem`) ideas from the roadmap are deferred follow-ups.

### Tests
Magic detection of the SFNT flavors, the `FontFile` facts (type/category/program), and an end-to-end specimen render asserting the embedded `@font-face`, a PUA-coded glyph cell, and its recovered Unicode label.

🤖 Generated with [Claude Code](https://claude.com/claude-code)