### PR TITLE
PDF stage 4.0: page-element IR + path accumulation

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -196,7 +196,7 @@ set(ODR_SOURCE_FILES
         "src/odr/internal/pdf/pdf_graphics_state.cpp"
         "src/odr/internal/pdf/pdf_object.cpp"
         "src/odr/internal/pdf/pdf_object_parser.cpp"
-        "src/odr/internal/pdf/pdf_page_text.cpp"
+        "src/odr/internal/pdf/pdf_page_extractor.cpp"
 
         "src/odr/internal/font/cff_builder.cpp"
         "src/odr/internal/font/cff_font.cpp"

--- a/src/odr/internal/html/pdf_file.cpp
+++ b/src/odr/internal/html/pdf_file.cpp
@@ -17,7 +17,7 @@
 #include <odr/internal/pdf/pdf_document_element.hpp>
 #include <odr/internal/pdf/pdf_document_parser.hpp>
 #include <odr/internal/pdf/pdf_file.hpp>
-#include <odr/internal/pdf/pdf_page_text.hpp>
+#include <odr/internal/pdf/pdf_page_extractor.hpp>
 #include <odr/internal/util/string_util.hpp>
 
 #include <utf8cpp/utf8/unchecked.h>

--- a/src/odr/internal/pdf/STAGE4_PLAN.md
+++ b/src/odr/internal/pdf/STAGE4_PLAN.md
@@ -1,0 +1,283 @@
+# PDF stage 4 — graphics: PR-by-PR plan
+
+Goal of stage 4: render the **non-text** imaging model — vector paths, images,
+shadings, patterns — plus the two font cases deferred from stage 3 (Type3,
+non-embedded). Everything is **serialized to SVG/HTML, never rasterized**
+(decision 2026-06, recorded in `AGENTS.md`): the browser draws it. pdf.js proves
+no native renderer is needed; the PDF and SVG imaging models are close cousins.
+
+## Two foundational decisions (fixed for this plan)
+
+1. **Painter-order interleave.** Today `extract_text` emits a text-only
+   `std::vector<TextElement>`. Stage 4 generalizes this to **one ordered element
+   stream in paint order** — text, path-paint, image, shading events — so a fill
+   painted after text occludes it and vice versa. The HTML layer walks that one
+   list and emits interleaved `<svg>` fragments and text `<span>`s. This is the
+   faithful model and avoids a painful re-refactor later; the cost is that 4.0
+   reshapes the current pipeline.
+
+2. **Text stays HTML, graphics become SVG.** We keep stage 3's dual-layer
+   `@font-face` text spans for selectable/searchable text. SVG carries only
+   non-text imaging (and Type3 glyphs, which have no font program). We do **not**
+   render normal glyphs into SVG.
+
+Each sub-stage is one PR (a few are split where noted). They are dependency
+ordered; 4.0–4.3 are the load-bearing refactor + first visible output, 4.4+ widen
+coverage. The perceptual-diff oracle (4.18) can land any time after 4.2 and should
+land early enough to guard the rest.
+
+---
+
+## 4.0 — Page-element IR + path accumulation (refactor, no new output)
+
+The linchpin. No visible change; pure plumbing + tests.
+
+- Introduce a renderer-agnostic **`PageElement`** model (variant / small class
+  hierarchy) with `TextElement` becoming one case. Add `PathElement` (geometry +
+  paint intent) as the second.
+- Rename `extract_text` → `extract_page` (or add it and reimplement
+  `extract_text` on top, then migrate callers) returning
+  `std::vector<PageElement>` in paint order. `html/pdf_file.cpp` keeps working by
+  handling only the text case for now.
+- **Accumulate path geometry in `GraphicsState`/the executor.** The construction
+  operators (`m l c v y h re`) are tokenized today but their geometry is
+  discarded (`Path::current_position` only). Build subpaths (lists of
+  line/cubic segments + closed flag) in user space by applying the CTM at
+  construction time (per ISO 32000-1 8.5.2.1 the CTM in effect when the point is
+  added). Bézier variants `v`/`y` expand to full cubics.
+- On a **paint operator** (`S s f F f* B B* b b* n` + clip variants `W W*`),
+  emit a `PathElement` carrying: the subpaths, paint kind (none/fill/stroke/
+  fill+stroke), fill rule (nonzero/evenodd), and a snapshot of the paint-relevant
+  state (stroke/fill color slots as-is for now, line width, caps/joins/miter/
+  dash, plus the current clip — see 4.3). Then reset the path. `n` with a pending
+  `W` emits a clip-only element.
+- Tests: inline content streams through `extract_page`, asserting subpath
+  geometry under `cm`/`q`/`Q`, rectangle expansion, Bézier expansion, the paint
+  matrix of emitted elements, and that text + path elements come out in paint
+  order.
+
+Deliverable: IR only. Visual output unchanged.
+
+## 4.1 — SVG scaffolding + filled paths (first pixels)
+
+- Per page, the HTML layer walks the ordered `PageElement` list and, for runs of
+  graphics elements, opens an `<svg>` positioned over the page box with a
+  `viewBox` in PDF user space (y-up handled by the SVG transform, matching the
+  existing text mapping) so path coordinates need no per-point flip.
+- Render **filled** `PathElement`s: subpaths → one `<path d=...>`,
+  `fill-rule: nonzero|evenodd`, `fill` from the current non-stroking color
+  (DeviceGray/RGB/CMYK → RGB only for now; CMYK via the naive
+  `255*(1-c)*(1-k)` conversion, refined in 4.4).
+- Interleave with text spans per the painter-order list (decision 1).
+- Tests: a known fill (rect, triangle) produces the expected `<path>` + color;
+  evenodd vs nonzero; a fill behind/in-front-of a text span lands on the right
+  side in the emitted DOM order.
+
+## 4.2 — Strokes & line style
+
+- Render **stroked** paths: `stroke` color, `stroke-width` (transformed by the
+  CTM — handle non-uniform scaling; for a non-uniform CTM SVG can't express an
+  anisotropic pen, so approximate with the average scale and note the limit),
+  `stroke-linecap` (`0/1/2` → butt/round/square), `stroke-linejoin`
+  (`0/1/2` → miter/round/bevel), `stroke-miterlimit`, `stroke-dasharray` +
+  `stroke-dashoffset` from the dash pattern.
+- Fill+stroke paint ops (`B`/`b` family) emit both.
+- Move the lingering stdout/stderr debug in `pdf_graphics_state.cpp` (dash
+  pattern, stroke/other color) onto `Logger` while here (cross-cutting cleanup).
+- Tests: each line param → attribute; dash pattern round-trip; fill+stroke emits
+  both paint attributes.
+
+## 4.3 — Clipping
+
+- Track the **clip path** in the graphics state: `W`/`W*` set a pending clip that
+  the next paint/`n` op installs as the intersection with the current clip; the
+  clip is part of saved/restored state (`q`/`Q`) and is snapshotted onto each
+  emitted `PathElement` (added to 4.0's snapshot).
+- HTML: emit nested `<clipPath>` elements and reference them via `clip-path`.
+  Intersection of multiple clips → nested clip paths. Form-XObject `/BBox`
+  clipping (deferred in stage 2) also lands here, since it's the same machinery.
+- Tests: a clip rect limits a later fill; nested clips intersect; `q`/`Q`
+  save/restore the clip; form `/BBox` clips its content.
+
+## 4.4 — PDF function evaluator + color spaces
+
+Shared prerequisite for proper color **and** shadings, so it lands before both.
+
+- **4.4a — Function evaluator (`pdf_function`).** Evaluate PDF functions
+  (ISO 32000-1 7.10): type 2 (exponential), type 3 (stitching), type 0 (sampled,
+  with interpolation), type 4 (PostScript calculator — a small stack-machine
+  interpreter). Pure, unit-testable in isolation against spec examples.
+- **4.4b — Color spaces (`pdf_color`).** Resolve `/ColorSpace` resources and the
+  `CS`/`cs`/`SC`/`SCN`/`sc`/`scn` operators (today only the device color ops are
+  modelled). Convert to RGB at emit time: `ICCBased` (approximate by component
+  count / `/Alternate`, treat as sRGB), `CalRGB`/`CalGray` (≈ device),
+  `Lab` (→ XYZ → sRGB), `Indexed` (palette lookup), `Separation`/`DeviceN`
+  (sample the tint transform via 4.4a). Overprint ignored. Wire into the path
+  fill/stroke color resolution from 4.1/4.2.
+- Tests: each function type against spec vectors; each color space → expected
+  RGB; `scn` with a Separation space.
+
+## 4.5 — Image XObjects: JPEG pass-through (`DCTDecode`)
+
+- The filter framework already hands back `DCTDecode` payloads undecoded
+  (`stopped_at_filter`). Detect an `/XObject /Image` invoked by `Do`, emit an
+  **`ImageElement`** (new `PageElement` case) referencing the raw JPEG bytes;
+  HTML emits `<image>` (inside the page `<svg>`, placed by the CTM — a unit
+  square maps to the image rectangle) with a `data:image/jpeg;base64` href.
+- Honor `/ImageMask` false here only; masks come in 4.8.
+- Color-key/`/Decode` and CMYK JPEGs flagged as follow-ups (Adobe CMYK JPEG
+  inversion is a known wrinkle).
+- Tests: a `Do` of a DCTDecode image emits an `ImageElement` at the CTM rect with
+  the right bytes; round-trip the base64.
+
+## 4.6 — Raster images: Flate/LZW → PNG encode
+
+- For images whose data **is** decoded (Flate/LZW/raw), assemble samples using
+  `/Width`/`/Height`/`/BitsPerComponent`/`/ColorSpace` (reuse 4.4b) and PNG-encode
+  to RGB(A). Needs a minimal PNG writer (zlib already available via the filter
+  framework's inflate dependency — confirm a deflate path exists or add one).
+- `/Decode` arrays, 1/2/4/8/16 bpc, indexed palettes.
+- Tests: a small known raster (e.g. 2×2 indexed) → expected PNG pixels.
+
+## 4.7 — Inline images (`BI`/`ID`/`EI`)
+
+- Fix the tokenizer first: `pdf_graphics_operator_parser` currently can't scan
+  past `ID` correctly (the binary payload isn't length-delimited; scan to the
+  `EI` delimiter respecting whitespace + the abbreviated keys). The filter
+  abbreviations are already handled by `pdf_filter`.
+- Map abbreviated keys (`/W /H /BPC /CS /F /IM /D`) to their long forms and route
+  through the same image emission as 4.5/4.6.
+- Tests: an inline image tokenizes as one operator with its dict + bytes; a
+  Flate inline image emits the expected `ImageElement`.
+
+## 4.8 — Image masks, stencil masks, soft masks (`SMask`)
+
+- `/ImageMask true` (1-bpc stencil): paint the current fill color through the
+  mask → SVG `<image>` + `<mask>` or a recolored PNG with alpha.
+- Explicit `/Mask` (color-key array or a mask image) and `/SMask` (alpha image):
+  composite into the RGBA PNG, or emit an SVG `<mask>`.
+- Tests: a stencil mask paints the fill color; an SMask produces alpha.
+
+## 4.9 — Axial & radial shadings (types 2/3)
+
+- `sh` operator and shading **patterns** (`scn` with a `/Pattern` color space
+  naming a `/PatternType 2` shading pattern).
+- Type 2 (axial) → `<linearGradient>`, type 3 (radial) → `<radialGradient>`,
+  with stops sampled from the shading's `/Function` (4.4a) across `/Domain`,
+  `/Extend` → `spreadMethod`/explicit end stops, `/Coords` mapped through the CTM
+  (and the pattern matrix). Background/`/BBox` honored.
+- Tests: an axial shading → gradient stops + coords; `/Extend` handling; a
+  shading pattern fills a path.
+
+## 4.10 — Tiling patterns (`PatternType 1`)
+
+- Reuse the form-XObject machinery (stage 2): a tiling pattern's content stream
+  is a mini page run. Emit an SVG `<pattern>` tile (its own nested element list,
+  recursively rendered) sized by `/XStep`/`/YStep` and the pattern `/Matrix`;
+  reference it as `fill="url(#...)"`. Colored (`/PaintType 1`) vs uncolored
+  (`/PaintType 2`, painted in the current color) variants.
+- Cycle/recursion guard analogous to the form active-set guard.
+- Tests: a tiling pattern emits a `<pattern>` with the tile content; uncolored
+  pattern picks up the current color.
+
+## 4.11 — Mesh & function-based shadings (types 1, 4–7)
+
+The SVG-residue long tail; lowest priority, rare in the corpus.
+
+- Tessellate into many small flat-shaded polygons (pdf.js's approach): type 1
+  (function-based) sampled over its domain, types 4–7 (Gouraud triangle meshes,
+  Coons/tensor patches) decoded from their data streams into triangles → flat
+  `<polygon>`s with averaged color. Coons/tensor patches flattened to triangles.
+- Tests: a type-4 triangle mesh → the expected polygons; a type-1 function
+  shading tessellates.
+
+## 4.12 — Non-embedded font substitution + standard-14 AFM widths
+
+Deferred from stage 3. Independent of the SVG path — can be parallelized.
+
+- A font with no `/FontFile*`: map the standard 14 (Helvetica/Times/Courier +
+  Symbol/ZapfDingbats) and common names to CSS `font-family` fallback stacks
+  (serif/sans/mono chosen by `/Flags` + name; bold/italic from `/Flags` and the
+  name). The glyph shapes are the browser's fallback font; text stays in the
+  existing span path (no SVG).
+- **AFM widths** for the standard 14 (which usually ship no `/Widths`) as a
+  generated data table (`tools/pdf/generate_afm_data.py` → `pdf_afm_data.*`),
+  feeding `Font::advance_width` so placement is correct. Closes the deferred
+  "AFM widths" item from stage 2.
+- Tests: a bare `/BaseFont /Helvetica` font resolves a family + AFM widths; flags
+  → bold/italic/serif selection.
+
+## 4.13 — Type3 fonts
+
+Deferred from stage 3; depends on the path→SVG machinery (4.1–4.4) since Type3
+glyphs are mini content streams.
+
+- A Type3 font's `/CharProcs` are content streams (already tokenizable). For each
+  shown code, run the char proc through the executor (it emits paths/images via
+  the stage-4 machinery) placed at `CTM × Tm × /FontMatrix` (font size folded
+  in), against the font's `/Resources`. `d0`/`d1` already modelled.
+- No glyph program → no PUA re-encode, no reverse map: the dual-layer model holds
+  (SVG glyph layer + transparent Unicode span from the code→Unicode chain for
+  selection).
+- Tests: a Type3 glyph emits its char-proc paths at the glyph transform; Unicode
+  still extracted for selection.
+
+## 4.14 — Transparency: constant alpha & blend modes
+
+- `/ExtGState` `CA`/`ca` → `stroke-opacity`/`fill-opacity` (or group `opacity`);
+  the `gs` operator already lands in state as `graphics_state_parameters` (a name
+  today) — resolve the actual `/ExtGState` dict.
+- Blend modes (`/BM`) → CSS `mix-blend-mode` where it maps; unmappable modes
+  (rare) fall back to normal with a `Logger` note.
+- Tests: `ca` → fill-opacity; a known `/BM` → the mapped blend mode.
+
+## 4.15 — Transparency groups & soft masks (`SMask` in ExtGState)
+
+- Luminosity/alpha soft masks (`/SMask` in `/ExtGState`, a transparency group
+  XObject) → SVG `<mask>`. Isolated/knockout groups don't map cleanly — punt with
+  a `Logger` note (rare), per the AGENTS sketch.
+- Tests: a luminosity soft mask → a `<mask>` applied to following content.
+
+## 4.16 — Annotation appearance streams (optional pull-forward from stage 5)
+
+Not core stage 4, but it reuses the form-XObject + path machinery and is cheap
+once 4.1–4.13 exist; can be deferred to stage 5. Listed here only as a candidate.
+
+## 4.17 — Coverage hardening + AGENTS.md rewrite
+
+- Sweep the corpus (odr-public + the PDF101 "nasty files"), fix the long tail of
+  operator gaps surfaced by the oracle, and **rewrite the `pdf/AGENTS.md`
+  stage-4 section** from "roadmap" to "what works" (as stages 0–3 did on close),
+  dropping any stage tags from code. Delete this plan file.
+
+## 4.18 — Perceptual-diff test oracle (land early, after 4.2)
+
+Parallels stage 3's OTS gate. **Not a runtime dependency.**
+
+- CI-only: render corpus fixtures with poppler **or** pdf.js, screenshot our HTML
+  output (headless Chromium), perceptual-diff against the reference, gate on a
+  threshold. Lives in `test/` / CI config, off the shipped build.
+- Land this right after 4.1/4.2 so every subsequent graphics PR is guarded.
+
+---
+
+## Suggested merge order
+
+`4.0 → 4.1 → 4.2 → 4.18 (oracle) → 4.3 → 4.4 → 4.5 → 4.6 → 4.7 → 4.8 → 4.9 →
+4.10 → 4.13 → 4.14 → 4.15 → 4.11 → 4.16? → 4.17`
+
+`4.12` (non-embedded fonts) is independent of the SVG path and can land any time
+in parallel. The high-value visual milestone is **4.0–4.6** (vector paths, color,
+JPEG + raster images) — most real PDFs look right after that; 4.9–4.15 are the
+fidelity tail.
+
+## Open questions to settle per-PR (not blockers now)
+
+- Where the page `<svg>` boundaries fall when graphics and text interleave many
+  times — one `<svg>` per contiguous graphics run vs one per page with text
+  woven through it as `<foreignObject>`. Lean: contiguous-run `<svg>` fragments
+  between span groups (keeps text as real HTML for selection).
+- CMYK conversion fidelity (naive vs ICC-approximated) — start naive (4.1),
+  revisit in 4.4 if the oracle demands.
+- PNG writer: confirm a deflate encoder is reachable from the existing zlib dep
+  before 4.6, else add a minimal one.

--- a/src/odr/internal/pdf/pdf_graphics_state.cpp
+++ b/src/odr/internal/pdf/pdf_graphics_state.cpp
@@ -58,6 +58,78 @@ void GraphicsState::advance_text(const double tx, const double ty) {
   text.matrix = util::math::Transform2D::translation(tx, ty) * text.matrix;
 }
 
+std::array<double, 2> GraphicsState::to_user(const double x,
+                                             const double y) const {
+  return current().general.transform_matrix.apply(x, y);
+}
+
+void GraphicsState::append_segment(const PathSegment &segment) {
+  if (path.empty()) {
+    // A construction operator before any `m` is malformed; tolerate it by
+    // opening a subpath at the current point.
+    path.push_back(Subpath{m_current_point, {}, false});
+  }
+  path.back().segments.push_back(segment);
+  m_current_point = segment.end;
+}
+
+void GraphicsState::path_move_to(const double x, const double y) {
+  m_current_point = to_user(x, y);
+  m_subpath_start = m_current_point;
+  path.push_back(Subpath{m_current_point, {}, false});
+}
+
+void GraphicsState::path_line_to(const double x, const double y) {
+  append_segment({PathSegment::Kind::line, {}, {}, to_user(x, y)});
+}
+
+void GraphicsState::path_cubic_to(const double x1, const double y1,
+                                  const double x2, const double y2,
+                                  const double x3, const double y3) {
+  append_segment({PathSegment::Kind::cubic, to_user(x1, y1), to_user(x2, y2),
+                  to_user(x3, y3)});
+}
+
+void GraphicsState::path_cubic_to_v(const double x2, const double y2,
+                                    const double x3, const double y3) {
+  append_segment({PathSegment::Kind::cubic, m_current_point, to_user(x2, y2),
+                  to_user(x3, y3)});
+}
+
+void GraphicsState::path_cubic_to_y(const double x1, const double y1,
+                                    const double x3, const double y3) {
+  const std::array<double, 2> end = to_user(x3, y3);
+  append_segment({PathSegment::Kind::cubic, to_user(x1, y1), end, end});
+}
+
+void GraphicsState::path_close() {
+  if (path.empty()) {
+    return;
+  }
+  path.back().closed = true;
+  m_current_point = m_subpath_start;
+}
+
+void GraphicsState::path_rectangle(const double x, const double y,
+                                   const double w, const double h) {
+  // `re` appends a complete closed rectangle and leaves the current point at
+  // its origin (ISO 32000-1 8.5.2.1).
+  Subpath rect{to_user(x, y), {}, true};
+  rect.segments.push_back({PathSegment::Kind::line, {}, {}, to_user(x + w, y)});
+  rect.segments.push_back(
+      {PathSegment::Kind::line, {}, {}, to_user(x + w, y + h)});
+  rect.segments.push_back({PathSegment::Kind::line, {}, {}, to_user(x, y + h)});
+  path.push_back(std::move(rect));
+  m_current_point = to_user(x, y);
+  m_subpath_start = m_current_point;
+}
+
+void GraphicsState::clear_path() {
+  path.clear();
+  m_current_point = {0, 0};
+  m_subpath_start = {0, 0};
+}
+
 void GraphicsState::save() { stack.push_back(stack.back()); }
 
 void GraphicsState::restore() { stack.pop_back(); }
@@ -110,30 +182,31 @@ void GraphicsState::execute(const GraphicsOperator &op) {
         op.arguments.at(0).as_string();
     break;
 
-  case GraphicsOperatorType::path_move_to:
-    for (int i = 0; i < 2; ++i) {
-      current().path.current_position.at(i) = op.arguments.at(i).as_real();
-    }
+  case GraphicsOperatorType::path_move_to: // m
+    path_move_to(op.arguments.at(0).as_real(), op.arguments.at(1).as_real());
     break;
-  case GraphicsOperatorType::path_line_to:
-    for (int i = 0; i < 2; ++i) {
-      current().path.current_position.at(i) = op.arguments.at(i).as_real();
-    }
+  case GraphicsOperatorType::path_line_to: // l
+    path_line_to(op.arguments.at(0).as_real(), op.arguments.at(1).as_real());
     break;
-  case GraphicsOperatorType::path_cubic_bezier_to:
-    for (int i = 0; i < 2; ++i) {
-      current().path.current_position.at(i) = op.arguments.at(i + 4).as_real();
-    }
+  case GraphicsOperatorType::path_cubic_bezier_to: // c
+    path_cubic_to(op.arguments.at(0).as_real(), op.arguments.at(1).as_real(),
+                  op.arguments.at(2).as_real(), op.arguments.at(3).as_real(),
+                  op.arguments.at(4).as_real(), op.arguments.at(5).as_real());
     break;
-  case GraphicsOperatorType::path_cubic_bezier_0eq1_to:
-    for (int i = 0; i < 2; ++i) {
-      current().path.current_position.at(i) = op.arguments.at(i + 2).as_real();
-    }
+  case GraphicsOperatorType::path_cubic_bezier_0eq1_to: // v
+    path_cubic_to_v(op.arguments.at(0).as_real(), op.arguments.at(1).as_real(),
+                    op.arguments.at(2).as_real(), op.arguments.at(3).as_real());
     break;
-  case GraphicsOperatorType::path_cubic_bezier_2eq3_to:
-    for (int i = 0; i < 2; ++i) {
-      current().path.current_position.at(i) = op.arguments.at(i + 2).as_real();
-    }
+  case GraphicsOperatorType::path_cubic_bezier_2eq3_to: // y
+    path_cubic_to_y(op.arguments.at(0).as_real(), op.arguments.at(1).as_real(),
+                    op.arguments.at(2).as_real(), op.arguments.at(3).as_real());
+    break;
+  case GraphicsOperatorType::close_path: // h
+    path_close();
+    break;
+  case GraphicsOperatorType::rectangle: // re
+    path_rectangle(op.arguments.at(0).as_real(), op.arguments.at(1).as_real(),
+                   op.arguments.at(2).as_real(), op.arguments.at(3).as_real());
     break;
 
   case GraphicsOperatorType::set_text_char_spacing:
@@ -202,14 +275,17 @@ void GraphicsState::execute(const GraphicsOperator &op) {
     std::cout << "stroke color name not implemented" << '\n';
     break;
   case GraphicsOperatorType::set_stroke_grey_color:
+    current().stroke_color.space = ColorSpace::device_grey;
     current().stroke_color.grey = op.arguments.at(0).as_real();
     break;
   case GraphicsOperatorType::set_stroke_rgb_color:
+    current().stroke_color.space = ColorSpace::device_rgb;
     for (int i = 0; i < 3; ++i) {
       current().stroke_color.rgb.at(i) = op.arguments.at(i).as_real();
     }
     break;
   case GraphicsOperatorType::set_stroke_cmyk_color:
+    current().stroke_color.space = ColorSpace::device_cmyk;
     for (int i = 0; i < 4; ++i) {
       current().stroke_color.cmyk.at(i) = op.arguments.at(i).as_real();
     }
@@ -228,14 +304,17 @@ void GraphicsState::execute(const GraphicsOperator &op) {
     std::cout << "other color name not implemented" << '\n';
     break;
   case GraphicsOperatorType::set_other_grey_color:
+    current().other_color.space = ColorSpace::device_grey;
     current().other_color.grey = op.arguments.at(0).as_real();
     break;
   case GraphicsOperatorType::set_other_rgb_color:
+    current().other_color.space = ColorSpace::device_rgb;
     for (int i = 0; i < 3; ++i) {
       current().other_color.rgb.at(i) = op.arguments.at(i).as_real();
     }
     break;
   case GraphicsOperatorType::set_other_cmyk_color:
+    current().other_color.space = ColorSpace::device_cmyk;
     for (int i = 0; i < 4; ++i) {
       current().other_color.cmyk.at(i) = op.arguments.at(i).as_real();
     }

--- a/src/odr/internal/pdf/pdf_graphics_state.hpp
+++ b/src/odr/internal/pdf/pdf_graphics_state.hpp
@@ -17,22 +17,41 @@ enum class ColorSpace {
   device_cmyk,
 };
 
+/// One segment of a subpath, in user space (the CTM is already applied at
+/// construction time, ISO 32000-1 8.5.2.1). A line carries only `end`; a cubic
+/// Bézier carries its two control points as well.
+struct PathSegment {
+  enum class Kind { line, cubic };
+  Kind kind{Kind::line};
+  std::array<double, 2> c1{};  // cubic control point 1 (unused for a line)
+  std::array<double, 2> c2{};  // cubic control point 2 (unused for a line)
+  std::array<double, 2> end{}; // segment endpoint
+};
+
+/// A subpath: a start point (from `m`/`re`), its segments, and whether it was
+/// explicitly closed (`h` or a close-and-paint operator). Coordinates are user
+/// space.
+struct Subpath {
+  std::array<double, 2> start{};
+  std::vector<PathSegment> segments;
+  bool closed{false};
+};
+
 struct GraphicsState {
   struct General {
-    double line_width{};
+    // PDF initial graphics state (ISO 32000-1 Table 52): line width 1.0, butt
+    // cap, miter join, miter limit 10.0. Defaulting these to 0 would emit
+    // zero-width/invalid-miter path elements for streams that stroke without an
+    // explicit `w`/`M`.
+    double line_width{1};
     int cap_style{};
     int join_style{};
-    double miter_limit{};
+    double miter_limit{10};
     int dash_pattern{};
     std::string color_rendering_intent;
     double flatness_tolerance{};
     std::string graphics_state_parameters;
     util::math::Transform2D transform_matrix; // CTM
-  };
-
-  struct Path {
-    std::array<double, 2> current_position{0, 0};
-    // TODO clipping
   };
 
   struct Text {
@@ -60,7 +79,6 @@ struct GraphicsState {
 
   struct State {
     General general;
-    Path path;
     Text text;
     Color stroke_color;
     Color other_color;
@@ -68,12 +86,34 @@ struct GraphicsState {
 
   std::vector<State> stack;
 
+  /// The path under construction. Unlike the rest of the state it is *not* part
+  /// of the `q`/`Q` stack (ISO 32000-1 8.5.2): it accumulates across
+  /// `m`/`l`/`c`/ `re`/… and is consumed (and cleared) by a path-painting
+  /// operator.
+  std::vector<Subpath> path;
+
   GraphicsState();
 
   State &current();
   [[nodiscard]] const State &current() const;
 
   void execute(const GraphicsOperator &);
+
+  /// Path construction. Operands are taken in the operator's coordinate space;
+  /// each point is mapped through the current CTM and stored in user space.
+  void path_move_to(double x, double y);
+  void path_line_to(double x, double y);
+  void path_cubic_to(double x1, double y1, double x2, double y2, double x3,
+                     double y3);
+  /// `v`: the first control point is the current point.
+  void path_cubic_to_v(double x2, double y2, double x3, double y3);
+  /// `y`: the second control point coincides with the endpoint.
+  void path_cubic_to_y(double x1, double y1, double x3, double y3);
+  void path_close();
+  void path_rectangle(double x, double y, double w, double h);
+  /// Close the current subpath (without the `h`-style "closed" mark) and drop
+  /// the accumulated path, as every path-painting operator does on completion.
+  void clear_path();
 
   /// Push a copy of the current state (`q`).
   void save();
@@ -98,6 +138,15 @@ private:
   /// Move to the start of a new text line: `Tlm = translate(tx, ty) * Tlm` and
   /// `Tm = Tlm` (the shared mechanic behind `Td`, `TD`, `T*`, `'`, `"`).
   void next_line(double tx, double ty);
+
+  /// Map an operand point through the current CTM into user space.
+  [[nodiscard]] std::array<double, 2> to_user(double x, double y) const;
+  /// Append `segment` to the current subpath, starting one at the current point
+  /// if a construction operator other than `m`/`re` opens the path (lenient).
+  void append_segment(const PathSegment &segment);
+
+  std::array<double, 2> m_current_point{0, 0}; // user space
+  std::array<double, 2> m_subpath_start{0, 0}; // user space, for `h`/close
 };
 
 } // namespace odr::internal::pdf

--- a/src/odr/internal/pdf/pdf_page_element.hpp
+++ b/src/odr/internal/pdf/pdf_page_element.hpp
@@ -1,17 +1,14 @@
 #pragma once
 
+#include <odr/internal/pdf/pdf_graphics_state.hpp>
 #include <odr/internal/util/math_util.hpp>
 
 #include <string>
+#include <variant>
 #include <vector>
-
-namespace odr {
-class Logger;
-}
 
 namespace odr::internal::pdf {
 
-struct Resources;
 struct Font;
 
 /// One show-text operation laid out in user space. The transform places the
@@ -58,15 +55,40 @@ struct TextElement {
   std::vector<double> advances;
 };
 
-/// Execute a page's (decoded, concatenated) content stream and collect the text
-/// it shows as placed elements. Non-text operators update the graphics state
-/// but produce no output. Each shown segment (one `Tj`/`'`/`"`, or one string
-/// of a `TJ` array) yields one element at its origin; the text matrix is
-/// advanced by the glyph widths (`font->advance_width`) plus char/word spacing
-/// and the `TJ` numeric adjustments, so segments and lines land in the right
-/// place.
-std::vector<TextElement> extract_text(const std::string &content,
-                                      const Resources &resources,
-                                      const Logger &logger);
+/// One path-painting operation (`S`/`s`/`f`/`F`/`f*`/`B`/…), laid out in user
+/// space. The geometry is fully resolved (the CTM applied at construction), so
+/// a renderer maps it through the page transform alone. The paint intent and
+/// the paint-relevant graphics state are snapshotted; colors are kept as PDF
+/// device colors and converted to RGB by the renderer. `/Pattern` color and
+/// clipping are stage 4.3+ and not yet represented.
+struct PathElement {
+  /// The subpaths to paint, in user space.
+  std::vector<Subpath> subpaths;
+  bool fill{false};
+  bool stroke{false};
+  /// Fill rule: false = nonzero winding, true = even-odd.
+  bool even_odd{false};
+  /// Non-stroking (fill) color and stroking color, as device colors.
+  GraphicsState::Color fill_color;
+  GraphicsState::Color stroke_color;
+  /// Stroke parameters. `line_width` is the raw PDF value in *unscaled* user
+  /// space; PDF stroke width scales with the CTM (ISO 32000-1 8.4.3.2), but the
+  /// path geometry above is already flattened to user space, so the CTM is no
+  /// longer recoverable from it. `ctm` is the paint-time CTM, captured here so
+  /// the renderer can derive the device stroke width (and handle non-uniform
+  /// scaling) at stage 4.2.
+  double line_width{1};
+  int line_cap{0};
+  int line_join{0};
+  double miter_limit{10};
+  /// Paint-time CTM (the geometry's user space -> the unscaled space line
+  /// width/dash lengths live in).
+  util::math::Transform2D ctm;
+};
+
+/// A single page-content element in paint (z) order: a shown text segment or a
+/// painted path. Images, shadings and patterns join this variant in later
+/// stage-4 PRs.
+using PageElement = std::variant<TextElement, PathElement>;
 
 } // namespace odr::internal::pdf

--- a/src/odr/internal/pdf/pdf_page_extractor.cpp
+++ b/src/odr/internal/pdf/pdf_page_extractor.cpp
@@ -1,4 +1,4 @@
-#include <odr/internal/pdf/pdf_page_text.hpp>
+#include <odr/internal/pdf/pdf_page_extractor.hpp>
 
 #include <odr/logger.hpp>
 
@@ -252,7 +252,7 @@ bool infer_space(const Pen &pen, const std::array<double, 2> &start) {
 }
 
 /// Emit one placed segment and advance the text matrix by its width.
-void show(std::vector<TextElement> &out, GraphicsState &state,
+void show(std::vector<PageElement> &out, GraphicsState &state,
           MarkedContentStack &marked, std::optional<Pen> &pen,
           std::string codes, Font *font) {
   const GraphicsState::Text &text = state.current().text;
@@ -307,6 +307,33 @@ void show(std::vector<TextElement> &out, GraphicsState &state,
   pen = Pen{{after.e, after.f}, direction, text.size * basis, trailing_space};
 }
 
+/// Emit a path-painting element from the path accumulated in `state` and the
+/// current paint state, then clear the path (as every painting operator does).
+/// `close` first closes the current subpath (the `s`/`b`/`b*` variants).
+void paint_path(std::vector<PageElement> &out, GraphicsState &state, bool fill,
+                bool stroke, bool even_odd, bool close) {
+  if (close) {
+    state.path_close();
+  }
+  const GraphicsState::State &s = state.current();
+  PathElement element;
+  element.subpaths = state.path;
+  element.fill = fill;
+  element.stroke = stroke;
+  element.even_odd = even_odd;
+  element.fill_color = s.other_color;
+  element.stroke_color = s.stroke_color;
+  element.line_width = s.general.line_width;
+  element.line_cap = s.general.cap_style;
+  element.line_join = s.general.join_style;
+  element.miter_limit = s.general.miter_limit;
+  // The geometry above is flattened to user space, so the CTM can no longer be
+  // recovered from it; capture it for the stroke metrics (ISO 32000-1 8.4.3.2).
+  element.ctm = s.general.transform_matrix;
+  out.push_back(std::move(element));
+  state.clear_path();
+}
+
 /// Form XObjects currently being rendered, by element identity. The parser
 /// represents the file faithfully, so the XObject graph may contain cycles
 /// (the spec forbids them — ISO 32000-1 8.10.1 — but real files err); this set
@@ -314,7 +341,7 @@ void show(std::vector<TextElement> &out, GraphicsState &state,
 using ActiveForms = std::set<const XObject *>;
 
 void run_content(const std::string &content, const Resources &resources,
-                 GraphicsState &state, std::vector<TextElement> &out,
+                 GraphicsState &state, std::vector<PageElement> &out,
                  const Logger &logger, std::set<std::string> &warned,
                  ActiveForms &active, MarkedContentStack &marked,
                  std::optional<Pen> &pen);
@@ -347,7 +374,7 @@ void begin_marked_content(const GraphicsOperator &op,
 /// `/BBox` clipping is deferred (text-only). Image and unknown XObjects are
 /// skipped, and a form already on the render stack is skipped (cycle guard).
 void invoke_x_object(const std::string &name, const Resources &resources,
-                     GraphicsState &state, std::vector<TextElement> &out,
+                     GraphicsState &state, std::vector<PageElement> &out,
                      const Logger &logger, std::set<std::string> &warned,
                      ActiveForms &active, MarkedContentStack &marked,
                      std::optional<Pen> &pen) {
@@ -383,7 +410,7 @@ void invoke_x_object(const std::string &name, const Resources &resources,
 }
 
 void run_content(const std::string &content, const Resources &resources,
-                 GraphicsState &state, std::vector<TextElement> &out,
+                 GraphicsState &state, std::vector<PageElement> &out,
                  const Logger &logger, std::set<std::string> &warned,
                  ActiveForms &active, MarkedContentStack &marked,
                  std::optional<Pen> &pen) {
@@ -426,6 +453,36 @@ void run_content(const std::string &content, const Resources &resources,
       invoke_x_object(op.arguments.at(0).as_string(), resources, state, out,
                       logger, warned, active, marked, pen);
       break;
+
+    case GraphicsOperatorType::stroke: // S
+      paint_path(out, state, false, true, false, false);
+      break;
+    case GraphicsOperatorType::close_stroke: // s
+      paint_path(out, state, false, true, false, true);
+      break;
+    case GraphicsOperatorType::fill_nonzero: // f, F
+      paint_path(out, state, true, false, false, false);
+      break;
+    case GraphicsOperatorType::fill_evenodd: // f*
+      paint_path(out, state, true, false, true, false);
+      break;
+    case GraphicsOperatorType::fill_nonzero_stroke: // B
+      paint_path(out, state, true, true, false, false);
+      break;
+    case GraphicsOperatorType::fill_evenodd_stroke: // B*
+      paint_path(out, state, true, true, true, false);
+      break;
+    case GraphicsOperatorType::close_fill_nonzero_stroke: // b
+      paint_path(out, state, true, true, false, true);
+      break;
+    case GraphicsOperatorType::close_fill_evenodd_stroke: // b*
+      paint_path(out, state, true, true, true, true);
+      break;
+    case GraphicsOperatorType::end_path: // n
+      // Path painted with no marks (used after a clip operator, stage 4.3);
+      // discard the geometry.
+      state.clear_path();
+      break;
     case GraphicsOperatorType::begin_marked_content_seq:       // BMC
     case GraphicsOperatorType::begin_marked_content_seq_props: // BDC
       begin_marked_content(op, resources, marked);
@@ -447,10 +504,10 @@ void run_content(const std::string &content, const Resources &resources,
 
 namespace odr::internal {
 
-std::vector<pdf::TextElement> pdf::extract_text(const std::string &content,
+std::vector<pdf::PageElement> pdf::extract_page(const std::string &content,
                                                 const Resources &resources,
                                                 const Logger &logger) {
-  std::vector<TextElement> result;
+  std::vector<PageElement> result;
   std::set<std::string> warned;
   ActiveForms active;
   MarkedContentStack marked;
@@ -460,6 +517,18 @@ std::vector<pdf::TextElement> pdf::extract_text(const std::string &content,
   run_content(content, resources, state, result, logger, warned, active, marked,
               pen);
 
+  return result;
+}
+
+std::vector<pdf::TextElement> pdf::extract_text(const std::string &content,
+                                                const Resources &resources,
+                                                const Logger &logger) {
+  std::vector<TextElement> result;
+  for (PageElement &element : extract_page(content, resources, logger)) {
+    if (auto *text = std::get_if<TextElement>(&element)) {
+      result.push_back(std::move(*text));
+    }
+  }
   return result;
 }
 

--- a/src/odr/internal/pdf/pdf_page_extractor.hpp
+++ b/src/odr/internal/pdf/pdf_page_extractor.hpp
@@ -1,0 +1,36 @@
+#pragma once
+
+#include <odr/internal/pdf/pdf_page_element.hpp>
+
+#include <vector>
+
+namespace odr {
+class Logger;
+}
+
+namespace odr::internal::pdf {
+
+struct Resources;
+
+/// Execute a page's (decoded, concatenated) content stream and collect the text
+/// it shows as placed elements. Non-text operators update the graphics state
+/// but produce no output. Each shown segment (one `Tj`/`'`/`"`, or one string
+/// of a `TJ` array) yields one element at its origin; the text matrix is
+/// advanced by the glyph widths (`font->advance_width`) plus char/word spacing
+/// and the `TJ` numeric adjustments, so segments and lines land in the right
+/// place.
+std::vector<TextElement> extract_text(const std::string &content,
+                                      const Resources &resources,
+                                      const Logger &logger);
+
+/// Execute a page's (decoded, concatenated) content stream and collect every
+/// painted element — text segments and paths — as placed `PageElement`s in
+/// paint (z) order, so a renderer can interleave them faithfully. Text segments
+/// are exactly those `extract_text` returns; path elements carry the
+/// constructed geometry and the paint state. `extract_text` is the text-only
+/// projection of this list.
+std::vector<PageElement> extract_page(const std::string &content,
+                                      const Resources &resources,
+                                      const Logger &logger);
+
+} // namespace odr::internal::pdf

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -51,7 +51,7 @@ add_executable(odr_test
         "src/internal/util/math_util_test.cpp"
         "src/internal/pdf/pdf_object.cpp"
         "src/internal/pdf/pdf_object_parser.cpp"
-        "src/internal/pdf/pdf_page_text.cpp"
+        "src/internal/pdf/pdf_page_extractor.cpp"
         "src/internal/pdf/pdf_test_file_builder.cpp"
 
         "src/internal/font/cff_font.cpp"

--- a/test/src/internal/pdf/pdf_page_extractor.cpp
+++ b/test/src/internal/pdf/pdf_page_extractor.cpp
@@ -1,10 +1,11 @@
-#include <odr/internal/pdf/pdf_page_text.hpp>
+#include <odr/internal/pdf/pdf_page_extractor.hpp>
 
 #include <odr/logger.hpp>
 
 #include <odr/internal/pdf/pdf_document_element.hpp>
 
 #include <string>
+#include <variant>
 #include <vector>
 
 #include <gtest/gtest.h>
@@ -40,7 +41,7 @@ Font simple_font(int first_char, std::vector<double> widths) {
 
 // `Td` places the origin via the text line matrix; the font size is carried
 // separately, not folded into the transform.
-TEST(PdfPageText, td_translation) {
+TEST(PdfPageExtractor, td_translation) {
   const auto texts = run("BT /F1 12 Tf 100 700 Td (Hi) Tj ET");
   ASSERT_EQ(texts.size(), 1);
   EXPECT_DOUBLE_EQ(texts[0].transform.e, 100);
@@ -53,7 +54,7 @@ TEST(PdfPageText, td_translation) {
 }
 
 // `Tm` sets the text matrix outright, scaling and all.
-TEST(PdfPageText, tm_scaling) {
+TEST(PdfPageExtractor, tm_scaling) {
   const auto texts = run("BT /F1 10 Tf 2 0 0 2 50 60 Tm (X) Tj ET");
   ASSERT_EQ(texts.size(), 1);
   EXPECT_DOUBLE_EQ(texts[0].transform.a, 2);
@@ -63,7 +64,7 @@ TEST(PdfPageText, tm_scaling) {
 }
 
 // `cm` concatenates into the CTM, which composes under the text matrix.
-TEST(PdfPageText, ctm_concatenates) {
+TEST(PdfPageExtractor, ctm_concatenates) {
   const auto texts = run("2 0 0 2 0 0 cm BT /F1 10 Tf 10 20 Td (Y) Tj ET");
   ASSERT_EQ(texts.size(), 1);
   EXPECT_DOUBLE_EQ(texts[0].transform.a, 2);
@@ -73,7 +74,7 @@ TEST(PdfPageText, ctm_concatenates) {
 }
 
 // Horizontal scaling (`Tz`, percent) scales x only, in the transform.
-TEST(PdfPageText, horizontal_scaling) {
+TEST(PdfPageExtractor, horizontal_scaling) {
   const auto texts = run("BT /F1 10 Tf 50 Tz 0 0 Td (Z) Tj ET");
   ASSERT_EQ(texts.size(), 1);
   EXPECT_DOUBLE_EQ(texts[0].transform.a, 0.5);
@@ -82,7 +83,7 @@ TEST(PdfPageText, horizontal_scaling) {
 }
 
 // Text rise (`Ts`) offsets the origin in y, unscaled by the font size.
-TEST(PdfPageText, text_rise) {
+TEST(PdfPageExtractor, text_rise) {
   const auto texts = run("BT /F1 10 Tf 0 0 Td 5 Ts (R) Tj ET");
   ASSERT_EQ(texts.size(), 1);
   EXPECT_DOUBLE_EQ(texts[0].transform.f, 5);
@@ -91,7 +92,7 @@ TEST(PdfPageText, text_rise) {
 
 // `TJ` emits one element per string; with no font the strings stay put (zero
 // advance) but the numeric adjustments still move the origin.
-TEST(PdfPageText, tj_emits_per_string_with_adjustments) {
+TEST(PdfPageExtractor, tj_emits_per_string_with_adjustments) {
   // adjustment -120 -> +120/1000 * 10 = +1.2 between the two strings
   const auto texts = run("BT /F1 10 Tf 0 0 Td [(Ab) -120 (cd)] TJ ET");
   ASSERT_EQ(texts.size(), 2);
@@ -103,7 +104,7 @@ TEST(PdfPageText, tj_emits_per_string_with_adjustments) {
 
 // Simple-font `/Widths` advance the text matrix, so a following show lands past
 // the previous one.
-TEST(PdfPageText, simple_font_widths_advance) {
+TEST(PdfPageExtractor, simple_font_widths_advance) {
   Font font = simple_font('A', {500, 600, 700}); // A=0.5, B=0.6, C=0.7 em
   Resources res;
   res.font["F1"] = &font;
@@ -117,7 +118,7 @@ TEST(PdfPageText, simple_font_widths_advance) {
 }
 
 // A `TJ` adjustment combines with the glyph width to place the next string.
-TEST(PdfPageText, tj_adjustment_after_width) {
+TEST(PdfPageExtractor, tj_adjustment_after_width) {
   Font font = simple_font('A', {500, 600}); // A=0.5, B=0.6 em
   Resources res;
   res.font["F1"] = &font;
@@ -130,7 +131,7 @@ TEST(PdfPageText, tj_adjustment_after_width) {
 }
 
 // Char spacing adds to every glyph's advance.
-TEST(PdfPageText, char_spacing_advance) {
+TEST(PdfPageExtractor, char_spacing_advance) {
   Font font = simple_font('A', {500, 500});
   Resources res;
   res.font["F1"] = &font;
@@ -143,7 +144,7 @@ TEST(PdfPageText, char_spacing_advance) {
 }
 
 // Word spacing adds to the single-byte space (0x20) only.
-TEST(PdfPageText, word_spacing_applies_to_space) {
+TEST(PdfPageExtractor, word_spacing_applies_to_space) {
   Font font = simple_font(32, {250}); // space = 0.25 em
   Resources res;
   res.font["F1"] = &font;
@@ -156,7 +157,7 @@ TEST(PdfPageText, word_spacing_applies_to_space) {
 }
 
 // Composite (Type0) fonts use 2-byte codes and the `/DW` default width.
-TEST(PdfPageText, composite_default_width_advance) {
+TEST(PdfPageExtractor, composite_default_width_advance) {
   Font font;
   font.composite = true;
   font.cid_default_width = 1000; // 1.0 em
@@ -172,7 +173,7 @@ TEST(PdfPageText, composite_default_width_advance) {
 
 // `Font::advance_width` falls back to `/MissingWidth` (simple) and `/DW`
 // (composite) for absent codes.
-TEST(PdfPageText, advance_width_fallbacks) {
+TEST(PdfPageExtractor, advance_width_fallbacks) {
   Font simple = simple_font('A', {500});
   simple.missing_width = 250;
   EXPECT_DOUBLE_EQ(simple.advance_width('A'), 0.5);
@@ -187,7 +188,7 @@ TEST(PdfPageText, advance_width_fallbacks) {
 }
 
 // `T*` moves down one line by the leading set with `TL`.
-TEST(PdfPageText, next_line_uses_leading) {
+TEST(PdfPageExtractor, next_line_uses_leading) {
   const auto texts = run("BT /F1 10 Tf 14 TL 0 800 Td (a) Tj T* (b) Tj ET");
   ASSERT_EQ(texts.size(), 2);
   EXPECT_DOUBLE_EQ(texts[0].transform.f, 800);
@@ -195,7 +196,7 @@ TEST(PdfPageText, next_line_uses_leading) {
 }
 
 // `'` does the line move and then shows.
-TEST(PdfPageText, show_next_line) {
+TEST(PdfPageExtractor, show_next_line) {
   const auto texts = run("BT /F1 10 Tf 10 TL 0 500 Td (a) Tj (b) ' ET");
   ASSERT_EQ(texts.size(), 2);
   EXPECT_DOUBLE_EQ(texts[1].transform.f, 490); // 500 - 10
@@ -203,7 +204,7 @@ TEST(PdfPageText, show_next_line) {
 }
 
 // `"` sets word/char spacing, does the line move, then shows the third operand.
-TEST(PdfPageText, show_next_line_set_spacing) {
+TEST(PdfPageExtractor, show_next_line_set_spacing) {
   const auto texts = run("BT /F1 10 Tf 12 TL 0 400 Td (a) Tj 1 2 (b) \" ET");
   ASSERT_EQ(texts.size(), 2);
   EXPECT_DOUBLE_EQ(texts[1].transform.f, 388); // 400 - 12
@@ -225,7 +226,7 @@ XObject form_x_object(std::string content) {
 } // namespace
 
 // `Do` on a form XObject runs its content stream and emits its text.
-TEST(PdfPageText, form_xobject_invoked) {
+TEST(PdfPageExtractor, form_xobject_invoked) {
   XObject form = form_x_object("BT /F1 10 Tf 0 0 Td (Hi) Tj ET");
   Resources res;
   res.x_object["Fm0"] = &form;
@@ -236,7 +237,7 @@ TEST(PdfPageText, form_xobject_invoked) {
 }
 
 // The form `/Matrix` concatenates onto the CTM, placing the form's content.
-TEST(PdfPageText, form_xobject_matrix_applies) {
+TEST(PdfPageExtractor, form_xobject_matrix_applies) {
   XObject form = form_x_object("BT /F1 10 Tf 0 0 Td (X) Tj ET");
   form.matrix = Transform2D::translation(100, 200);
   Resources res;
@@ -250,7 +251,7 @@ TEST(PdfPageText, form_xobject_matrix_applies) {
 
 // The CTM (incl. the form matrix) is restored after the form, so following page
 // content is unaffected.
-TEST(PdfPageText, form_xobject_restores_state) {
+TEST(PdfPageExtractor, form_xobject_restores_state) {
   XObject form = form_x_object("BT /F1 10 Tf 0 0 Td (a) Tj ET");
   form.matrix = Transform2D::translation(100, 0);
   Resources res;
@@ -263,7 +264,7 @@ TEST(PdfPageText, form_xobject_restores_state) {
 }
 
 // A form resolves fonts against its own `/Resources`, not the invoking scope.
-TEST(PdfPageText, form_xobject_uses_own_resources) {
+TEST(PdfPageExtractor, form_xobject_uses_own_resources) {
   Font font = simple_font('A', {500});
   Resources form_res;
   form_res.font["F1"] = &font;
@@ -279,7 +280,7 @@ TEST(PdfPageText, form_xobject_uses_own_resources) {
 }
 
 // Forms nest: a form may invoke another form (resolved in its own resources).
-TEST(PdfPageText, form_xobject_nested) {
+TEST(PdfPageExtractor, form_xobject_nested) {
   XObject inner = form_x_object("BT /F1 10 Tf 0 0 Td (in) Tj ET");
   Resources inner_res;
   inner_res.x_object["Inner"] = &inner;
@@ -294,8 +295,8 @@ TEST(PdfPageText, form_xobject_nested) {
   EXPECT_EQ(texts[0].codes, "in");
 }
 
-// Image XObjects are recognized but not rendered (stage 4): `Do` is a no-op.
-TEST(PdfPageText, image_xobject_ignored) {
+// Image XObjects are recognized but not rendered: `Do` is a no-op.
+TEST(PdfPageExtractor, image_xobject_ignored) {
   XObject image;
   image.subtype = XObject::Subtype::image;
   Resources res;
@@ -305,14 +306,14 @@ TEST(PdfPageText, image_xobject_ignored) {
 }
 
 // An unknown XObject name is skipped without throwing.
-TEST(PdfPageText, unknown_xobject_ignored) {
+TEST(PdfPageExtractor, unknown_xobject_ignored) {
   EXPECT_TRUE(run("/Missing Do").empty());
 }
 
 // A form that invokes itself (a cyclic graph, as the parser now represents it)
 // terminates at render time: the body runs once, the re-entrant `Do` is
 // skipped.
-TEST(PdfPageText, form_xobject_self_cycle_terminates) {
+TEST(PdfPageExtractor, form_xobject_self_cycle_terminates) {
   XObject form = form_x_object("BT /F1 10 Tf 0 0 Td (a) Tj ET /Self Do");
   Resources form_res;
   form_res.x_object["Self"] = &form; // the form references itself
@@ -329,7 +330,7 @@ TEST(PdfPageText, form_xobject_self_cycle_terminates) {
 // The text rendering mode (`Tr`) rides along on each element; the HTML layer
 // turns the unpainted modes (3 invisible, 7 clip-only) into transparent but
 // still selectable spans.
-TEST(PdfPageText, rendering_mode_propagates) {
+TEST(PdfPageExtractor, rendering_mode_propagates) {
   const auto texts = run("BT /F1 10 Tf 3 Tr 0 0 Td (x) Tj ET");
   ASSERT_EQ(texts.size(), 1);
   EXPECT_EQ(texts[0].rendering_mode, 3);
@@ -338,7 +339,7 @@ TEST(PdfPageText, rendering_mode_propagates) {
 // A composite font with no `/ToUnicode` and no usable predefined encoding has
 // no recoverable Unicode: the segment is marked `no_unicode` with empty text
 // (the glyphs render once the embedded font lands in stage 3).
-TEST(PdfPageText, no_unicode_marks_composite_without_tounicode) {
+TEST(PdfPageExtractor, no_unicode_marks_composite_without_tounicode) {
   Font font;
   font.composite = true; // 2-byte codes, empty cmap, no cid_encoding_name
   Resources res;
@@ -353,7 +354,7 @@ TEST(PdfPageText, no_unicode_marks_composite_without_tounicode) {
 
 // `/ActualText` on a marked-content sequence overrides the per-glyph text for
 // extraction (ligatures, reordered glyphs); a literal string is taken as-is.
-TEST(PdfPageText, actual_text_overrides_segment) {
+TEST(PdfPageExtractor, actual_text_overrides_segment) {
   const auto texts =
       run("BT /F1 10 Tf 0 0 Td /Span <</ActualText (OK)>> BDC (xyz) Tj EMC ET");
   ASSERT_EQ(texts.size(), 1);
@@ -364,7 +365,7 @@ TEST(PdfPageText, actual_text_overrides_segment) {
 
 // A UTF-16BE `/ActualText` (the common form, opening with the FE FF BOM) is
 // decoded to UTF-8.
-TEST(PdfPageText, actual_text_utf16be) {
+TEST(PdfPageExtractor, actual_text_utf16be) {
   // <FEFF 0041 0042> = "AB"
   const auto texts = run("BT /F1 10 Tf 0 0 Td /Span <</ActualText "
                          "<FEFF00410042>>> BDC (zz) Tj EMC ET");
@@ -374,7 +375,7 @@ TEST(PdfPageText, actual_text_utf16be) {
 
 // A non-BOM `/ActualText` is PDFDocEncoding, not Latin-1: the upper-half bytes
 // 0x83/0x84 decode to ellipsis/em dash, not the C1 controls Latin-1 would give.
-TEST(PdfPageText, actual_text_pdfdocencoding) {
+TEST(PdfPageExtractor, actual_text_pdfdocencoding) {
   const auto texts = run("BT /F1 10 Tf 0 0 Td /Span <</ActualText "
                          "<8384>>> BDC (zz) Tj EMC ET");
   ASSERT_EQ(texts.size(), 1);
@@ -383,7 +384,7 @@ TEST(PdfPageText, actual_text_pdfdocencoding) {
 
 // `/ActualText` covers the whole sequence: it is emitted once, and the
 // remaining shows in the sequence carry no extractable text of their own.
-TEST(PdfPageText, actual_text_emitted_once_then_suppressed) {
+TEST(PdfPageExtractor, actual_text_emitted_once_then_suppressed) {
   const auto texts = run("BT /F1 10 Tf 0 0 Td /Span <</ActualText (Sum)>> BDC "
                          "(a) Tj (b) Tj EMC ET");
   ASSERT_EQ(texts.size(), 2);
@@ -393,7 +394,7 @@ TEST(PdfPageText, actual_text_emitted_once_then_suppressed) {
 
 // A named property list (`BDC /Tag /Name`) resolves `/ActualText` through the
 // `/Properties` resource subdictionary.
-TEST(PdfPageText, actual_text_named_property) {
+TEST(PdfPageExtractor, actual_text_named_property) {
   Dictionary props;
   props["ActualText"] = Object(StandardString("Z"));
   Resources res;
@@ -407,14 +408,14 @@ TEST(PdfPageText, actual_text_named_property) {
 
 // Marked content without `/ActualText` (a plain `BMC`, or a `BDC` whose
 // property list carries none) leaves extraction untouched.
-TEST(PdfPageText, marked_content_without_actual_text_passthrough) {
+TEST(PdfPageExtractor, marked_content_without_actual_text_passthrough) {
   const auto texts = run("BT /F1 10 Tf 0 0 Td /Tag BMC (hi) Tj EMC ET");
   ASSERT_EQ(texts.size(), 1);
   EXPECT_EQ(texts[0].text, "hi"); // no font -> raw codes, no override
 }
 
 // A stray `EMC` (more ends than begins) is tolerated, not a crash.
-TEST(PdfPageText, stray_emc_tolerated) {
+TEST(PdfPageExtractor, stray_emc_tolerated) {
   const auto texts = run("BT /F1 10 Tf 0 0 Td EMC (ok) Tj ET");
   ASSERT_EQ(texts.size(), 1);
   EXPECT_EQ(texts[0].text, "ok");
@@ -424,7 +425,7 @@ TEST(PdfPageText, stray_emc_tolerated) {
 
 // A forward gap past ~0.2 em between segments on a line infers a space, so a
 // producer that emits no space glyph still yields separable words.
-TEST(PdfPageText, space_inferred_on_word_gap) {
+TEST(PdfPageExtractor, space_inferred_on_word_gap) {
   Font font = simple_font('A', {500, 500}); // A, B = 0.5 em
   Resources res;
   res.font["F1"] = &font;
@@ -437,7 +438,7 @@ TEST(PdfPageText, space_inferred_on_word_gap) {
 }
 
 // Abutting segments (the next begins where the last ended) get no space.
-TEST(PdfPageText, no_space_when_abutting) {
+TEST(PdfPageExtractor, no_space_when_abutting) {
   Font font = simple_font('A', {500, 500});
   Resources res;
   res.font["F1"] = &font;
@@ -448,7 +449,7 @@ TEST(PdfPageText, no_space_when_abutting) {
 }
 
 // A small `TJ` kern stays below threshold (no space); a large one crosses it.
-TEST(PdfPageText, tj_kern_threshold) {
+TEST(PdfPageExtractor, tj_kern_threshold) {
   Font font = simple_font('A', {500, 500});
   Resources res;
   res.font["F1"] = &font;
@@ -460,7 +461,7 @@ TEST(PdfPageText, tj_kern_threshold) {
 }
 
 // A perpendicular jump (a new text line) infers a space so lines don't merge.
-TEST(PdfPageText, space_inferred_on_new_line) {
+TEST(PdfPageExtractor, space_inferred_on_new_line) {
   Font font = simple_font('A', {500, 500});
   Resources res;
   res.font["F1"] = &font;
@@ -473,7 +474,7 @@ TEST(PdfPageText, space_inferred_on_new_line) {
 // A suppressed segment (the tail of an `/ActualText` span, a `no_unicode`
 // glyph) carries no extractable text, but must not clear the trailing space of
 // the segment before it, or the next gap would infer a second space.
-TEST(PdfPageText, trailing_space_survives_suppressed_segment) {
+TEST(PdfPageExtractor, trailing_space_survives_suppressed_segment) {
   Font font = simple_font('A', {500, 500}); // A, B = 0.5 em
   Resources res;
   res.font["F1"] = &font;
@@ -490,7 +491,7 @@ TEST(PdfPageText, trailing_space_survives_suppressed_segment) {
 }
 
 // A segment whose text already ends in a space suppresses the inferred one.
-TEST(PdfPageText, no_double_space_after_trailing_space) {
+TEST(PdfPageExtractor, no_double_space_after_trailing_space) {
   Font font = simple_font('A', {500, 500}); // 'A'=5, the space falls back to 0
   Resources res;
   res.font["F1"] = &font;
@@ -500,4 +501,168 @@ TEST(PdfPageText, no_double_space_after_trailing_space) {
   ASSERT_EQ(texts.size(), 2);
   EXPECT_EQ(texts[0].text, "A ");
   EXPECT_EQ(texts[1].text, "B");
+}
+
+namespace {
+
+std::vector<PageElement> run_page(const std::string &content) {
+  Resources resources;
+  return extract_page(content, resources, Logger::null());
+}
+
+const PathElement &path_at(const std::vector<PageElement> &page,
+                           std::size_t index) {
+  return std::get<PathElement>(page.at(index));
+}
+
+} // namespace
+
+// A move/line/stroke builds one open subpath; the points are in user space and
+// the paint intent is stroke-only.
+TEST(PdfPageExtractor, path_move_line_stroke) {
+  const auto page = run_page("100 200 m 300 400 l S");
+  ASSERT_EQ(page.size(), 1);
+  const PathElement &p = path_at(page, 0);
+  EXPECT_TRUE(p.stroke);
+  EXPECT_FALSE(p.fill);
+  ASSERT_EQ(p.subpaths.size(), 1);
+  const Subpath &s = p.subpaths[0];
+  EXPECT_FALSE(s.closed);
+  EXPECT_DOUBLE_EQ(s.start[0], 100);
+  EXPECT_DOUBLE_EQ(s.start[1], 200);
+  ASSERT_EQ(s.segments.size(), 1);
+  EXPECT_EQ(s.segments[0].kind, PathSegment::Kind::line);
+  EXPECT_DOUBLE_EQ(s.segments[0].end[0], 300);
+  EXPECT_DOUBLE_EQ(s.segments[0].end[1], 400);
+}
+
+// `re` appends a closed rectangle subpath; `f` fills it with nonzero winding.
+TEST(PdfPageExtractor, path_rectangle_fill_nonzero) {
+  const auto page = run_page("10 20 30 40 re f");
+  ASSERT_EQ(page.size(), 1);
+  const PathElement &p = path_at(page, 0);
+  EXPECT_TRUE(p.fill);
+  EXPECT_FALSE(p.stroke);
+  EXPECT_FALSE(p.even_odd);
+  ASSERT_EQ(p.subpaths.size(), 1);
+  const Subpath &s = p.subpaths[0];
+  EXPECT_TRUE(s.closed);
+  EXPECT_DOUBLE_EQ(s.start[0], 10);
+  EXPECT_DOUBLE_EQ(s.start[1], 20);
+  ASSERT_EQ(s.segments.size(), 3);
+  EXPECT_DOUBLE_EQ(s.segments[0].end[0], 40); // 10 + 30
+  EXPECT_DOUBLE_EQ(s.segments[0].end[1], 20);
+  EXPECT_DOUBLE_EQ(s.segments[2].end[0], 10);
+  EXPECT_DOUBLE_EQ(s.segments[2].end[1], 60); // 20 + 40
+}
+
+// `f*` selects the even-odd fill rule.
+TEST(PdfPageExtractor, path_fill_evenodd) {
+  const auto page = run_page("0 0 10 10 re f*");
+  ASSERT_EQ(page.size(), 1);
+  EXPECT_TRUE(path_at(page, 0).even_odd);
+}
+
+// `b` closes the open subpath, then fills and strokes it.
+TEST(PdfPageExtractor, path_close_fill_stroke) {
+  const auto page = run_page("0 0 m 10 0 l 10 10 l b");
+  ASSERT_EQ(page.size(), 1);
+  const PathElement &p = path_at(page, 0);
+  EXPECT_TRUE(p.fill);
+  EXPECT_TRUE(p.stroke);
+  ASSERT_EQ(p.subpaths.size(), 1);
+  EXPECT_TRUE(p.subpaths[0].closed);
+}
+
+// The CTM in force at construction maps the points into user space.
+TEST(PdfPageExtractor, path_points_under_ctm) {
+  const auto page = run_page("2 0 0 2 5 5 cm 10 10 m 20 10 l S");
+  ASSERT_EQ(page.size(), 1);
+  const Subpath &s = path_at(page, 0).subpaths[0];
+  EXPECT_DOUBLE_EQ(s.start[0], 25); // 10*2 + 5
+  EXPECT_DOUBLE_EQ(s.start[1], 25);
+  EXPECT_DOUBLE_EQ(s.segments[0].end[0], 45); // 20*2 + 5
+  EXPECT_DOUBLE_EQ(s.segments[0].end[1], 25);
+}
+
+// `c` is a cubic Bézier carrying both control points; `v` and `y` derive one.
+TEST(PdfPageExtractor, path_cubic_beziers) {
+  const auto page = run_page("0 0 m 1 1 2 2 3 3 c 4 4 5 5 v 6 6 7 7 y S");
+  ASSERT_EQ(page.size(), 1);
+  const Subpath &s = path_at(page, 0).subpaths[0];
+  ASSERT_EQ(s.segments.size(), 3);
+  // c: explicit controls
+  EXPECT_EQ(s.segments[0].kind, PathSegment::Kind::cubic);
+  EXPECT_DOUBLE_EQ(s.segments[0].c1[0], 1);
+  EXPECT_DOUBLE_EQ(s.segments[0].c2[0], 2);
+  EXPECT_DOUBLE_EQ(s.segments[0].end[0], 3);
+  // v: first control is the current point (3,3)
+  EXPECT_DOUBLE_EQ(s.segments[1].c1[0], 3);
+  EXPECT_DOUBLE_EQ(s.segments[1].c1[1], 3);
+  EXPECT_DOUBLE_EQ(s.segments[1].end[0], 5);
+  // y: second control coincides with the endpoint (7,7)
+  EXPECT_DOUBLE_EQ(s.segments[2].c2[0], 7);
+  EXPECT_DOUBLE_EQ(s.segments[2].end[0], 7);
+}
+
+// `n` discards the path (its only use today is after a clip operator).
+TEST(PdfPageExtractor, path_end_no_paint_emits_nothing) {
+  const auto page = run_page("0 0 10 10 re n");
+  EXPECT_TRUE(page.empty());
+}
+
+// Device colors are snapshotted onto the element as the current fill/stroke.
+TEST(PdfPageExtractor, path_snapshots_device_colors) {
+  const auto page = run_page("1 0 0 rg 0 0 1 RG 0 0 10 10 re B");
+  ASSERT_EQ(page.size(), 1);
+  const PathElement &p = path_at(page, 0);
+  EXPECT_EQ(p.fill_color.space, ColorSpace::device_rgb);
+  EXPECT_DOUBLE_EQ(p.fill_color.rgb[0], 1);
+  EXPECT_EQ(p.stroke_color.space, ColorSpace::device_rgb);
+  EXPECT_DOUBLE_EQ(p.stroke_color.rgb[2], 1);
+}
+
+// A path stroked without `w`/`M`/`J`/`j` carries the PDF initial line params
+// (line width 1, miter limit 10, butt cap, miter join), not zeros.
+TEST(PdfPageExtractor, path_stroke_uses_initial_line_defaults) {
+  const auto page = run_page("0 0 m 10 0 l S");
+  ASSERT_EQ(page.size(), 1);
+  const PathElement &p = path_at(page, 0);
+  EXPECT_DOUBLE_EQ(p.line_width, 1);
+  EXPECT_DOUBLE_EQ(p.miter_limit, 10);
+  EXPECT_EQ(p.line_cap, 0);
+  EXPECT_EQ(p.line_join, 0);
+}
+
+// Explicit line-style operators are snapshotted onto the element.
+TEST(PdfPageExtractor, path_snapshots_line_params) {
+  const auto page = run_page("3 w 1 J 2 j 5 M 0 0 m 10 0 l S");
+  ASSERT_EQ(page.size(), 1);
+  const PathElement &p = path_at(page, 0);
+  EXPECT_DOUBLE_EQ(p.line_width, 3);
+  EXPECT_EQ(p.line_cap, 1);
+  EXPECT_EQ(p.line_join, 2);
+  EXPECT_DOUBLE_EQ(p.miter_limit, 5);
+}
+
+// The paint-time CTM is captured so the renderer can scale the (unscaled) line
+// width even though the geometry is already flattened to user space.
+TEST(PdfPageExtractor, path_captures_paint_ctm) {
+  const auto page = run_page("2 0 0 3 5 7 cm 0 0 m 10 0 l S");
+  ASSERT_EQ(page.size(), 1);
+  const PathElement &p = path_at(page, 0);
+  EXPECT_DOUBLE_EQ(p.ctm.a, 2);
+  EXPECT_DOUBLE_EQ(p.ctm.d, 3);
+  EXPECT_DOUBLE_EQ(p.ctm.e, 5);
+  EXPECT_DOUBLE_EQ(p.ctm.f, 7);
+}
+
+// Text and paths come out interleaved in paint order.
+TEST(PdfPageExtractor, page_preserves_paint_order) {
+  const auto page =
+      run_page("0 0 10 10 re f BT /F1 10 Tf (Hi) Tj ET 5 5 m 6 6 l S");
+  ASSERT_EQ(page.size(), 3);
+  EXPECT_TRUE(std::holds_alternative<PathElement>(page[0]));
+  EXPECT_TRUE(std::holds_alternative<TextElement>(page[1]));
+  EXPECT_TRUE(std::holds_alternative<PathElement>(page[2]));
 }

--- a/test/src/internal/pdf/pdf_page_extractor.cpp
+++ b/test/src/internal/pdf/pdf_page_extractor.cpp
@@ -337,8 +337,7 @@ TEST(PdfPageExtractor, rendering_mode_propagates) {
 }
 
 // A composite font with no `/ToUnicode` and no usable predefined encoding has
-// no recoverable Unicode: the segment is marked `no_unicode` with empty text
-// (the glyphs render once the embedded font lands in stage 3).
+// no recoverable Unicode: the segment is marked `no_unicode` with empty text.
 TEST(PdfPageExtractor, no_unicode_marks_composite_without_tounicode) {
   Font font;
   font.composite = true; // 2-byte codes, empty cmap, no cid_encoding_name
@@ -420,8 +419,6 @@ TEST(PdfPageExtractor, stray_emc_tolerated) {
   ASSERT_EQ(texts.size(), 1);
   EXPECT_EQ(texts[0].text, "ok");
 }
-
-// --- Stage 2.5: space inference ---
 
 // A forward gap past ~0.2 em between segments on a line infers a space, so a
 // producer that emits no space glyph still yields separable words.


### PR DESCRIPTION
🤖 Generated with [Claude Code](https://claude.com/claude-code)

First PR of **stage 4 (graphics)**. Foundational refactor — **no visual change yet**.

Today the page-content executor is text-only (`extract_text` → `TextElement[]`); path/image operators are tokenized but their geometry is discarded. Stage 4 needs an ordered, paint-order element stream so vector graphics can interleave faithfully with the existing text spans (z-order: a fill painted after text occludes it and vice versa).

## What this does
- Introduces `PageElement = std::variant<TextElement, PathElement>`. `extract_page` returns the full ordered stream in paint order; `extract_text` becomes its text-only projection (the HTML layer is unchanged).
- `GraphicsState` now **accumulates path geometry**: `m`/`l`/`c`/`v`/`y`/`h`/`re` build `Subpath`s in user space, with the CTM applied at construction (ISO 32000-1 8.5.2.1). The current path is a standalone member, not part of the `q`/`Q` stack (8.5.2).
- Path-painting operators (`S s f F f* B B* b b* n`) emit a `PathElement` snapshotting geometry, paint intent (fill/stroke), fill rule, colors and line params, then clear the path.
- Device color operators (`g/rg/k`, `G/RG/K`) now also set the color-space enum, so the snapshotted color is self-describing.

## Tests
Adds assertion-based path-extraction tests (move/line/stroke, rectangle fill, even-odd, close+fill+stroke, points under CTM, cubic `c`/`v`/`y`, `n` discards, device-color snapshot, and text/path paint-order interleave). Full PDF suite green (124 tests).

Also adds `STAGE4_PLAN.md` — the PR-by-PR plan for the whole stage.

Stacked PR 1/3 (4.1 SVG fills and 4.2 strokes follow on top).