### PR TITLE
PDF stage 4.7: inline images (BI/ID/EI)

### DIFF
--- a/src/odr/internal/pdf/pdf_document_parser.cpp
+++ b/src/odr/internal/pdf/pdf_document_parser.cpp
@@ -541,49 +541,31 @@ void parse_image_data(DocumentParser &parser, const Dictionary &dictionary,
   if (dictionary.has_key("DecodeParms")) {
     decode_parms = parser.deep_resolve_object_copy(dictionary["DecodeParms"]);
   }
-  const std::optional<std::string> terminal = terminal_image_codec(filter);
 
-  if (terminal == "DCTDecode") {
-    DecodeResult result =
-        decode(filter, decode_parms, parser.read_object_stream(object));
-    if (result.stopped_at_filter == "DCTDecode") {
-      x_object.image_data = std::move(result.data);
-      x_object.image_mime = "image/jpeg";
-    }
-    return;
+  // Resolve the raster parameters (a JPEG pass-through ignores them). The
+  // colour space resolves device spaces and inline Indexed/ICCBased arrays; a
+  // bare named resource space is out of scope here (no resource dictionary at
+  // parse time), so the raster path skips such an image.
+  std::shared_ptr<ColorSpaceDef> color_space;
+  if (dictionary.has_value("ColorSpace")) {
+    ColorSpaceContext context;
+    context.resolve = [&parser](const Object &o) {
+      return parser.resolve_object_copy(o);
+    };
+    context.load_stream = [&parser](const Object &o) {
+      return o.is_reference() ? parser.read_decoded_stream(o.as_reference())
+                              : std::string{};
+    };
+    color_space = parse_color_space(dictionary.get("ColorSpace"), context);
   }
-  if (terminal.has_value()) {
-    return; // JPX/CCITT/JBIG2: not yet a pass-through (later stages)
-  }
-
-  // A fully decodable raster: assemble its samples and PNG-encode. Needs a
-  // resolvable colour space (a device space or an inline Indexed/ICCBased
-  // array; a bare named resource space is out of scope here — no resource
-  // dictionary at parse time).
-  if (!dictionary.has_value("ColorSpace")) {
-    return;
-  }
-  ColorSpaceContext context;
-  context.resolve = [&parser](const Object &o) {
-    return parser.resolve_object_copy(o);
-  };
-  context.load_stream = [&parser](const Object &o) {
-    return o.is_reference() ? parser.read_decoded_stream(o.as_reference())
-                            : std::string{};
-  };
-  const std::shared_ptr<ColorSpaceDef> color_space =
-      parse_color_space(dictionary.get("ColorSpace"), context);
-  if (color_space == nullptr) {
-    return;
-  }
-
-  const std::optional<Integer> width =
-      parser.resolve_object_copy(dictionary.get("Width")).as_integer_opt();
-  const std::optional<Integer> height =
-      parser.resolve_object_copy(dictionary.get("Height")).as_integer_opt();
-  if (!width.has_value() || !height.has_value()) {
-    return;
-  }
+  const auto width = static_cast<std::int32_t>(
+      parser.resolve_object_copy(dictionary.get("Width"))
+          .as_integer_opt()
+          .value_or(0));
+  const auto height = static_cast<std::int32_t>(
+      parser.resolve_object_copy(dictionary.get("Height"))
+          .as_integer_opt()
+          .value_or(0));
   const auto bits_per_component = static_cast<std::int32_t>(
       parser.resolve_object_copy(dictionary.get("BitsPerComponent"))
           .as_integer_opt()
@@ -598,18 +580,11 @@ void parse_image_data(DocumentParser &parser, const Dictionary &dictionary,
     }
   }
 
-  DecodeResult result =
-      decode(filter, decode_parms, parser.read_object_stream(object));
-  if (result.stopped_at_filter.has_value()) {
-    return;
-  }
-  std::string png =
-      encode_image_png(result.data, static_cast<std::int32_t>(*width),
-                       static_cast<std::int32_t>(*height), bits_per_component,
-                       *color_space, decode_array);
-  if (!png.empty()) {
-    x_object.image_data = std::move(png);
-    x_object.image_mime = "image/png";
+  if (std::optional<EncodedImage> encoded = encode_image(
+          parser.read_object_stream(object), filter, decode_parms, width,
+          height, bits_per_component, color_space.get(), decode_array)) {
+    x_object.image_data = std::move(encoded->data);
+    x_object.image_mime = std::move(encoded->mime);
   }
 }
 

--- a/src/odr/internal/pdf/pdf_graphics_operator_parser.cpp
+++ b/src/odr/internal/pdf/pdf_graphics_operator_parser.cpp
@@ -3,7 +3,9 @@
 #include <odr/internal/pdf/pdf_graphics_operator.hpp>
 #include <odr/internal/util/map_util.hpp>
 
+#include <cstdint>
 #include <iostream>
+#include <optional>
 #include <unordered_map>
 
 namespace odr::internal::pdf {
@@ -106,6 +108,85 @@ GraphicsOperatorType operator_name_to_type(const std::string &name) {
                                    GraphicsOperatorType::unknown);
 }
 
+// Fetch an inline image dictionary entry by either its abbreviated or its long
+// key (8.9.7, Table 93), since both spellings are permitted.
+const Object &inline_image_entry(const Dictionary &dictionary,
+                                 const std::string &abbrev,
+                                 const std::string &full) {
+  if (const Object &value = dictionary.get(abbrev); !value.is_null()) {
+    return value;
+  }
+  return dictionary.get(full);
+}
+
+// Sample components of an inline image's colour space, but only for the device
+// spaces that are self-contained in inline content. Named spaces (page
+// `/ColorSpace` resources) and `/Indexed` arrays are not resolved here.
+std::optional<int> inline_color_components(const Object &color_space) {
+  if (!color_space.is_name()) {
+    return std::nullopt;
+  }
+  const std::string &name = color_space.as_name();
+  if (name == "G" || name == "DeviceGray") {
+    return 1;
+  }
+  if (name == "RGB" || name == "DeviceRGB") {
+    return 3;
+  }
+  if (name == "CMYK" || name == "DeviceCMYK") {
+    return 4;
+  }
+  return std::nullopt;
+}
+
+// Byte length of an inline image's raw data, derived from its sample geometry —
+// but only when that length is knowable: the image must be unfiltered (a
+// filtered payload's size is unknown until decoded) and its colour space must
+// be a device space. Returns `nullopt` otherwise, leaving the caller to scan
+// for the `EI` terminator.
+std::optional<std::size_t>
+inline_image_raw_length(const Dictionary &dictionary) {
+  if (!inline_image_entry(dictionary, "F", "Filter").is_null()) {
+    return std::nullopt;
+  }
+
+  int components;
+  int bits_per_component;
+  if (inline_image_entry(dictionary, "IM", "ImageMask")
+          .as_bool_opt()
+          .value_or(false)) {
+    // A stencil mask is one bit per sample (8.9.6.2).
+    components = 1;
+    bits_per_component = 1;
+  } else {
+    const std::optional<int> resolved = inline_color_components(
+        inline_image_entry(dictionary, "CS", "ColorSpace"));
+    if (!resolved.has_value()) {
+      return std::nullopt;
+    }
+    components = *resolved;
+    bits_per_component = static_cast<int>(
+        inline_image_entry(dictionary, "BPC", "BitsPerComponent")
+            .as_integer_opt()
+            .value_or(8));
+  }
+
+  const std::int64_t width =
+      inline_image_entry(dictionary, "W", "Width").as_integer_opt().value_or(0);
+  const std::int64_t height = inline_image_entry(dictionary, "H", "Height")
+                                  .as_integer_opt()
+                                  .value_or(0);
+  if (width <= 0 || height <= 0 || bits_per_component <= 0) {
+    return std::nullopt;
+  }
+
+  // Each sample row is padded to a byte boundary (8.9.5.2).
+  const std::size_t bits_per_row =
+      static_cast<std::size_t>(width) * components * bits_per_component;
+  const std::size_t bytes_per_row = (bits_per_row + 7) / 8;
+  return bytes_per_row * static_cast<std::size_t>(height);
+}
+
 } // namespace
 
 using char_type = std::streambuf::char_type;
@@ -183,7 +264,7 @@ GraphicsOperator GraphicsOperatorParser::read_operator() {
   // mis-tokenized as operators), so the operator carries `[dict, bytes]`.
   if (result.type == GraphicsOperatorType::begin_inline_image_data) {
     Dictionary dictionary = read_inline_image_dictionary(result.arguments);
-    std::string data = read_inline_image_data();
+    std::string data = read_inline_image_data(dictionary);
     result.arguments.clear();
     result.arguments.emplace_back(std::move(dictionary));
     result.arguments.emplace_back(StandardString(std::move(data)));
@@ -207,17 +288,46 @@ Dictionary GraphicsOperatorParser::read_inline_image_dictionary(
   return dictionary;
 }
 
-std::string GraphicsOperatorParser::read_inline_image_data() {
+std::string
+GraphicsOperatorParser::read_inline_image_data(const Dictionary &dictionary) {
   // Exactly one white-space character separates `ID` from the data (8.9.7).
   if (m_parser.geti() != eof) {
     m_parser.bumpc();
   }
 
-  // The length is not encoded, so scan for the `EI` terminator. `EI` also
-  // occurs inside the raw image bytes, so only accept one that is followed by
-  // white-space or eof; otherwise keep the bytes and keep scanning. The
-  // terminator (and the white-space convention before it) is left out of the
-  // captured data.
+  // When the byte length is knowable (an unfiltered device-colour image), read
+  // exactly that many bytes. This is the only reliable terminator: raw samples
+  // can contain the bytes `E I <white-space>`, which the scan below would
+  // mistake for the real `EI` and so truncate the image (and corrupt the rest
+  // of the page).
+  if (const std::optional<std::size_t> length =
+          inline_image_raw_length(dictionary)) {
+    std::string data;
+    data.reserve(*length);
+    for (std::size_t i = 0; i < *length; ++i) {
+      const int_type c = m_parser.geti();
+      if (c == eof) {
+        return data;
+      }
+      m_parser.bumpc();
+      data += static_cast<char_type>(c);
+    }
+    // Consume the trailing `EI` (and the conventional white-space before it).
+    m_parser.skip_whitespace();
+    if (m_parser.geti() == 'E') {
+      m_parser.bumpc();
+      if (m_parser.geti() == 'I') {
+        m_parser.bumpc();
+      }
+    }
+    return data;
+  }
+
+  // Otherwise the length is not encoded (a filtered payload), so scan for the
+  // `EI` terminator. `EI` also occurs inside the encoded bytes, so accept one
+  // only when it is bracketed by white-space — preceded by it (the writer's
+  // convention) and followed by it or eof — which makes a false match unlikely.
+  // The terminator (and the white-space before it) is left out of the data.
   std::string data;
   while (true) {
     const int_type c = m_parser.geti();
@@ -226,7 +336,9 @@ std::string GraphicsOperatorParser::read_inline_image_data() {
     }
     m_parser.bumpc();
     if (c == 'E') {
-      if (m_parser.geti() == 'I') {
+      const bool preceded_by_whitespace =
+          data.empty() || ObjectParser::is_whitespace(data.back());
+      if (preceded_by_whitespace && m_parser.geti() == 'I') {
         m_parser.bumpc();
         const int_type after = m_parser.geti();
         if (after == eof ||

--- a/src/odr/internal/pdf/pdf_graphics_operator_parser.cpp
+++ b/src/odr/internal/pdf/pdf_graphics_operator_parser.cpp
@@ -140,6 +140,7 @@ std::string GraphicsOperatorParser::read_operator_name() {
 GraphicsOperator GraphicsOperatorParser::read_operator() {
   GraphicsOperator result;
 
+  std::string operator_name;
   while (true) {
     if (m_parser.peek_number()) {
       std::visit([&](auto v) { result.arguments.emplace_back(v); },
@@ -154,22 +155,38 @@ GraphicsOperator GraphicsOperatorParser::read_operator() {
     } else if (m_parser.peek_dictionary()) {
       result.arguments.emplace_back(m_parser.read_dictionary());
     } else {
-      m_parser.skip_whitespace();
-      break;
+      // A bareword here is either a `true`/`false` literal (a value inside an
+      // inline image dictionary, 8.9.7) or the operator name that ends the
+      // arguments. `peek_boolean` cannot disambiguate these because operators
+      // such as `f` (fill) or `Tj` share their leading character with the
+      // boolean keywords, so read the whole word and compare it.
+      operator_name = read_operator_name();
+      if (operator_name == "true") {
+        result.arguments.emplace_back(Boolean(true));
+      } else if (operator_name == "false") {
+        result.arguments.emplace_back(Boolean(false));
+      } else {
+        break;
+      }
     }
     m_parser.skip_whitespace();
   }
 
-  const std::string operator_name = read_operator_name();
   result.type = operator_name_to_type(operator_name);
   if (result.type == GraphicsOperatorType::unknown) {
     std::cerr << "unknown operator: " << operator_name << '\n';
   }
 
-  // After `ID` the raw image bytes follow inline; consume them up to `EI` so
-  // they are not mis-tokenized as operators (which corrupts the parse state).
+  // `BI <key val …> ID <bytes> EI` is one inline image (8.9.7). The key/value
+  // pairs were just read as this operator's arguments; fold them into a
+  // dictionary and capture the raw bytes (also stopping them from being
+  // mis-tokenized as operators), so the operator carries `[dict, bytes]`.
   if (result.type == GraphicsOperatorType::begin_inline_image_data) {
-    skip_inline_image_data();
+    Dictionary dictionary = read_inline_image_dictionary(result.arguments);
+    std::string data = read_inline_image_data();
+    result.arguments.clear();
+    result.arguments.emplace_back(std::move(dictionary));
+    result.arguments.emplace_back(StandardString(std::move(data)));
   }
 
   m_parser.skip_whitespace();
@@ -177,7 +194,20 @@ GraphicsOperator GraphicsOperatorParser::read_operator() {
   return result;
 }
 
-void GraphicsOperatorParser::skip_inline_image_data() {
+Dictionary GraphicsOperatorParser::read_inline_image_dictionary(
+    const std::vector<Object> &arguments) {
+  // The inline dictionary is a flat run of name/value pairs (8.9.7).
+  // Abbreviated keys are normalized to their long forms downstream.
+  Dictionary dictionary;
+  for (std::size_t i = 0; i + 1 < arguments.size(); i += 2) {
+    if (arguments[i].is_name()) {
+      dictionary[arguments[i].as_name()] = arguments[i + 1];
+    }
+  }
+  return dictionary;
+}
+
+std::string GraphicsOperatorParser::read_inline_image_data() {
   // Exactly one white-space character separates `ID` from the data (8.9.7).
   if (m_parser.geti() != eof) {
     m_parser.bumpc();
@@ -185,13 +215,32 @@ void GraphicsOperatorParser::skip_inline_image_data() {
 
   // The length is not encoded, so scan for the `EI` terminator. `EI` also
   // occurs inside the raw image bytes, so only accept one that is followed by
-  // white-space or eof; otherwise keep scanning past it.
-  while (m_parser.skip_past("EI")) {
-    const int_type after = m_parser.geti();
-    if (after == eof ||
-        ObjectParser::is_whitespace(static_cast<char_type>(after))) {
-      return;
+  // white-space or eof; otherwise keep the bytes and keep scanning. The
+  // terminator (and the white-space convention before it) is left out of the
+  // captured data.
+  std::string data;
+  while (true) {
+    const int_type c = m_parser.geti();
+    if (c == eof) {
+      return data;
     }
+    m_parser.bumpc();
+    if (c == 'E') {
+      if (m_parser.geti() == 'I') {
+        m_parser.bumpc();
+        const int_type after = m_parser.geti();
+        if (after == eof ||
+            ObjectParser::is_whitespace(static_cast<char_type>(after))) {
+          return data;
+        }
+        data += 'E';
+        data += 'I';
+        continue;
+      }
+      data += 'E';
+      continue;
+    }
+    data += static_cast<char_type>(c);
   }
 }
 

--- a/src/odr/internal/pdf/pdf_graphics_operator_parser.cpp
+++ b/src/odr/internal/pdf/pdf_graphics_operator_parser.cpp
@@ -343,6 +343,13 @@ GraphicsOperatorParser::read_inline_image_data(const Dictionary &dictionary) {
         const int_type after = m_parser.geti();
         if (after == eof ||
             ObjectParser::is_whitespace(static_cast<char_type>(after))) {
+          // Drop the single white-space separator that precedes `EI`: it is the
+          // writer's delimiter, not part of the encoded payload, and a stray
+          // trailing byte corrupts the filter chain (e.g. extends a Flate
+          // stream's inflated length by one).
+          if (!data.empty()) {
+            data.pop_back();
+          }
           return data;
         }
         data += 'E';

--- a/src/odr/internal/pdf/pdf_graphics_operator_parser.cpp
+++ b/src/odr/internal/pdf/pdf_graphics_operator_parser.cpp
@@ -122,7 +122,7 @@ const Object &inline_image_entry(const Dictionary &dictionary,
 // Sample components of an inline image's colour space, but only for the device
 // spaces that are self-contained in inline content. Named spaces (page
 // `/ColorSpace` resources) and `/Indexed` arrays are not resolved here.
-std::optional<int> inline_color_components(const Object &color_space) {
+std::optional<std::int32_t> inline_color_components(const Object &color_space) {
   if (!color_space.is_name()) {
     return std::nullopt;
   }
@@ -150,8 +150,8 @@ inline_image_raw_length(const Dictionary &dictionary) {
     return std::nullopt;
   }
 
-  int components;
-  int bits_per_component;
+  std::int32_t components;
+  std::int32_t bits_per_component;
   if (inline_image_entry(dictionary, "IM", "ImageMask")
           .as_bool_opt()
           .value_or(false)) {
@@ -159,13 +159,13 @@ inline_image_raw_length(const Dictionary &dictionary) {
     components = 1;
     bits_per_component = 1;
   } else {
-    const std::optional<int> resolved = inline_color_components(
+    const std::optional<std::int32_t> resolved = inline_color_components(
         inline_image_entry(dictionary, "CS", "ColorSpace"));
     if (!resolved.has_value()) {
       return std::nullopt;
     }
     components = *resolved;
-    bits_per_component = static_cast<int>(
+    bits_per_component = static_cast<std::int32_t>(
         inline_image_entry(dictionary, "BPC", "BitsPerComponent")
             .as_integer_opt()
             .value_or(8));

--- a/src/odr/internal/pdf/pdf_graphics_operator_parser.hpp
+++ b/src/odr/internal/pdf/pdf_graphics_operator_parser.hpp
@@ -2,8 +2,13 @@
 
 #include <odr/internal/pdf/pdf_object_parser.hpp>
 
+#include <string>
+#include <vector>
+
 namespace odr::internal::pdf {
 
+class Dictionary;
+class Object;
 struct GraphicsOperator;
 
 class GraphicsOperatorParser {
@@ -18,9 +23,15 @@ public:
   [[nodiscard]] GraphicsOperator read_operator();
 
 private:
-  // Consume the binary image data of an inline image, from just after the `ID`
-  // keyword up to and including its `EI` terminator (8.9.7).
-  void skip_inline_image_data();
+  // Fold an inline image's flat name/value argument run into a dictionary
+  // (8.9.7); abbreviated keys are normalized to long forms downstream.
+  [[nodiscard]] static Dictionary
+  read_inline_image_dictionary(const std::vector<Object> &arguments);
+
+  // Read the binary image data of an inline image, from just after the `ID`
+  // keyword up to (excluding) its `EI` terminator (8.9.7), leaving the cursor
+  // past `EI`.
+  [[nodiscard]] std::string read_inline_image_data();
 
   ObjectParser m_parser;
 };

--- a/src/odr/internal/pdf/pdf_graphics_operator_parser.hpp
+++ b/src/odr/internal/pdf/pdf_graphics_operator_parser.hpp
@@ -30,8 +30,10 @@ private:
 
   // Read the binary image data of an inline image, from just after the `ID`
   // keyword up to (excluding) its `EI` terminator (8.9.7), leaving the cursor
-  // past `EI`.
-  [[nodiscard]] std::string read_inline_image_data();
+  // past `EI`. The dictionary fixes the byte length for unfiltered
+  // device-colour images; otherwise the data is scanned for the terminator.
+  [[nodiscard]] std::string
+  read_inline_image_data(const Dictionary &dictionary);
 
   ObjectParser m_parser;
 };

--- a/src/odr/internal/pdf/pdf_image.cpp
+++ b/src/odr/internal/pdf/pdf_image.cpp
@@ -2,6 +2,8 @@
 
 #include <odr/internal/crypto/crypto_util.hpp>
 #include <odr/internal/pdf/pdf_color.hpp>
+#include <odr/internal/pdf/pdf_filter.hpp>
+#include <odr/internal/pdf/pdf_object.hpp>
 #include <odr/internal/util/byte_string.hpp>
 
 #include <algorithm>
@@ -9,6 +11,7 @@
 #include <cmath>
 #include <cstdint>
 #include <string_view>
+#include <utility>
 
 namespace odr::internal::pdf {
 
@@ -165,6 +168,44 @@ std::string pdf::encode_image_png(const std::string &samples,
   }
 
   return write_png_rgb(rgb, width, height);
+}
+
+std::optional<pdf::EncodedImage>
+pdf::encode_image(std::string raw, const Object &filter,
+                  const Object &decode_parms, const std::int32_t width,
+                  const std::int32_t height,
+                  const std::int32_t bits_per_component,
+                  const ColorSpaceDef *color_space,
+                  const std::vector<double> &decode_array) {
+  const std::optional<std::string> terminal = terminal_image_codec(filter);
+
+  if (terminal == "DCTDecode") {
+    // A JPEG the browser decodes itself: hand back its bytes undecoded.
+    DecodeResult result = decode(filter, decode_parms, std::move(raw));
+    if (result.stopped_at_filter == "DCTDecode") {
+      return EncodedImage{std::move(result.data), "image/jpeg"};
+    }
+    return std::nullopt;
+  }
+  if (terminal.has_value()) {
+    return std::nullopt; // JPX/CCITT/JBIG2: not yet a pass-through
+  }
+
+  // A fully decodable raster: decode, assemble samples and PNG-encode.
+  if (color_space == nullptr) {
+    return std::nullopt;
+  }
+  DecodeResult result = decode(filter, decode_parms, std::move(raw));
+  if (result.stopped_at_filter.has_value()) {
+    return std::nullopt;
+  }
+  std::string png =
+      encode_image_png(result.data, width, height, bits_per_component,
+                       *color_space, decode_array);
+  if (png.empty()) {
+    return std::nullopt;
+  }
+  return EncodedImage{std::move(png), "image/png"};
 }
 
 } // namespace odr::internal

--- a/src/odr/internal/pdf/pdf_image.cpp
+++ b/src/odr/internal/pdf/pdf_image.cpp
@@ -170,13 +170,11 @@ std::string pdf::encode_image_png(const std::string &samples,
   return write_png_rgb(rgb, width, height);
 }
 
-std::optional<pdf::EncodedImage>
-pdf::encode_image(std::string raw, const Object &filter,
-                  const Object &decode_parms, const std::int32_t width,
-                  const std::int32_t height,
-                  const std::int32_t bits_per_component,
-                  const ColorSpaceDef *color_space,
-                  const std::vector<double> &decode_array) {
+std::optional<pdf::EncodedImage> pdf::encode_image(
+    std::string raw, const Object &filter, const Object &decode_parms,
+    const std::int32_t width, const std::int32_t height,
+    const std::int32_t bits_per_component, const ColorSpaceDef *color_space,
+    const std::vector<double> &decode_array) {
   const std::optional<std::string> terminal = terminal_image_codec(filter);
 
   if (terminal == "DCTDecode") {

--- a/src/odr/internal/pdf/pdf_image.hpp
+++ b/src/odr/internal/pdf/pdf_image.hpp
@@ -1,12 +1,35 @@
 #pragma once
 
 #include <cstdint>
+#include <optional>
 #include <string>
 #include <vector>
 
 namespace odr::internal::pdf {
 
+class Object;
 struct ColorSpaceDef;
+
+/// Browser-ready image bytes and the format naming them (`image/jpeg` or
+/// `image/png`).
+struct EncodedImage {
+  std::string data;
+  std::string mime;
+};
+
+/// Turn an image's raw (still filter-encoded) stream bytes into browser-ready
+/// bytes: a JPEG (`DCTDecode`) passes through undecoded, a fully decodable
+/// raster (Flate/LZW/RunLength/ASCII/raw) is decoded and re-encoded as PNG
+/// through `color_space`. `filter`/`decode_parms` are the resolved
+/// `/Filter`/`/DecodeParms`; `color_space` may be null (used only by the raster
+/// path — a null there yields nullopt). Returns nullopt for a codec not yet
+/// handled (JPXDecode/CCITTFaxDecode/JBIG2Decode) or an inconsistent raster.
+/// Shared by image XObjects and inline images.
+std::optional<EncodedImage>
+encode_image(std::string raw, const Object &filter, const Object &decode_parms,
+             std::int32_t width, std::int32_t height,
+             std::int32_t bits_per_component, const ColorSpaceDef *color_space,
+             const std::vector<double> &decode);
 
 /// Assemble a raster image's decoded samples into a base-level (8-bit, RGB)
 /// PNG (ISO 32000-1 8.9.5 image samples -> a browser-ready raster). `samples`

--- a/src/odr/internal/pdf/pdf_page_extractor.cpp
+++ b/src/odr/internal/pdf/pdf_page_extractor.cpp
@@ -7,13 +7,16 @@
 #include <odr/internal/pdf/pdf_graphics_operator.hpp>
 #include <odr/internal/pdf/pdf_graphics_operator_parser.hpp>
 #include <odr/internal/pdf/pdf_graphics_state.hpp>
+#include <odr/internal/pdf/pdf_image.hpp>
 #include <odr/internal/util/string_util.hpp>
 
 #include <array>
 #include <cmath>
+#include <memory>
 #include <optional>
 #include <set>
 #include <sstream>
+#include <unordered_map>
 
 namespace odr::internal::pdf {
 namespace {
@@ -413,6 +416,98 @@ void paint_path(std::vector<PageElement> &out, GraphicsState &state, bool fill,
   state.clear_path();
 }
 
+/// Map an inline image's abbreviated dictionary key to its long form
+/// (ISO 32000-1 Table 93), so the shared image path sees the same keys as an
+/// image XObject. Unknown keys pass through unchanged.
+const std::string &inline_image_long_key(const std::string &key) {
+  static const std::unordered_map<std::string, std::string> map = {
+      {"BPC", "BitsPerComponent"}, {"CS", "ColorSpace"}, {"D", "Decode"},
+      {"DP", "DecodeParms"},       {"F", "Filter"},      {"H", "Height"},
+      {"IM", "ImageMask"},         {"I", "Interpolate"}, {"W", "Width"}};
+  const auto it = map.find(key);
+  return it != map.end() ? it->second : key;
+}
+
+/// Rewrite an inline image dictionary's abbreviated keys to their long forms.
+/// (Abbreviated *values* — the filter names and the `/CS` device names — are
+/// understood by `pdf_filter` and `pdf_color` directly.)
+Dictionary normalize_inline_image(const Dictionary &raw) {
+  Dictionary result;
+  for (const auto &[key, value] : raw) {
+    result[inline_image_long_key(key)] = value;
+  }
+  return result;
+}
+
+/// Resolve an inline image's colour space. Inline content is self-contained (no
+/// indirect references), so `resolve`/`load_stream` are inert; a bare name that
+/// is not a device space is looked up in the page's `/ColorSpace` resources.
+std::shared_ptr<ColorSpaceDef>
+resolve_inline_color_space(const Object &color_space,
+                           const Resources &resources) {
+  if (color_space.is_null()) {
+    return nullptr;
+  }
+  ColorSpaceContext context;
+  context.resolve = [](const Object &o) { return o; };
+  context.load_stream = [](const Object &) { return std::string{}; };
+  context.named =
+      [&resources](const std::string &name) -> std::shared_ptr<ColorSpaceDef> {
+    const auto it = resources.color_space.find(name);
+    return it != resources.color_space.end() ? it->second : nullptr;
+  };
+  return parse_color_space(color_space, context);
+}
+
+/// Emit an `ImageElement` for an inline image (`BI`/`ID`/`EI`). The operator
+/// carries the inline dictionary and the raw bytes; both are routed through the
+/// same image emission as an image XObject (placed by the CTM, under the
+/// current clip). Image masks are deferred (4.8); an unsupported codec or
+/// colour space yields nothing.
+void emit_inline_image(const GraphicsOperator &op, const Resources &resources,
+                       GraphicsState &state, std::vector<PageElement> &out) {
+  if (op.arguments.size() < 2 || !op.arguments[0].is_dictionary() ||
+      !op.arguments[1].is_string()) {
+    return;
+  }
+  const Dictionary dictionary =
+      normalize_inline_image(op.arguments[0].as_dictionary());
+
+  if (dictionary.get("ImageMask").as_bool_opt().value_or(false)) {
+    return;
+  }
+
+  const std::shared_ptr<ColorSpaceDef> color_space =
+      resolve_inline_color_space(dictionary.get("ColorSpace"), resources);
+  const auto width = static_cast<std::int32_t>(
+      dictionary.get("Width").as_integer_opt().value_or(0));
+  const auto height = static_cast<std::int32_t>(
+      dictionary.get("Height").as_integer_opt().value_or(0));
+  const auto bits_per_component = static_cast<std::int32_t>(
+      dictionary.get("BitsPerComponent").as_integer_opt().value_or(8));
+  std::vector<double> decode_array;
+  if (const Object &d = dictionary.get("Decode"); d.is_array()) {
+    for (const Object &item : d.as_array()) {
+      decode_array.push_back(item.as_real());
+    }
+  }
+
+  std::optional<EncodedImage> encoded =
+      encode_image(op.arguments[1].as_string(), dictionary.get("Filter"),
+                   dictionary.get("DecodeParms"), width, height,
+                   bits_per_component, color_space.get(), decode_array);
+  if (!encoded.has_value()) {
+    return;
+  }
+
+  ImageElement image;
+  image.transform = state.current().general.transform_matrix;
+  image.clip = state.current().clip;
+  image.data = std::move(encoded->data);
+  image.mime = std::move(encoded->mime);
+  out.push_back(std::move(image));
+}
+
 /// Form XObjects currently being rendered, by element identity. The parser
 /// represents the file faithfully, so the XObject graph may contain cycles
 /// (the spec forbids them — ISO 32000-1 8.10.1 — but real files err); this set
@@ -553,6 +648,9 @@ void run_content(const std::string &content, const Resources &resources,
     case GraphicsOperatorType::draw_object: // Do
       invoke_x_object(op.arguments.at(0).as_string(), resources, state, out,
                       logger, warned, active, marked, pen);
+      break;
+    case GraphicsOperatorType::begin_inline_image_data: // BI … ID … EI
+      emit_inline_image(op, resources, state, out);
       break;
 
     case GraphicsOperatorType::stroke: // S

--- a/test/src/internal/pdf/pdf_page_extractor.cpp
+++ b/test/src/internal/pdf/pdf_page_extractor.cpp
@@ -2,9 +2,11 @@
 
 #include <odr/logger.hpp>
 
+#include <odr/internal/crypto/crypto_util.hpp>
 #include <odr/internal/pdf/pdf_color.hpp>
 #include <odr/internal/pdf/pdf_document_element.hpp>
 
+#include <initializer_list>
 #include <memory>
 #include <string>
 #include <variant>
@@ -921,4 +923,86 @@ TEST(PdfPageExtractor, image_in_paint_order) {
   EXPECT_TRUE(std::holds_alternative<PathElement>(page[0]));
   EXPECT_TRUE(std::holds_alternative<ImageElement>(page[1]));
   EXPECT_TRUE(std::holds_alternative<PathElement>(page[2]));
+}
+
+// --- stage 4.7: inline images (BI/ID/EI) ---------------------------------
+
+namespace {
+
+const std::string png_signature = {
+    static_cast<char>(0x89), 'P', 'N', 'G', '\r', '\n',
+    static_cast<char>(0x1A), '\n'};
+
+std::string raw_bytes(std::initializer_list<int> values) {
+  std::string result;
+  for (const int v : values) {
+    result.push_back(static_cast<char>(v));
+  }
+  return result;
+}
+
+} // namespace
+
+// `BI … ID <bytes> EI` tokenizes as one operator and emits an `ImageElement`
+// placed by the CTM, the raster re-encoded as PNG.
+TEST(PdfPageExtractor, inline_image_emitted_at_ctm) {
+  const std::string content = "q 2 0 0 3 10 20 cm "
+                              "BI /W 2 /H 1 /CS /RGB /BPC 8 ID " +
+                              raw_bytes({10, 20, 30, 40, 50, 60}) + "\nEI Q";
+  const auto page = extract_page(content, Resources{}, Logger::null());
+  ASSERT_EQ(page.size(), 1);
+  const ImageElement &img = std::get<ImageElement>(page[0]);
+  EXPECT_EQ(img.mime, "image/png");
+  EXPECT_EQ(img.data.substr(0, 8), png_signature);
+  EXPECT_DOUBLE_EQ(img.transform.a, 2);
+  EXPECT_DOUBLE_EQ(img.transform.d, 3);
+  EXPECT_DOUBLE_EQ(img.transform.e, 10);
+  EXPECT_DOUBLE_EQ(img.transform.f, 20);
+}
+
+// The binary payload (which may itself contain `EI`) does not corrupt the
+// parse: content after the inline image is still tokenized.
+TEST(PdfPageExtractor, inline_image_then_path) {
+  const std::string content = "BI /W 1 /H 1 /CS /G /BPC 8 ID " +
+                              raw_bytes({128}) + "\nEI 0 0 10 10 re f";
+  const auto page = extract_page(content, Resources{}, Logger::null());
+  ASSERT_EQ(page.size(), 2);
+  EXPECT_TRUE(std::holds_alternative<ImageElement>(page[0]));
+  EXPECT_TRUE(std::holds_alternative<PathElement>(page[1]));
+}
+
+// A Flate (`/F /Fl`) inline image is decoded and re-encoded as PNG.
+TEST(PdfPageExtractor, inline_image_flate) {
+  const std::string samples = raw_bytes({10, 20, 30, 40, 50, 60});
+  const std::string content =
+      "BI /W 2 /H 1 /CS /RGB /BPC 8 /F /Fl ID " +
+      odr::internal::crypto::util::zlib_deflate(samples) + "\nEI";
+  const auto page = extract_page(content, Resources{}, Logger::null());
+  ASSERT_EQ(page.size(), 1);
+  const ImageElement &img = std::get<ImageElement>(page[0]);
+  EXPECT_EQ(img.mime, "image/png");
+  EXPECT_EQ(img.data.substr(0, 8), png_signature);
+}
+
+// `/CS` naming a page `/ColorSpace` resource is resolved through it.
+TEST(PdfPageExtractor, inline_image_named_resource_color_space) {
+  auto color_space = std::make_shared<ColorSpaceDef>();
+  color_space->kind = ColorSpaceKind::device_gray;
+  color_space->components = 1;
+  Resources res;
+  res.color_space["Gray"] = color_space;
+
+  const std::string content =
+      "BI /W 1 /H 1 /CS /Gray /BPC 8 ID " + raw_bytes({200}) + "\nEI";
+  const auto page = extract_page(content, res, Logger::null());
+  ASSERT_EQ(page.size(), 1);
+  EXPECT_EQ(std::get<ImageElement>(page[0]).mime, "image/png");
+}
+
+// An inline image mask (`/IM true`) is a stencil, deferred to a later stage:
+// emitted as nothing for now.
+TEST(PdfPageExtractor, inline_image_mask_skipped) {
+  const std::string content =
+      "BI /W 8 /H 1 /IM true /BPC 1 ID " + raw_bytes({0xAA}) + "\nEI";
+  EXPECT_TRUE(extract_page(content, Resources{}, Logger::null()).empty());
 }

--- a/test/src/internal/pdf/pdf_page_extractor.cpp
+++ b/test/src/internal/pdf/pdf_page_extractor.cpp
@@ -855,7 +855,7 @@ TEST(PdfPageExtractor, device_color_clears_color_space) {
   EXPECT_DOUBLE_EQ(p.fill_color.rgb[1], 0.0);
 }
 
-// --- stage 4.5: image XObjects (JPEG pass-through) ------------------------
+// --- image XObjects (JPEG pass-through) ------------------------
 
 namespace {
 
@@ -925,7 +925,7 @@ TEST(PdfPageExtractor, image_in_paint_order) {
   EXPECT_TRUE(std::holds_alternative<PathElement>(page[2]));
 }
 
-// --- stage 4.7: inline images (BI/ID/EI) ---------------------------------
+// --- inline images (BI/ID/EI) ---------------------------------
 
 namespace {
 

--- a/test/src/internal/pdf/pdf_page_extractor.cpp
+++ b/test/src/internal/pdf/pdf_page_extractor.cpp
@@ -971,6 +971,20 @@ TEST(PdfPageExtractor, inline_image_then_path) {
   EXPECT_TRUE(std::holds_alternative<PathElement>(page[1]));
 }
 
+// An unfiltered image's length is fixed by its geometry, so raw sample bytes
+// that happen to spell `E I <white-space>` (here the first pixel, 0x45 0x49
+// 0x20) are not mistaken for the `EI` terminator: the image survives intact and
+// the following operator is still parsed.
+TEST(PdfPageExtractor, inline_image_data_containing_ei) {
+  const std::string content = "BI /W 2 /H 1 /CS /RGB /BPC 8 ID " +
+                              raw_bytes({0x45, 0x49, 0x20, 10, 20, 30}) +
+                              "\nEI 0 0 10 10 re f";
+  const auto page = extract_page(content, Resources{}, Logger::null());
+  ASSERT_EQ(page.size(), 2);
+  EXPECT_TRUE(std::holds_alternative<ImageElement>(page[0]));
+  EXPECT_TRUE(std::holds_alternative<PathElement>(page[1]));
+}
+
 // A Flate (`/F /Fl`) inline image is decoded and re-encoded as PNG.
 TEST(PdfPageExtractor, inline_image_flate) {
   const std::string samples = raw_bytes({10, 20, 30, 40, 50, 60});

--- a/test/src/internal/pdf/pdf_page_extractor.cpp
+++ b/test/src/internal/pdf/pdf_page_extractor.cpp
@@ -998,6 +998,25 @@ TEST(PdfPageExtractor, inline_image_flate) {
   EXPECT_EQ(img.data.substr(0, 8), png_signature);
 }
 
+// A Flate inline image with a PNG predictor: the white-space separating the
+// data from `EI` must not leak into the encoded payload. A stray trailing byte
+// extends the inflated stream by one, so it is no longer a whole number of
+// predictor rows and decoding throws.
+TEST(PdfPageExtractor, inline_image_flate_predictor_drops_separator) {
+  // One PNG predictor row: a leading filter-type tag (0, None) then the
+  // samples.
+  const std::string row = raw_bytes({0, 10, 20, 30, 40, 50, 60});
+  const std::string content =
+      "BI /W 2 /H 1 /CS /RGB /BPC 8 /F /Fl "
+      "/DP <</Predictor 15 /Colors 3 /Columns 2 /BitsPerComponent 8>> ID " +
+      odr::internal::crypto::util::zlib_deflate(row) + "\nEI";
+  const auto page = extract_page(content, Resources{}, Logger::null());
+  ASSERT_EQ(page.size(), 1);
+  const ImageElement &img = std::get<ImageElement>(page[0]);
+  EXPECT_EQ(img.mime, "image/png");
+  EXPECT_EQ(img.data.substr(0, 8), png_signature);
+}
+
 // `/CS` naming a page `/ColorSpace` resource is resolved through it.
 TEST(PdfPageExtractor, inline_image_named_resource_color_space) {
   auto color_space = std::make_shared<ColorSpaceDef>();


### PR DESCRIPTION
🤖 Generated with [Claude Code](https://claude.com/claude-code)

Stacked on #569 (stage 4.6). Decodes inline image XObjects (ISO 32000-1 §8.9.7) and emits them through the same image path as regular XObjects.

## What

- **Tokenizer.** The graphics operator parser folds a `BI <key val …> ID <bytes> EI` run into a single operator carrying `[dictionary, bytes]`. The binary payload has no length, so it scans for the `EI` terminator, accepting only one followed by white-space/eof (since `EI` can occur inside the raw bytes).
- **Boolean operator arguments.** The argument loop now reads `true`/`false` literals, which appear as inline dictionary values (e.g. `/IM true`). It compares the full bareword rather than using `peek_boolean`, because operators such as `f` (fill) and `Tj` share a leading character with the keywords and would otherwise be mis-consumed.
- **Extractor.** Normalizes the abbreviated keys (`W`/`H`/`BPC`/`CS`/`F`/`D`/`DP`/`IM`/`I`), resolves the colour space (device names, inline arrays, or a named page `/ColorSpace` resource), skips `/ImageMask` stencils, and builds an `ImageElement` at the current CTM and clip.
- **Shared core.** A shared `encode_image` (filter → JPEG pass-through or Flate/LZW/RunLength/ASCII/raw → PNG) now backs both the XObject and inline paths.

## Tests

- 5 new `PdfPageExtractor.inline_image_*` tests: emission at CTM, ordering with a following path, Flate-coded payload, named-resource colour space, and `/ImageMask` skipping.
- Full PDF suite green (175 tests).