### PR TITLE
PDF stage 4.9: axial & radial shadings (types 2/3)

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -200,6 +200,7 @@ set(ODR_SOURCE_FILES
         "src/odr/internal/pdf/pdf_object.cpp"
         "src/odr/internal/pdf/pdf_object_parser.cpp"
         "src/odr/internal/pdf/pdf_page_extractor.cpp"
+        "src/odr/internal/pdf/pdf_shading.cpp"
 
         "src/odr/internal/font/cff_builder.cpp"
         "src/odr/internal/font/cff_font.cpp"

--- a/src/odr/internal/html/pdf_file.cpp
+++ b/src/odr/internal/html/pdf_file.cpp
@@ -295,7 +295,7 @@ private:
 /// Honouring them needs the fill clipped to the gradient band/annulus.
 class GradientRegistry {
 public:
-  explicit GradientRegistry(std::uint32_t page) : m_page{page} {}
+  explicit GradientRegistry(const std::uint32_t page) : m_page{page} {}
 
   /// The gradient id to reference via `fill="url(#id)"` for `shading` placed by
   /// `m` (shading space -> page box). Empty for an unrepresentable shading.
@@ -344,7 +344,7 @@ public:
   [[nodiscard]] std::string defs() const { return m_defs.str(); }
 
 private:
-  std::uint32_t m_page;
+  std::uint32_t m_page{};
   std::uint32_t m_count{0};
   std::unordered_map<std::string, std::string> m_id_by_signature;
   std::ostringstream m_defs;
@@ -355,8 +355,8 @@ private:
 /// `sh` time). Returns "" when the shading produced no gradient. The rect spans
 /// the whole page; the clip (and the gradient's own extent) bound the paint.
 std::string svg_shading_fragment(const std::string &gradient_id,
-                                 const std::string &clip_id, double width,
-                                 double height) {
+                                 const std::string &clip_id, const double width,
+                                 const double height) {
   if (gradient_id.empty()) {
     return {};
   }
@@ -700,7 +700,8 @@ public:
         // the page viewBox (fill and/or stroke), under any active clip. A
         // shading-pattern fill is painted through a gradient instead of a
         // colour.
-        if (const auto *path = std::get_if<pdf::PathElement>(&element)) {
+        if (const auto *path = std::get_if<pdf::PathElement>(&element);
+            path != nullptr) {
           const std::string clip_id = clips.register_clip(path->clip, to_box);
           std::string gradient_id;
           if (path->fill_shading != nullptr) {
@@ -717,7 +718,8 @@ public:
 
         // An `sh` shading flood: a `<rect>` over the page box filled with the
         // shading's gradient, bounded by the clip in force at `sh` time.
-        if (const auto *shading = std::get_if<pdf::ShadingElement>(&element)) {
+        if (const auto *shading = std::get_if<pdf::ShadingElement>(&element);
+            shading != nullptr) {
           if (shading->shading == nullptr) {
             continue;
           }

--- a/src/odr/internal/html/pdf_file.cpp
+++ b/src/odr/internal/html/pdf_file.cpp
@@ -79,6 +79,18 @@ std::string device_color_to_css(const pdf::GraphicsState::Color &color) {
   return std::move(s).str();
 }
 
+/// Convert an sRGB triple in [0, 1] (a shading colour stop) to a CSS
+/// `rgb(...)`.
+std::string rgb_to_css(const std::array<double, 3> &rgb) {
+  const auto to255 = [](const double v) {
+    return static_cast<int>(std::lround(std::clamp(v, 0.0, 1.0) * 255.0));
+  };
+  std::ostringstream s;
+  s << "rgb(" << to255(rgb[0]) << ',' << to255(rgb[1]) << ',' << to255(rgb[2])
+    << ')';
+  return std::move(s).str();
+}
+
 /// Build an SVG `d` attribute from a path's subpaths, each point mapped through
 /// `to_box` (PDF user space -> the page box, y-down). Lines become `L`, cubic
 /// Béziers `C`, and an explicitly closed subpath ends with `Z`.
@@ -117,10 +129,12 @@ std::string svg_path_d(const std::vector<pdf::Subpath> &subpaths,
 /// stroke carries width (CTM-scaled in user space), caps, joins, miter limit
 /// and the dash pattern. A zero stroke width renders as a thin hairline.
 /// `clip_id`, when non-empty, references a `<clipPath>` installed via
-/// `clip-path`.
+/// `clip-path`. `gradient_id`, when non-empty, fills the path with that
+/// gradient (a shading pattern) instead of `fill_color`.
 std::string svg_path_fragment(const pdf::PathElement &path,
                               const util::math::Transform2D &to_box,
-                              const std::string &clip_id) {
+                              const std::string &clip_id,
+                              const std::string &gradient_id) {
   if ((!path.fill && !path.stroke) || path.subpaths.empty()) {
     return {};
   }
@@ -131,7 +145,11 @@ std::string svg_path_fragment(const pdf::PathElement &path,
   }
 
   if (path.fill) {
-    f << " fill=\"" << device_color_to_css(path.fill_color) << '"';
+    if (!gradient_id.empty()) {
+      f << " fill=\"url(#" << gradient_id << ")\"";
+    } else {
+      f << " fill=\"" << device_color_to_css(path.fill_color) << '"';
+    }
     if (path.even_odd) {
       f << " fill-rule=\"evenodd\"";
     }
@@ -262,6 +280,87 @@ private:
   std::unordered_map<std::string, std::string> m_id_by_signature;
   std::ostringstream m_defs;
 };
+
+/// Registers a page's shadings (axial/radial) as `<linearGradient>`/
+/// `<radialGradient>` defs, deduplicating by shading and placement. The
+/// shading's pre-sampled colour stops become `<stop>`s; `gradientTransform`
+/// (shading space -> page box) places the gradient in the page's user space, so
+/// referencing elements use `gradientUnits="userSpaceOnUse"`. PDF `/Extend` is
+/// approximated by SVG's default `pad` spread (the end stops extend outward).
+/// Ids are namespaced per page (`g<page>_<n>`).
+class GradientRegistry {
+public:
+  explicit GradientRegistry(std::uint32_t page) : m_page{page} {}
+
+  /// The gradient id to reference via `fill="url(#id)"` for `shading` placed by
+  /// `m` (shading space -> page box). Empty for an unrepresentable shading.
+  std::string register_gradient(const pdf::Shading &shading,
+                                const util::math::Transform2D &m) {
+    if ((shading.type != 2 && shading.type != 3) || shading.stops.empty()) {
+      return {};
+    }
+    std::ostringstream sig;
+    sig << shading.type << ':' << static_cast<const void *>(&shading) << ':'
+        << m.a << ',' << m.b << ',' << m.c << ',' << m.d << ',' << m.e << ','
+        << m.f;
+    const auto [it, inserted] = m_id_by_signature.try_emplace(sig.str());
+    if (!inserted) {
+      return it->second;
+    }
+    it->second = "g" + std::to_string(m_page) + "_" + std::to_string(++m_count);
+    const std::string &id = it->second;
+
+    const std::array<double, 6> &c = shading.coords;
+    if (shading.type == 2) {
+      m_defs << "<linearGradient id=\"" << id << "\" x1=\"" << c[0]
+             << "\" y1=\"" << c[1] << "\" x2=\"" << c[2] << "\" y2=\"" << c[3]
+             << '"';
+    } else {
+      // Radial: the outer circle (x1,y1,r1) is SVG's (cx,cy,r); the inner
+      // circle (x0,y0,r0) is the focal point and radius (fr is SVG2).
+      m_defs << "<radialGradient id=\"" << id << "\" cx=\"" << c[3]
+             << "\" cy=\"" << c[4] << "\" r=\"" << c[5] << "\" fx=\"" << c[0]
+             << "\" fy=\"" << c[1] << "\" fr=\"" << c[2] << '"';
+    }
+    m_defs << " gradientUnits=\"userSpaceOnUse\" gradientTransform=\"matrix("
+           << m.a << ',' << m.b << ',' << m.c << ',' << m.d << ','
+           << round2(m.e) << ',' << round2(m.f) << ")\">";
+    for (const pdf::GradientStop &stop : shading.stops) {
+      m_defs << "<stop offset=\"" << round2(stop.offset) << "\" stop-color=\""
+             << rgb_to_css(stop.rgb) << "\"/>";
+    }
+    m_defs << (shading.type == 2 ? "</linearGradient>" : "</radialGradient>");
+    return id;
+  }
+
+  [[nodiscard]] std::string defs() const { return m_defs.str(); }
+
+private:
+  std::uint32_t m_page;
+  std::uint32_t m_count{0};
+  std::unordered_map<std::string, std::string> m_id_by_signature;
+  std::ostringstream m_defs;
+};
+
+/// Serialize an `sh` shading flood to an SVG `<rect>` covering the page box,
+/// filled with `gradient_id` and bounded by `clip_id` (the clip in force at
+/// `sh` time). Returns "" when the shading produced no gradient. The rect spans
+/// the whole page; the clip (and the gradient's own extent) bound the paint.
+std::string svg_shading_fragment(const std::string &gradient_id,
+                                 const std::string &clip_id, double width,
+                                 double height) {
+  if (gradient_id.empty()) {
+    return {};
+  }
+  std::ostringstream f;
+  f << "<rect x=\"0\" y=\"0\" width=\"" << round2(width) << "\" height=\""
+    << round2(height) << "\" fill=\"url(#" << gradient_id << ")\"";
+  if (!clip_id.empty()) {
+    f << " clip-path=\"url(#" << clip_id << ")\"";
+  }
+  f << "/>";
+  return std::move(f).str();
+}
 
 /// Deduplicates CSS declarations into atomic, single-property classes. PDF text
 /// emits one absolutely-positioned span per glyph run, and the same font sizes,
@@ -585,14 +684,41 @@ public:
           util::math::Transform2D::scaling_translation(1, -1, 0, height);
 
       ClipRegistry clips(static_cast<std::uint32_t>(pages_out.size()));
+      GradientRegistry gradients(static_cast<std::uint32_t>(pages_out.size()));
 
       for (const pdf::PageElement &element :
            pdf::extract_page(stream, *page->resources, *m_logger)) {
         // A painted path: serialize its subpaths to an SVG `<path>` fragment in
-        // the page viewBox (fill and/or stroke), under any active clip.
+        // the page viewBox (fill and/or stroke), under any active clip. A
+        // shading-pattern fill is painted through a gradient instead of a
+        // colour.
         if (const auto *path = std::get_if<pdf::PathElement>(&element)) {
           const std::string clip_id = clips.register_clip(path->clip, to_box);
-          std::string fragment = svg_path_fragment(*path, to_box, clip_id);
+          std::string gradient_id;
+          if (path->fill_shading != nullptr) {
+            gradient_id = gradients.register_gradient(
+                *path->fill_shading, path->shading_transform * to_box);
+          }
+          std::string fragment =
+              svg_path_fragment(*path, to_box, clip_id, gradient_id);
+          if (!fragment.empty()) {
+            page_out.items.push_back(PathOut{std::move(fragment)});
+          }
+          continue;
+        }
+
+        // An `sh` shading flood: a `<rect>` over the page box filled with the
+        // shading's gradient, bounded by the clip in force at `sh` time.
+        if (const auto *shading = std::get_if<pdf::ShadingElement>(&element)) {
+          if (shading->shading == nullptr) {
+            continue;
+          }
+          const std::string clip_id =
+              clips.register_clip(shading->clip, to_box);
+          const std::string gradient_id = gradients.register_gradient(
+              *shading->shading, shading->transform * to_box);
+          std::string fragment =
+              svg_shading_fragment(gradient_id, clip_id, width, height);
           if (!fragment.empty()) {
             page_out.items.push_back(PathOut{std::move(fragment)});
           }
@@ -823,7 +949,8 @@ public:
         }
       }
 
-      page_out.clip_defs = clips.defs();
+      // Clip-path and gradient defs share the page's hidden `<svg><defs>`.
+      page_out.clip_defs = clips.defs() + gradients.defs();
     }
 
     // Post-pass: every page has been scanned, so the per-font used-scalar sets
@@ -969,10 +1096,11 @@ public:
     for (const PageOut &page : pages_out) {
       out.write_element_begin("div",
                               HtmlElementOptions().set_class(page.classes));
-      // Clip-path defs for this page, in a hidden zero-size `<svg>`. They are
-      // referenced by id from the page's path fragments; `clipPathUnits`
-      // defaults to `userSpaceOnUse`, so the geometry is read in the user space
-      // of the referencing element (the page viewBox), not this `<svg>`.
+      // Clip-path and gradient defs for this page, in a hidden zero-size
+      // `<svg>`. They are referenced by id from the page's fragments;
+      // `clipPathUnits`/`gradientUnits` are `userSpaceOnUse`, so the geometry
+      // is read in the user space of the referencing element (the page
+      // viewBox), not this `<svg>`.
       if (!page.clip_defs.empty()) {
         out.write_raw(
             "<svg width=\"0\" height=\"0\" style=\"position:absolute\">"

--- a/src/odr/internal/html/pdf_file.cpp
+++ b/src/odr/internal/html/pdf_file.cpp
@@ -285,9 +285,14 @@ private:
 /// `<radialGradient>` defs, deduplicating by shading and placement. The
 /// shading's pre-sampled colour stops become `<stop>`s; `gradientTransform`
 /// (shading space -> page box) places the gradient in the page's user space, so
-/// referencing elements use `gradientUnits="userSpaceOnUse"`. PDF `/Extend` is
-/// approximated by SVG's default `pad` spread (the end stops extend outward).
-/// Ids are namespaced per page (`g<page>_<n>`).
+/// referencing elements use `gradientUnits="userSpaceOnUse"`. Ids are
+/// namespaced per page (`g<page>_<n>`).
+///
+/// DEFERRED (out of scope for this stage): PDF `/Extend` is approximated by
+/// SVG's default `pad` spread (the end stops extend outward), so a non-extended
+/// shading is over-painted beyond its interval instead of being masked to it;
+/// `Shading::background` and `Shading::bbox` are likewise not yet honoured.
+/// Honouring them needs the fill clipped to the gradient band/annulus.
 class GradientRegistry {
 public:
   explicit GradientRegistry(std::uint32_t page) : m_page{page} {}
@@ -322,6 +327,9 @@ public:
              << "\" cy=\"" << c[4] << "\" r=\"" << c[5] << "\" fx=\"" << c[0]
              << "\" fy=\"" << c[1] << "\" fr=\"" << c[2] << '"';
     }
+    // Only the translation (e, f) is rounded — it lives in page-box units where
+    // 1/100 px is plenty; the linear part (a..d) keeps full precision so small
+    // scale/skew factors aren't quantized to zero.
     m_defs << " gradientUnits=\"userSpaceOnUse\" gradientTransform=\"matrix("
            << m.a << ',' << m.b << ',' << m.c << ',' << m.d << ','
            << round2(m.e) << ',' << round2(m.f) << ")\">";

--- a/src/odr/internal/pdf/AGENTS.md
+++ b/src/odr/internal/pdf/AGENTS.md
@@ -574,6 +574,15 @@ stage exists to avoid.
   current fill colour; `/SMask` and `/Mask` (stencil + colour-key) composited
   into RGBA on the raster path (a mask on a JPEG base is ignored — decoding the
   JPEG to composite is out of scope).
+- **Shadings & shading patterns** (axial type 2, radial type 3): `parse_shading`
+  pre-samples the tint `/Function` across `/Domain` into 32 sRGB colour stops, so
+  the renderer needs no function evaluator. The `sh` operator floods the current
+  clip (a `ShadingElement` → `<rect>` filled with the gradient); a `/PatternType
+  2` shading pattern selected by `scn` fills a path (`PathElement::fill_shading`
+  + the pattern `/Matrix`). Both emit SVG `<linearGradient>`/`<radialGradient>`
+  with `gradientUnits="userSpaceOnUse"`; `/Extend` is approximated by SVG's `pad`
+  spread. Mesh/function shadings (types 1, 4–7) and tiling patterns
+  (`/PatternType 1`) are still future stages.
 - **SVG residue** — where no 1:1 primitive exists; all at generation time, never
   rasterization: mesh/function shadings (types 1, 4–7) → tessellate into small
   flat polygons (pdf.js's approach); color spaces

--- a/src/odr/internal/pdf/AGENTS.md
+++ b/src/odr/internal/pdf/AGENTS.md
@@ -580,9 +580,12 @@ stage exists to avoid.
   clip (a `ShadingElement` → `<rect>` filled with the gradient); a `/PatternType
   2` shading pattern selected by `scn` fills a path (`PathElement::fill_shading`
   + the pattern `/Matrix`). Both emit SVG `<linearGradient>`/`<radialGradient>`
-  with `gradientUnits="userSpaceOnUse"`; `/Extend` is approximated by SVG's `pad`
-  spread. Mesh/function shadings (types 1, 4–7) and tiling patterns
-  (`/PatternType 1`) are still future stages.
+  with `gradientUnits="userSpaceOnUse"`. `/Extend`, `/Background` and `/BBox` are
+  parsed onto `Shading` but **not yet honoured** by the renderer (deferred): it
+  always uses SVG's `pad` spread, so a non-extended shading is over-painted past
+  its interval rather than masked to it (honouring it needs the fill clipped to
+  the gradient band/annulus). Mesh/function shadings (types 1, 4–7) and tiling
+  patterns (`/PatternType 1`) are still future stages.
 - **SVG residue** — where no 1:1 primitive exists; all at generation time, never
   rasterization: mesh/function shadings (types 1, 4–7) → tessellate into small
   flat polygons (pdf.js's approach); color spaces

--- a/src/odr/internal/pdf/pdf_document_element.hpp
+++ b/src/odr/internal/pdf/pdf_document_element.hpp
@@ -99,10 +99,14 @@ struct Resources final : Element {
   std::unordered_map<std::string, Object> properties;
   /// The `/Shading` subdictionary (ISO 32000-1 8.7.4.3): named shadings painted
   /// by the `sh` operator. Resolved eagerly (the tint function sampled into
-  /// colour stops) so extraction needs no parser handle.
+  /// colour stops) so extraction needs no parser handle. Held by `shared_ptr`
+  /// because `Shading` is a plain value type, not a document `Element` (a
+  /// shading pattern shares ownership of the same `Shading`).
   std::unordered_map<std::string, std::shared_ptr<Shading>> shading;
   /// The `/Pattern` subdictionary (ISO 32000-1 8.7.3.3): named tiling/shading
   /// patterns selected as a colour by `scn`/`SCN` in a `/Pattern` colour space.
+  /// A non-owning pointer: `Pattern` is a document `Element`, owned by the
+  /// `Document` graph like the other resource elements (`Font`, `XObject`).
   std::unordered_map<std::string, Pattern *> pattern;
 };
 

--- a/src/odr/internal/pdf/pdf_document_element.hpp
+++ b/src/odr/internal/pdf/pdf_document_element.hpp
@@ -3,6 +3,7 @@
 #include <odr/internal/pdf/pdf_cmap.hpp>
 #include <odr/internal/pdf/pdf_encoding.hpp>
 #include <odr/internal/pdf/pdf_object.hpp>
+#include <odr/internal/pdf/pdf_shading.hpp>
 #include <odr/internal/util/math_util.hpp>
 
 #include <array>
@@ -28,6 +29,7 @@ struct Annotation;
 struct Resources;
 struct Font;
 struct XObject;
+struct Pattern;
 struct ColorSpaceDef;
 
 struct Element {
@@ -95,6 +97,13 @@ struct Resources final : Element {
   /// referenced by `BDC`. Each value is the resolved property-list dictionary
   /// `Object`; used to recover `/ActualText` for a `BDC /Tag /Name` sequence.
   std::unordered_map<std::string, Object> properties;
+  /// The `/Shading` subdictionary (ISO 32000-1 8.7.4.3): named shadings painted
+  /// by the `sh` operator. Resolved eagerly (the tint function sampled into
+  /// colour stops) so extraction needs no parser handle.
+  std::unordered_map<std::string, std::shared_ptr<Shading>> shading;
+  /// The `/Pattern` subdictionary (ISO 32000-1 8.7.3.3): named tiling/shading
+  /// patterns selected as a colour by `scn`/`SCN` in a `/Pattern` colour space.
+  std::unordered_map<std::string, Pattern *> pattern;
 };
 
 /// An external object referenced by `Do` and listed in a resource dictionary's
@@ -143,6 +152,27 @@ struct XObject final : Element {
   std::int32_t stencil_width{0};  ///< `/Width`
   std::int32_t stencil_height{0}; ///< `/Height`
   std::vector<double> stencil_decode; ///< `/Decode`, empty = default `[0 1]`
+};
+
+/// A pattern listed in a resource dictionary's `/Pattern` subdictionary
+/// (ISO 32000-1 8.7.3), selected as a colour by `scn`/`SCN` in a `/Pattern`
+/// colour space. Shading patterns (`/PatternType 2`) paint a gradient through
+/// the path; tiling patterns (`/PatternType 1`) repeat a content-stream cell.
+struct Pattern final : Element {
+  enum class Type {
+    unknown,
+    tiling,  ///< `/PatternType 1`
+    shading, ///< `/PatternType 2`
+  };
+  Type type{Type::unknown};
+
+  /// `/Matrix` mapping pattern space to the default coordinate system of the
+  /// pattern's parent content stream (8.7.3.1); default identity.
+  util::math::Transform2D matrix;
+
+  /// Shading pattern (`/PatternType 2`): the shading painted through the path,
+  /// pre-resolved (its tint function sampled into stops). Null otherwise.
+  std::shared_ptr<Shading> shading;
 };
 
 /// A non-owning view over a string of PDF character codes, splitting it into

--- a/src/odr/internal/pdf/pdf_document_parser.cpp
+++ b/src/odr/internal/pdf/pdf_document_parser.cpp
@@ -759,6 +759,79 @@ XObject *parse_x_object(State &state, const ObjectReference &reference) {
   return x_object;
 }
 
+/// A `ColorSpaceContext` over the parser, resolving a base/alternate space
+/// named by name against the (being-built) `/ColorSpace` table of `resources`.
+ColorSpaceContext make_color_space_context(DocumentParser &parser,
+                                           const Resources *resources) {
+  ColorSpaceContext context;
+  context.resolve = [&parser](const Object &object) {
+    return parser.resolve_object_copy(object);
+  };
+  context.load_stream = [&parser](const Object &object) {
+    return object.is_reference()
+               ? parser.read_decoded_stream(object.as_reference())
+               : std::string{};
+  };
+  context.named =
+      [resources](const std::string &name) -> std::shared_ptr<ColorSpaceDef> {
+    const auto it = resources->color_space.find(name);
+    return it != resources->color_space.end() ? it->second : nullptr;
+  };
+  return context;
+}
+
+/// Parse a `/Shading` dictionary into a resolved `Shading` (its tint function
+/// sampled into colour stops). `resources` supplies named colour spaces.
+std::shared_ptr<Shading> parse_shading_resource(State &state,
+                                                const Object &object,
+                                                const Resources *resources) {
+  DocumentParser &parser = state.parser();
+  ShadingContext context;
+  context.resolve = [&parser](const Object &o) {
+    return parser.resolve_object_copy(o);
+  };
+  context.load_stream = [&parser](const Object &o) {
+    return o.is_reference() ? parser.read_decoded_stream(o.as_reference())
+                            : std::string{};
+  };
+  return parse_shading(object, context,
+                       make_color_space_context(parser, resources));
+}
+
+/// Parse a `/Pattern` entry. A shading pattern (`/PatternType 2`) resolves its
+/// `/Shading`; a tiling pattern (`/PatternType 1`) is recognized here and its
+/// content rendered in a later stage. `/Matrix` is taken either way.
+Pattern *parse_pattern(State &state, const ObjectReference &reference,
+                       const Resources *resources) {
+  DocumentParser &parser = state.parser();
+  Document &document = state.document();
+
+  auto *pattern = document.create_element<Pattern>();
+  IndirectObject object = parser.read_object(reference);
+  if (!object.object.is_dictionary()) {
+    return pattern;
+  }
+  const Dictionary &dictionary = object.object.as_dictionary();
+  pattern->object_reference = reference;
+  pattern->object = Object(dictionary);
+
+  if (dictionary.has_value("Matrix")) {
+    pattern->matrix = parse_matrix(parser, dictionary["Matrix"]);
+  }
+  const auto pattern_type = static_cast<std::int32_t>(
+      parser.resolve_object_copy(dictionary.get("PatternType"))
+          .as_integer_opt()
+          .value_or(0));
+  if (pattern_type == 2) {
+    pattern->type = Pattern::Type::shading;
+    pattern->shading =
+        parse_shading_resource(state, dictionary.get("Shading"), resources);
+  } else if (pattern_type == 1) {
+    pattern->type = Pattern::Type::tiling;
+  }
+  return pattern;
+}
+
 Resources *parse_resources(State &state, const Object &object) {
   DocumentParser &parser = state.parser();
   Document &document = state.document();
@@ -816,6 +889,29 @@ Resources *parse_resources(State &state, const Object &object) {
     for (const auto &[key, value] : color_space_table) {
       if (resources->color_space.find(key) == resources->color_space.end()) {
         resources->color_space[key] = parse_color_space(value, context);
+      }
+    }
+  }
+
+  // Shadings and patterns are parsed after `/ColorSpace` so a named colour
+  // space they reference is already in `resources->color_space`.
+  if (dictionary.has_value("Shading")) {
+    const Dictionary shading_table =
+        parser.resolve_object_copy(dictionary["Shading"]).as_dictionary();
+    for (const auto &[key, value] : shading_table) {
+      if (auto shading = parse_shading_resource(state, value, resources)) {
+        resources->shading[key] = std::move(shading);
+      }
+    }
+  }
+
+  if (dictionary.has_value("Pattern")) {
+    const Dictionary pattern_table =
+        parser.resolve_object_copy(dictionary["Pattern"]).as_dictionary();
+    for (const auto &[key, value] : pattern_table) {
+      if (value.is_reference()) {
+        resources->pattern[key] =
+            parse_pattern(state, value.as_reference(), resources);
       }
     }
   }

--- a/src/odr/internal/pdf/pdf_document_parser.cpp
+++ b/src/odr/internal/pdf/pdf_document_parser.cpp
@@ -538,15 +538,22 @@ std::int32_t image_int(DocumentParser &parser, const Dictionary &dictionary,
 /// The `/Decode` array of an image dictionary as doubles ([] when absent).
 std::vector<double> image_decode(DocumentParser &parser,
                                  const Dictionary &dictionary) {
-  std::vector<double> decode;
-  const Object decode_object =
-      parser.resolve_object_copy(dictionary.get("Decode"));
-  if (decode_object.is_array()) {
-    for (const Object &item : decode_object.as_array()) {
-      decode.push_back(item.as_real());
-    }
-  }
-  return decode;
+  return as_reals(parser.resolve_object_copy(dictionary.get("Decode")));
+}
+
+/// Bind the parser-backed `resolve`/`load_stream` hooks shared by every typed
+/// context (`ColorSpaceContext`, `FunctionContext`, `ShadingContext`): each
+/// dereferences an object and decodes a stream's bytes through `parser`.
+template <typename Context>
+void bind_parser_io(Context &context, DocumentParser &parser) {
+  context.resolve = [&parser](const Object &object) {
+    return parser.resolve_object_copy(object);
+  };
+  context.load_stream = [&parser](const Object &object) {
+    return object.is_reference()
+               ? parser.read_decoded_stream(object.as_reference())
+               : std::string{};
+  };
 }
 
 /// Resolve a `/SMask` (soft mask) or stencil `/Mask` sub-image referenced by
@@ -647,13 +654,7 @@ void parse_image_data(DocumentParser &parser, const Dictionary &dictionary,
   std::shared_ptr<ColorSpaceDef> color_space;
   if (dictionary.has_value("ColorSpace")) {
     ColorSpaceContext context;
-    context.resolve = [&parser](const Object &o) {
-      return parser.resolve_object_copy(o);
-    };
-    context.load_stream = [&parser](const Object &o) {
-      return o.is_reference() ? parser.read_decoded_stream(o.as_reference())
-                              : std::string{};
-    };
+    bind_parser_io(context, parser);
     color_space = parse_color_space(dictionary.get("ColorSpace"), context);
   }
   const std::int32_t width = image_int(parser, dictionary, "Width", 0);
@@ -675,9 +676,7 @@ void parse_image_data(DocumentParser &parser, const Dictionary &dictionary,
   if (alpha.empty() && dictionary.has_value("Mask")) {
     const Object mask = parser.resolve_object_copy(dictionary["Mask"]);
     if (mask.is_array()) {
-      for (const Object &item : mask.as_array()) {
-        color_key.push_back(item.as_real());
-      }
+      color_key = as_reals(mask);
     } else if (dictionary["Mask"].is_reference()) {
       alpha = resolve_mask_alpha(parser, dictionary["Mask"], width, height,
                                  /*stencil=*/true);
@@ -764,14 +763,7 @@ XObject *parse_x_object(State &state, const ObjectReference &reference) {
 ColorSpaceContext make_color_space_context(DocumentParser &parser,
                                            const Resources *resources) {
   ColorSpaceContext context;
-  context.resolve = [&parser](const Object &object) {
-    return parser.resolve_object_copy(object);
-  };
-  context.load_stream = [&parser](const Object &object) {
-    return object.is_reference()
-               ? parser.read_decoded_stream(object.as_reference())
-               : std::string{};
-  };
+  bind_parser_io(context, parser);
   context.named =
       [resources](const std::string &name) -> std::shared_ptr<ColorSpaceDef> {
     const auto it = resources->color_space.find(name);
@@ -787,13 +779,7 @@ std::shared_ptr<Shading> parse_shading_resource(State &state,
                                                 const Resources *resources) {
   DocumentParser &parser = state.parser();
   ShadingContext context;
-  context.resolve = [&parser](const Object &o) {
-    return parser.resolve_object_copy(o);
-  };
-  context.load_stream = [&parser](const Object &o) {
-    return o.is_reference() ? parser.read_decoded_stream(o.as_reference())
-                            : std::string{};
-  };
+  bind_parser_io(context, parser);
   return parse_shading(object, context,
                        make_color_space_context(parser, resources));
 }
@@ -863,14 +849,7 @@ Resources *parse_resources(State &state, const Object &object) {
     const Dictionary color_space_table =
         parser.resolve_object_copy(dictionary["ColorSpace"]).as_dictionary();
     ColorSpaceContext context;
-    context.resolve = [&parser](const Object &object) {
-      return parser.resolve_object_copy(object);
-    };
-    context.load_stream = [&parser](const Object &object) {
-      return object.is_reference()
-                 ? parser.read_decoded_stream(object.as_reference())
-                 : std::string{};
-    };
+    bind_parser_io(context, parser);
     // A base/alternate space may be named (referencing another `/ColorSpace`
     // entry); resolve it lazily from the same table, caching the result.
     context.named =

--- a/src/odr/internal/pdf/pdf_document_parser.cpp
+++ b/src/odr/internal/pdf/pdf_document_parser.cpp
@@ -538,7 +538,7 @@ std::int32_t image_int(DocumentParser &parser, const Dictionary &dictionary,
 /// The `/Decode` array of an image dictionary as doubles ([] when absent).
 std::vector<double> image_decode(DocumentParser &parser,
                                  const Dictionary &dictionary) {
-  return as_reals(parser.resolve_object_copy(dictionary.get("Decode")));
+  return parser.resolve_object_copy(dictionary.get("Decode")).as_reals();
 }
 
 /// Bind the parser-backed `resolve`/`load_stream` hooks shared by every typed
@@ -676,7 +676,7 @@ void parse_image_data(DocumentParser &parser, const Dictionary &dictionary,
   if (alpha.empty() && dictionary.has_value("Mask")) {
     const Object mask = parser.resolve_object_copy(dictionary["Mask"]);
     if (mask.is_array()) {
-      color_key = as_reals(mask);
+      color_key = mask.as_reals();
     } else if (dictionary["Mask"].is_reference()) {
       alpha = resolve_mask_alpha(parser, dictionary["Mask"], width, height,
                                  /*stencil=*/true);

--- a/src/odr/internal/pdf/pdf_graphics_state.cpp
+++ b/src/odr/internal/pdf/pdf_graphics_state.cpp
@@ -293,6 +293,7 @@ void GraphicsState::execute(const GraphicsOperator &op) {
     current().stroke_color.space = ColorSpace::device_grey;
     current().stroke_color.grey = op.arguments.at(0).as_real();
     current().stroke_color.def = nullptr;
+    current().stroke_color.pattern.clear();
     break;
   case GraphicsOperatorType::set_stroke_rgb_color:
     current().stroke_color.space = ColorSpace::device_rgb;
@@ -300,6 +301,7 @@ void GraphicsState::execute(const GraphicsOperator &op) {
       current().stroke_color.rgb.at(i) = op.arguments.at(i).as_real();
     }
     current().stroke_color.def = nullptr;
+    current().stroke_color.pattern.clear();
     break;
   case GraphicsOperatorType::set_stroke_cmyk_color:
     current().stroke_color.space = ColorSpace::device_cmyk;
@@ -307,12 +309,14 @@ void GraphicsState::execute(const GraphicsOperator &op) {
       current().stroke_color.cmyk.at(i) = op.arguments.at(i).as_real();
     }
     current().stroke_color.def = nullptr;
+    current().stroke_color.pattern.clear();
     break;
 
   case GraphicsOperatorType::set_other_grey_color:
     current().other_color.space = ColorSpace::device_grey;
     current().other_color.grey = op.arguments.at(0).as_real();
     current().other_color.def = nullptr;
+    current().other_color.pattern.clear();
     break;
   case GraphicsOperatorType::set_other_rgb_color:
     current().other_color.space = ColorSpace::device_rgb;
@@ -320,6 +324,7 @@ void GraphicsState::execute(const GraphicsOperator &op) {
       current().other_color.rgb.at(i) = op.arguments.at(i).as_real();
     }
     current().other_color.def = nullptr;
+    current().other_color.pattern.clear();
     break;
   case GraphicsOperatorType::set_other_cmyk_color:
     current().other_color.space = ColorSpace::device_cmyk;
@@ -327,6 +332,7 @@ void GraphicsState::execute(const GraphicsOperator &op) {
       current().other_color.cmyk.at(i) = op.arguments.at(i).as_real();
     }
     current().other_color.def = nullptr;
+    current().other_color.pattern.clear();
     break;
 
   case GraphicsOperatorType::set_glyph_width:

--- a/src/odr/internal/pdf/pdf_graphics_state.hpp
+++ b/src/odr/internal/pdf/pdf_graphics_state.hpp
@@ -113,6 +113,10 @@ struct GraphicsState {
     /// at the time the operator runs; null for a device colour space. Cleared
     /// by the device colour operators (`g`/`rg`/`k`).
     const ColorSpaceDef *def{nullptr};
+    /// The resource name of the `/Pattern` selected by `scn`/`SCN` (a shading
+    /// or tiling pattern), resolved against `Resources::pattern` at paint time.
+    /// Empty for a plain colour; cleared by the device colour operators.
+    std::string pattern;
   };
 
   struct State {

--- a/src/odr/internal/pdf/pdf_object.cpp
+++ b/src/odr/internal/pdf/pdf_object.cpp
@@ -11,18 +11,6 @@
 
 namespace odr::internal::pdf {
 
-std::vector<double> as_reals(const Object &object) {
-  std::vector<double> result;
-  if (object.is_array()) {
-    const Array &array = object.as_array();
-    result.reserve(array.size());
-    for (const Object &item : array) {
-      result.push_back(item.as_real());
-    }
-  }
-  return result;
-}
-
 void StandardString::to_stream(std::ostream &out) const {
   // TODO escape
   out << "(" << string << ")";
@@ -121,6 +109,18 @@ std::optional<std::string> Object::as_string_opt() && {
     return std::move(*this).as_name_opt();
   }
   return std::nullopt;
+}
+
+std::vector<double> Object::as_reals() const {
+  std::vector<double> result;
+  if (is_array()) {
+    const Array &array = as_array();
+    result.reserve(array.size());
+    for (const Object &item : array) {
+      result.push_back(item.as_real());
+    }
+  }
+  return result;
 }
 
 void Object::to_stream(std::ostream &out) const {

--- a/src/odr/internal/pdf/pdf_object.cpp
+++ b/src/odr/internal/pdf/pdf_object.cpp
@@ -11,6 +11,18 @@
 
 namespace odr::internal::pdf {
 
+std::vector<double> as_reals(const Object &object) {
+  std::vector<double> result;
+  if (object.is_array()) {
+    const Array &array = object.as_array();
+    result.reserve(array.size());
+    for (const Object &item : array) {
+      result.push_back(item.as_real());
+    }
+  }
+  return result;
+}
+
 void StandardString::to_stream(std::ostream &out) const {
   // TODO escape
   out << "(" << string << ")";

--- a/src/odr/internal/pdf/pdf_object.hpp
+++ b/src/odr/internal/pdf/pdf_object.hpp
@@ -223,6 +223,13 @@ public:
   Array *as_array_ptr() & { return as_ptr<Array>(); }
   Dictionary *as_dictionary_ptr() & { return as_ptr<Dictionary>(); }
 
+  /// The elements of an array `Object` as doubles, in order (each via
+  /// `Object::as_real`). Returns an empty vector when `object` is not an array.
+  /// Convenience for the many PDF arrays that are plain number lists
+  /// (`/Decode`,
+  /// `/Coords`, `/Domain`, `/Background`, a colour-key `/Mask`, ...).
+  std::vector<double> as_reals() const;
+
   void to_stream(std::ostream &) const;
   [[nodiscard]] std::string to_string() const;
 
@@ -342,12 +349,6 @@ public:
 private:
   Holder m_holder;
 };
-
-/// The elements of an array `Object` as doubles, in order (each via
-/// `Object::as_real`). Returns an empty vector when `object` is not an array.
-/// Convenience for the many PDF arrays that are plain number lists (`/Decode`,
-/// `/Coords`, `/Domain`, `/Background`, a colour-key `/Mask`, ...).
-std::vector<double> as_reals(const Object &object);
 
 std::ostream &operator<<(std::ostream &, const StandardString &);
 std::ostream &operator<<(std::ostream &, const HexString &);

--- a/src/odr/internal/pdf/pdf_object.hpp
+++ b/src/odr/internal/pdf/pdf_object.hpp
@@ -343,6 +343,12 @@ private:
   Holder m_holder;
 };
 
+/// The elements of an array `Object` as doubles, in order (each via
+/// `Object::as_real`). Returns an empty vector when `object` is not an array.
+/// Convenience for the many PDF arrays that are plain number lists (`/Decode`,
+/// `/Coords`, `/Domain`, `/Background`, a colour-key `/Mask`, ...).
+std::vector<double> as_reals(const Object &object);
+
 std::ostream &operator<<(std::ostream &, const StandardString &);
 std::ostream &operator<<(std::ostream &, const HexString &);
 std::ostream &operator<<(std::ostream &, const Name &);

--- a/src/odr/internal/pdf/pdf_page_element.hpp
+++ b/src/odr/internal/pdf/pdf_page_element.hpp
@@ -10,6 +10,7 @@
 namespace odr::internal::pdf {
 
 struct Font;
+struct Shading;
 
 /// One show-text operation laid out in user space. The transform places the
 /// text origin and orientation; the font size is kept separate so the renderer
@@ -65,8 +66,9 @@ struct TextElement {
 /// space. The geometry is fully resolved (the CTM applied at construction), so
 /// a renderer maps it through the page transform alone. The paint intent and
 /// the paint-relevant graphics state are snapshotted; colors are kept as PDF
-/// device colors and converted to RGB by the renderer. `/Pattern` color is
-/// stage 4.9+ and not yet represented.
+/// device colors and converted to RGB by the renderer. A `/PatternType 2`
+/// shading pattern fill is carried by `fill_shading`; tiling patterns
+/// (`/PatternType 1`) are a later stage.
 struct PathElement {
   /// The subpaths to paint, in user space.
   std::vector<Subpath> subpaths;
@@ -81,6 +83,13 @@ struct PathElement {
   /// Non-stroking (fill) color and stroking color, as device colors.
   GraphicsState::Color fill_color;
   GraphicsState::Color stroke_color;
+  /// When the fill is a shading pattern (`scn` naming a `/PatternType 2`
+  /// pattern), the resolved shading to paint through the path instead of
+  /// `fill_color`, with `shading_transform` mapping shading space to user space
+  /// (the pattern `/Matrix`). Null for a plain colour fill. Owned by
+  /// `Resources`, which outlives the element.
+  const Shading *fill_shading{nullptr};
+  util::math::Transform2D shading_transform;
   /// Stroke parameters. `line_width` and the dash lengths are in the path's
   /// user space (the CTM scale is already folded in, so they live in the same
   /// space as the geometry). A `line_width` of 0 means a device-thin line.
@@ -105,9 +114,24 @@ struct ImageElement {
   std::string mime; // e.g. "image/jpeg"
 };
 
+/// One area painted by the `sh` operator (ISO 32000-1 8.7.4.2): a shading
+/// flooded over the current clip region (no path geometry of its own). The
+/// transform maps shading space to user space (the CTM at `sh` time); the clip
+/// is snapshotted as for a path. The renderer paints the shading's gradient
+/// across the clipped area.
+struct ShadingElement {
+  /// The shading to paint. Owned by `Resources`, which outlives the element.
+  const Shading *shading{nullptr};
+  /// Shading space -> user space (the CTM in force at `sh` time).
+  util::math::Transform2D transform;
+  /// The clip in force, snapshotted so the renderer bounds the flood.
+  std::vector<ClipPath> clip;
+};
+
 /// A single page-content element in paint (z) order: a shown text segment, a
-/// painted path or an image. Shadings and patterns join this variant in later
-/// stage-4 PRs.
-using PageElement = std::variant<TextElement, PathElement, ImageElement>;
+/// painted path, an image, or a shading flood (`sh`). Shading *patterns* ride
+/// on `PathElement::fill_shading`; tiling patterns join in a later stage.
+using PageElement =
+    std::variant<TextElement, PathElement, ImageElement, ShadingElement>;
 
 } // namespace odr::internal::pdf

--- a/src/odr/internal/pdf/pdf_page_extractor.cpp
+++ b/src/odr/internal/pdf/pdf_page_extractor.cpp
@@ -527,7 +527,7 @@ void emit_inline_image(const GraphicsOperator &op, const Resources &resources,
       dictionary.get("Width").as_integer_opt().value_or(0));
   const auto height = static_cast<std::int32_t>(
       dictionary.get("Height").as_integer_opt().value_or(0));
-  const std::vector<double> decode_array = as_reals(dictionary.get("Decode"));
+  const std::vector<double> decode_array = dictionary.get("Decode").as_reals();
 
   // An inline `/ImageMask true` stencil: decode the 1-bpc bitmap and paint it
   // in the current fill colour, as for a stencil image XObject (ISO

--- a/src/odr/internal/pdf/pdf_page_extractor.cpp
+++ b/src/odr/internal/pdf/pdf_page_extractor.cpp
@@ -340,24 +340,28 @@ void set_color_space(GraphicsState::Color &color, const std::string &name,
 /// Resolve a general colour operator (`sc`/`scn`/`SC`/`SCN`): convert the
 /// operand components through the active colour space to RGB. With no resource
 /// colour space, interpret the components as a device colour by their count
-/// (ISO 32000-1 8.6.8). A trailing name operand (a `/Pattern`) carries no
-/// convertible components — left as-is (stage 4.9/4.10).
+/// (ISO 32000-1 8.6.8). A trailing name operand selects a `/Pattern`: its name
+/// is recorded on `color.pattern` and resolved against `Resources::pattern` at
+/// paint time (a shading pattern then fills the path through its gradient).
 void set_color(GraphicsState::Color &color, const GraphicsOperator &op) {
   std::vector<double> components;
-  bool has_pattern_name = false;
+  std::string pattern_name;
   for (const Object &argument : op.arguments) {
     if (argument.is_name()) {
-      has_pattern_name = true;
+      pattern_name = argument.as_name();
     } else if (argument.is_real()) {
       components.push_back(argument.as_real());
     }
   }
+  color.pattern = pattern_name;
+  if (!pattern_name.empty()) {
+    // A pattern colour carries no device components to convert; the pattern is
+    // resolved at paint time. Leave any underlying colour as-is.
+    return;
+  }
   if (color.def != nullptr) {
     color.space = ColorSpace::device_rgb;
     color.rgb = color.def->to_rgb(components);
-    return;
-  }
-  if (has_pattern_name) {
     return;
   }
   switch (components.size()) {
@@ -404,9 +408,9 @@ std::array<double, 3> color_to_rgb(const GraphicsState::Color &color) {
 /// Emit a path-painting element from the path accumulated in `state` and the
 /// current paint state, then clear the path (as every painting operator does).
 /// `close` first closes the current subpath (the `s`/`b`/`b*` variants).
-void paint_path(std::vector<PageElement> &out, GraphicsState &state,
-                const bool fill, const bool stroke, const bool even_odd,
-                const bool close) {
+void paint_path(std::vector<PageElement> &out, const Resources &resources,
+                GraphicsState &state, const bool fill, const bool stroke,
+                const bool even_odd, const bool close) {
   if (close) {
     state.path_close();
   }
@@ -421,6 +425,22 @@ void paint_path(std::vector<PageElement> &out, GraphicsState &state,
   element.even_odd = even_odd;
   element.fill_color = s.other_color;
   element.stroke_color = s.stroke_color;
+  // A `/Pattern`-coloured fill: resolve the pattern selected by `scn`. A
+  // shading pattern (`/PatternType 2`) paints its gradient through the path;
+  // its
+  // `/Matrix` maps shading space to the page's default user space (ISO 32000-1
+  // 8.7.3.1). Other pattern types fall through to the plain fill colour.
+  if (fill && !s.other_color.pattern.empty()) {
+    if (const auto it = resources.pattern.find(s.other_color.pattern);
+        it != resources.pattern.end() && it->second != nullptr) {
+      const Pattern *pattern = it->second;
+      if (pattern->type == Pattern::Type::shading &&
+          pattern->shading != nullptr) {
+        element.fill_shading = pattern->shading.get();
+        element.shading_transform = pattern->matrix;
+      }
+    }
+  }
   // The stroke width and dash lengths are given in the CTM's space; fold the
   // CTM scale in so they live in the same user space as the geometry. Use the
   // area-preserving factor sqrt|det| (an anisotropic CTM can't be expressed as
@@ -559,6 +579,26 @@ void emit_inline_image(const GraphicsOperator &op, const Resources &resources,
   image.data = std::move(encoded->data);
   image.mime = std::move(encoded->mime);
   out.push_back(std::move(image));
+}
+
+/// Emit a `ShadingElement` for the `sh` operator (ISO 32000-1 8.7.4.2): flood
+/// the named `/Shading` over the current clip region. The shading is mapped to
+/// user space by the CTM in force; unsupported shadings (parsed to nothing)
+/// produce no element.
+void emit_shading(const GraphicsOperator &op, const Resources &resources,
+                  GraphicsState &state, std::vector<PageElement> &out) {
+  if (op.arguments.empty() || !op.arguments.at(0).is_name()) {
+    return;
+  }
+  const auto it = resources.shading.find(op.arguments.at(0).as_name());
+  if (it == resources.shading.end() || it->second == nullptr) {
+    return;
+  }
+  ShadingElement element;
+  element.shading = it->second.get();
+  element.transform = state.current().general.transform_matrix;
+  element.clip = state.current().clip;
+  out.push_back(std::move(element));
 }
 
 /// Form XObjects currently being rendered, by element identity. The parser
@@ -722,28 +762,31 @@ void run_content(const std::string &content, const Resources &resources,
       break;
 
     case GraphicsOperatorType::stroke: // S
-      paint_path(out, state, false, true, false, false);
+      paint_path(out, resources, state, false, true, false, false);
       break;
     case GraphicsOperatorType::close_stroke: // s
-      paint_path(out, state, false, true, false, true);
+      paint_path(out, resources, state, false, true, false, true);
       break;
     case GraphicsOperatorType::fill_nonzero: // f, F
-      paint_path(out, state, true, false, false, false);
+      paint_path(out, resources, state, true, false, false, false);
       break;
     case GraphicsOperatorType::fill_evenodd: // f*
-      paint_path(out, state, true, false, true, false);
+      paint_path(out, resources, state, true, false, true, false);
       break;
     case GraphicsOperatorType::fill_nonzero_stroke: // B
-      paint_path(out, state, true, true, false, false);
+      paint_path(out, resources, state, true, true, false, false);
       break;
     case GraphicsOperatorType::fill_evenodd_stroke: // B*
-      paint_path(out, state, true, true, true, false);
+      paint_path(out, resources, state, true, true, true, false);
       break;
     case GraphicsOperatorType::close_fill_nonzero_stroke: // b
-      paint_path(out, state, true, true, false, true);
+      paint_path(out, resources, state, true, true, false, true);
       break;
     case GraphicsOperatorType::close_fill_evenodd_stroke: // b*
-      paint_path(out, state, true, true, true, true);
+      paint_path(out, resources, state, true, true, true, true);
+      break;
+    case GraphicsOperatorType::set_clipping_path_shading: // sh
+      emit_shading(op, resources, state, out);
       break;
     case GraphicsOperatorType::end_path: // n
       // Path painted with no marks — its only role is to install a pending

--- a/src/odr/internal/pdf/pdf_page_extractor.cpp
+++ b/src/odr/internal/pdf/pdf_page_extractor.cpp
@@ -427,8 +427,7 @@ void paint_path(std::vector<PageElement> &out, const Resources &resources,
   element.stroke_color = s.stroke_color;
   // A `/Pattern`-coloured fill: resolve the pattern selected by `scn`. A
   // shading pattern (`/PatternType 2`) paints its gradient through the path;
-  // its
-  // `/Matrix` maps shading space to the page's default user space (ISO 32000-1
+  // its matrix maps shading space to the page's default user space (ISO 32000-1
   // 8.7.3.1). Other pattern types fall through to the plain fill colour.
   if (fill && !s.other_color.pattern.empty()) {
     if (const auto it = resources.pattern.find(s.other_color.pattern);
@@ -528,12 +527,7 @@ void emit_inline_image(const GraphicsOperator &op, const Resources &resources,
       dictionary.get("Width").as_integer_opt().value_or(0));
   const auto height = static_cast<std::int32_t>(
       dictionary.get("Height").as_integer_opt().value_or(0));
-  std::vector<double> decode_array;
-  if (const Object &d = dictionary.get("Decode"); d.is_array()) {
-    for (const Object &item : d.as_array()) {
-      decode_array.push_back(item.as_real());
-    }
-  }
+  const std::vector<double> decode_array = as_reals(dictionary.get("Decode"));
 
   // An inline `/ImageMask true` stencil: decode the 1-bpc bitmap and paint it
   // in the current fill colour, as for a stencil image XObject (ISO

--- a/src/odr/internal/pdf/pdf_shading.cpp
+++ b/src/odr/internal/pdf/pdf_shading.cpp
@@ -8,17 +8,11 @@ namespace odr::internal::pdf {
 
 namespace {
 
-/// Read a numeric array entry as doubles ([] when absent or not an array).
+/// Read a numeric array entry as doubles ([] when absent or not an array),
+/// resolving an indirect reference first.
 std::vector<double> read_numbers(const Dictionary &dict, const std::string &key,
                                  const ShadingContext &context) {
-  std::vector<double> result;
-  const Object value = context.resolve(dict.get(key));
-  if (value.is_array()) {
-    for (const Object &item : value.as_array()) {
-      result.push_back(item.as_real());
-    }
-  }
-  return result;
+  return as_reals(context.resolve(dict.get(key)));
 }
 
 /// Parse the `/Function` of a shading: either one function or an array of

--- a/src/odr/internal/pdf/pdf_shading.cpp
+++ b/src/odr/internal/pdf/pdf_shading.cpp
@@ -1,0 +1,153 @@
+#include <odr/internal/pdf/pdf_shading.hpp>
+
+#include <odr/internal/pdf/pdf_object.hpp>
+
+#include <cstddef>
+
+namespace odr::internal::pdf {
+
+namespace {
+
+/// Read a numeric array entry as doubles ([] when absent or not an array).
+std::vector<double> read_numbers(const Dictionary &dict, const std::string &key,
+                                 const ShadingContext &context) {
+  std::vector<double> result;
+  const Object value = context.resolve(dict.get(key));
+  if (value.is_array()) {
+    for (const Object &item : value.as_array()) {
+      result.push_back(item.as_real());
+    }
+  }
+  return result;
+}
+
+/// Parse the `/Function` of a shading: either one function or an array of
+/// single-output functions (one per colour component, ISO 32000-1 8.7.4.5.2).
+std::vector<std::shared_ptr<Function>>
+parse_shading_functions(const Object &function, const ShadingContext &context) {
+  FunctionContext function_context;
+  function_context.resolve = context.resolve;
+  function_context.load_stream = context.load_stream;
+
+  std::vector<std::shared_ptr<Function>> functions;
+  const Object resolved = context.resolve(function);
+  if (resolved.is_array()) {
+    for (const Object &item : resolved.as_array()) {
+      functions.push_back(parse_function(item, function_context));
+    }
+  } else {
+    functions.push_back(parse_function(resolved, function_context));
+  }
+  // A null entry (an unsupported function type) makes the whole shading
+  // unusable: sampling would yield wrong colours silently.
+  for (const auto &f : functions) {
+    if (f == nullptr) {
+      return {};
+    }
+  }
+  return functions;
+}
+
+/// Evaluate the shading's tint functions at `t`, concatenating their outputs
+/// into the colour-component vector the colour space expects.
+std::vector<double>
+eval_components(const std::vector<std::shared_ptr<Function>> &functions,
+                double t) {
+  std::vector<double> components;
+  for (const auto &function : functions) {
+    std::vector<double> out = function->eval({t});
+    components.insert(components.end(), out.begin(), out.end());
+  }
+  return components;
+}
+
+} // namespace
+
+} // namespace odr::internal::pdf
+
+namespace odr::internal {
+
+std::shared_ptr<pdf::Shading>
+pdf::parse_shading(const Object &object, const ShadingContext &context,
+                   const ColorSpaceContext &color_context) {
+  const Object resolved = context.resolve(object);
+  if (!resolved.is_dictionary()) {
+    return nullptr;
+  }
+  const Dictionary &dict = resolved.as_dictionary();
+
+  if (!dict.get("ShadingType").is_integer()) {
+    return nullptr;
+  }
+  const auto type =
+      static_cast<std::int32_t>(dict.get("ShadingType").as_integer());
+  if (type != 2 && type != 3) {
+    return nullptr; // function-based / mesh shadings are a later stage
+  }
+
+  const std::shared_ptr<ColorSpaceDef> color_space =
+      parse_color_space(dict.get("ColorSpace"), color_context);
+  if (color_space == nullptr) {
+    return nullptr;
+  }
+
+  const std::vector<double> coords = read_numbers(dict, "Coords", context);
+  const std::size_t need = type == 2 ? 4 : 6;
+  if (coords.size() < need) {
+    return nullptr;
+  }
+
+  const std::vector<std::shared_ptr<Function>> functions =
+      parse_shading_functions(dict.get("Function"), context);
+  if (functions.empty()) {
+    return nullptr;
+  }
+
+  auto shading = std::make_shared<Shading>();
+  shading->type = type;
+  for (std::size_t i = 0; i < need; ++i) {
+    shading->coords[i] = coords[i];
+  }
+
+  const std::vector<double> domain = read_numbers(dict, "Domain", context);
+  if (domain.size() >= 2) {
+    shading->domain = {domain[0], domain[1]};
+  }
+
+  const Object extend = context.resolve(dict.get("Extend"));
+  if (extend.is_array() && extend.as_array().size() >= 2) {
+    shading->extend = {extend.as_array()[0].as_bool_opt().value_or(false),
+                       extend.as_array()[1].as_bool_opt().value_or(false)};
+  }
+
+  // Sample the tint function(s) across the domain into colour stops. A fixed
+  // count captures non-linear (stitching/sampled/PostScript) functions well
+  // enough for an SVG gradient; an exponential one is reproduced near-exactly.
+  constexpr std::size_t sample_count = 32;
+  const double t0 = shading->domain[0];
+  const double t1 = shading->domain[1];
+  shading->stops.reserve(sample_count);
+  for (std::size_t i = 0; i < sample_count; ++i) {
+    const double f = static_cast<double>(i) / (sample_count - 1);
+    const double t = t0 + (t1 - t0) * f;
+    shading->stops.push_back(
+        GradientStop{f, color_space->to_rgb(eval_components(functions, t))});
+  }
+
+  const std::vector<double> background =
+      read_numbers(dict, "Background", context);
+  if (!background.empty()) {
+    shading->has_background = true;
+    shading->background = color_space->to_rgb(background);
+  }
+
+  const std::vector<double> bbox = read_numbers(dict, "BBox", context);
+  if (bbox.size() >= 4) {
+    shading->has_bbox = true;
+    shading->bbox = {bbox[0], bbox[1], bbox[2], bbox[3]};
+  }
+
+  return shading;
+}
+
+} // namespace odr::internal

--- a/src/odr/internal/pdf/pdf_shading.cpp
+++ b/src/odr/internal/pdf/pdf_shading.cpp
@@ -46,7 +46,7 @@ parse_shading_functions(const Object &function, const ShadingContext &context) {
 /// into the colour-component vector the colour space expects.
 std::vector<double>
 eval_components(const std::vector<std::shared_ptr<Function>> &functions,
-                double t) {
+                const double t) {
   std::vector<double> components;
   for (const auto &function : functions) {
     std::vector<double> out = function->eval({t});

--- a/src/odr/internal/pdf/pdf_shading.cpp
+++ b/src/odr/internal/pdf/pdf_shading.cpp
@@ -12,7 +12,7 @@ namespace {
 /// resolving an indirect reference first.
 std::vector<double> read_numbers(const Dictionary &dict, const std::string &key,
                                  const ShadingContext &context) {
-  return as_reals(context.resolve(dict.get(key)));
+  return context.resolve(dict.get(key)).as_reals();
 }
 
 /// Parse the `/Function` of a shading: either one function or an array of

--- a/src/odr/internal/pdf/pdf_shading.hpp
+++ b/src/odr/internal/pdf/pdf_shading.hpp
@@ -25,6 +25,12 @@ struct GradientStop {
 /// The tint `/Function` is pre-sampled into `stops`, so a renderer maps this to
 /// an SVG `<linearGradient>`/`<radialGradient>` directly. Other shading types
 /// (1, 4–7) are not modelled here (a later stage tessellates them).
+///
+/// NOTE: `extend`, `background` and `bbox` are parsed but not yet honoured by
+/// the renderer — it always emits the gradient with SVG's `pad` spread, which
+/// over-paints a non-extended shading beyond its interval (see
+/// `GradientRegistry` in `html/pdf_file.cpp`). They are carried here so the
+/// deferred bounds and background handling needs no re-parse.
 struct Shading {
   /// `/ShadingType`: 2 (axial) or 3 (radial).
   std::int32_t type{0};
@@ -34,17 +40,19 @@ struct Shading {
   std::array<double, 6> coords{};
   /// `/Domain` `[t0 t1]` of the parametric variable (default `[0 1]`).
   std::array<double, 2> domain{0, 1};
-  /// `/Extend`: whether the shading continues beyond the axis ends.
-  std::array<bool, 2> extend{false, false};
   /// Colour stops sampled across `domain` (offsets in [0, 1], `stops.front()`
   /// at `t0`), in source order — at least two.
   std::vector<GradientStop> stops;
+  /// `/Extend`: whether the shading continues beyond the axis ends. Parsed but
+  /// not yet honoured (see the struct note).
+  std::array<bool, 2> extend{false, false};
   /// `/Background` colour (sRGB), painted outside the shading where `/Extend`
-  /// does not reach; absent when the shading declares none.
+  /// does not reach; absent when the shading declares none. Parsed but not yet
+  /// honoured (see the struct note).
   bool has_background{false};
   std::array<double, 3> background{};
   /// `/BBox` `[x0 y0 x1 y1]` in shading space, clipping the shading; absent
-  /// when none is declared.
+  /// when none is declared. Parsed but not yet honoured (see the struct note).
   bool has_bbox{false};
   std::array<double, 4> bbox{};
 };
@@ -57,9 +65,8 @@ struct ShadingContext {
 };
 
 /// Build a shading from its `/Shading` dictionary, sampling its tint function
-/// into `stops` through the shading's colour space. `color_context` resolves
-/// the
-/// `/ColorSpace`. Returns `nullptr` for a malformed or unsupported shading
+/// into `stops` through the shading's colour space (resolved via
+/// `color_context`). Returns `nullptr` for a malformed or unsupported shading
 /// (types other than 2/3).
 std::shared_ptr<Shading> parse_shading(const Object &object,
                                        const ShadingContext &context,

--- a/src/odr/internal/pdf/pdf_shading.hpp
+++ b/src/odr/internal/pdf/pdf_shading.hpp
@@ -1,0 +1,68 @@
+#pragma once
+
+#include <odr/internal/pdf/pdf_color.hpp>
+#include <odr/internal/pdf/pdf_function.hpp>
+
+#include <array>
+#include <cstdint>
+#include <functional>
+#include <memory>
+#include <vector>
+
+namespace odr::internal::pdf {
+
+class Object;
+
+/// One colour stop of a gradient: an `offset` in [0, 1] along the gradient axis
+/// and the sRGB colour there. Sampled from a shading's `/Function` across its
+/// `/Domain` at parse time, so the renderer needs no function evaluator.
+struct GradientStop {
+  double offset{0};
+  std::array<double, 3> rgb{};
+};
+
+/// A resolved axial (type 2) or radial (type 3) shading (ISO 32000-1 8.7.4.5).
+/// The tint `/Function` is pre-sampled into `stops`, so a renderer maps this to
+/// an SVG `<linearGradient>`/`<radialGradient>` directly. Other shading types
+/// (1, 4–7) are not modelled here (a later stage tessellates them).
+struct Shading {
+  /// `/ShadingType`: 2 (axial) or 3 (radial).
+  std::int32_t type{0};
+  /// Axial: `[x0 y0 x1 y1]` (the axis). Radial: `[x0 y0 r0 x1 y1 r1]` (the two
+  /// circles). In shading space (mapped to user space by the caller's CTM or a
+  /// pattern matrix).
+  std::array<double, 6> coords{};
+  /// `/Domain` `[t0 t1]` of the parametric variable (default `[0 1]`).
+  std::array<double, 2> domain{0, 1};
+  /// `/Extend`: whether the shading continues beyond the axis ends.
+  std::array<bool, 2> extend{false, false};
+  /// Colour stops sampled across `domain` (offsets in [0, 1], `stops.front()`
+  /// at `t0`), in source order — at least two.
+  std::vector<GradientStop> stops;
+  /// `/Background` colour (sRGB), painted outside the shading where `/Extend`
+  /// does not reach; absent when the shading declares none.
+  bool has_background{false};
+  std::array<double, 3> background{};
+  /// `/BBox` `[x0 y0 x1 y1]` in shading space, clipping the shading; absent
+  /// when none is declared.
+  bool has_bbox{false};
+  std::array<double, 4> bbox{};
+};
+
+/// How `parse_shading` reaches indirect data: `resolve` dereferences an object,
+/// `load_stream` decodes a stream's bytes (a type-0 sampled `/Function`).
+struct ShadingContext {
+  std::function<Object(const Object &)> resolve;
+  std::function<std::string(const Object &)> load_stream;
+};
+
+/// Build a shading from its `/Shading` dictionary, sampling its tint function
+/// into `stops` through the shading's colour space. `color_context` resolves
+/// the
+/// `/ColorSpace`. Returns `nullptr` for a malformed or unsupported shading
+/// (types other than 2/3).
+std::shared_ptr<Shading> parse_shading(const Object &object,
+                                       const ShadingContext &context,
+                                       const ColorSpaceContext &color_context);
+
+} // namespace odr::internal::pdf

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -55,6 +55,7 @@ add_executable(odr_test
         "src/internal/pdf/pdf_object.cpp"
         "src/internal/pdf/pdf_object_parser.cpp"
         "src/internal/pdf/pdf_page_extractor.cpp"
+        "src/internal/pdf/pdf_shading.cpp"
         "src/internal/pdf/pdf_test_file_builder.cpp"
 
         "src/internal/font/cff_font.cpp"

--- a/test/src/internal/pdf/pdf_page_extractor.cpp
+++ b/test/src/internal/pdf/pdf_page_extractor.cpp
@@ -876,6 +876,75 @@ TEST(PdfPageExtractor, device_color_clears_color_space) {
   EXPECT_DOUBLE_EQ(p.fill_color.rgb[1], 0.0);
 }
 
+// --- shadings & shading patterns -------------------------------
+
+namespace {
+
+// A minimal axial shading with two stops (black to white).
+std::shared_ptr<Shading> axial_shading() {
+  auto shading = std::make_shared<Shading>();
+  shading->type = 2;
+  shading->coords = {0, 0, 1, 0, 0, 0};
+  shading->stops = {GradientStop{0.0, {0, 0, 0}}, GradientStop{1.0, {1, 1, 1}}};
+  return shading;
+}
+
+} // namespace
+
+// `scn` naming a `/PatternType 2` pattern fills the path through the pattern's
+// shading; `fill_shading` is resolved and the pattern `/Matrix` carried.
+TEST(PdfPageExtractor, scn_shading_pattern_fills_path) {
+  Pattern pattern;
+  pattern.type = Pattern::Type::shading;
+  pattern.shading = axial_shading();
+  pattern.matrix = Transform2D::translation(5, 7);
+  Resources res;
+  res.pattern["P0"] = &pattern;
+
+  const auto page =
+      extract_page("/Pattern cs /P0 scn 0 0 10 10 re f", res, Logger::null());
+  ASSERT_EQ(page.size(), 1);
+  const PathElement &p = std::get<PathElement>(page[0]);
+  ASSERT_NE(p.fill_shading, nullptr);
+  EXPECT_EQ(p.fill_shading->type, 2);
+  EXPECT_TRUE(p.fill);
+  EXPECT_DOUBLE_EQ(p.shading_transform.e, 5);
+  EXPECT_DOUBLE_EQ(p.shading_transform.f, 7);
+}
+
+// `scn` naming an unknown pattern leaves the fill with no shading (a plain
+// colour fill); the path still paints.
+TEST(PdfPageExtractor, scn_unknown_pattern_has_no_shading) {
+  Resources res;
+  const auto page = extract_page("/Pattern cs /Missing scn 0 0 10 10 re f", res,
+                                 Logger::null());
+  ASSERT_EQ(page.size(), 1);
+  EXPECT_EQ(std::get<PathElement>(page[0]).fill_shading, nullptr);
+}
+
+// The `sh` operator floods the current clip with a named `/Shading`, emitting a
+// `ShadingElement` placed by the CTM.
+TEST(PdfPageExtractor, sh_emits_shading_element) {
+  Resources res;
+  res.shading["Sh0"] = axial_shading();
+
+  const auto page =
+      extract_page("q 2 0 0 2 10 20 cm /Sh0 sh Q", res, Logger::null());
+  ASSERT_EQ(page.size(), 1);
+  const ShadingElement &s = std::get<ShadingElement>(page[0]);
+  ASSERT_NE(s.shading, nullptr);
+  EXPECT_EQ(s.shading->type, 2);
+  EXPECT_DOUBLE_EQ(s.transform.a, 2);
+  EXPECT_DOUBLE_EQ(s.transform.e, 10);
+  EXPECT_DOUBLE_EQ(s.transform.f, 20);
+}
+
+// `sh` naming an unknown shading emits nothing.
+TEST(PdfPageExtractor, sh_unknown_shading_emits_nothing) {
+  Resources res;
+  EXPECT_TRUE(extract_page("/Missing sh", res, Logger::null()).empty());
+}
+
 // --- image XObjects (JPEG pass-through) ------------------------
 
 namespace {

--- a/test/src/internal/pdf/pdf_shading.cpp
+++ b/test/src/internal/pdf/pdf_shading.cpp
@@ -1,0 +1,160 @@
+#include <odr/internal/pdf/pdf_shading.hpp>
+
+#include <odr/internal/pdf/pdf_color.hpp>
+#include <odr/internal/pdf/pdf_object.hpp>
+
+#include <string>
+#include <vector>
+
+#include <gtest/gtest.h>
+
+using namespace odr::internal::pdf;
+
+namespace {
+
+// A context with no indirection: objects resolve to themselves and no stream is
+// needed (the shadings under test use exponential tint functions).
+ShadingContext context() {
+  ShadingContext ctx;
+  ctx.resolve = [](const Object &object) { return object; };
+  ctx.load_stream = [](const Object &) { return std::string{}; };
+  return ctx;
+}
+
+// DeviceRGB resolves without a named lookup; the colour-space resolver is
+// inert.
+ColorSpaceContext color_context() {
+  ColorSpaceContext ctx;
+  ctx.resolve = [](const Object &object) { return object; };
+  ctx.load_stream = [](const Object &) { return std::string{}; };
+  ctx.named = nullptr;
+  return ctx;
+}
+
+Object reals(std::initializer_list<double> values) {
+  std::vector<Object> holder;
+  for (const double value : values) {
+    holder.emplace_back(Real{value});
+  }
+  return Object(Array(std::move(holder)));
+}
+
+// A linear DeviceRGB tint from C0 to C1 (type 2, N = 1).
+Object linear_function(std::initializer_list<double> c0,
+                       std::initializer_list<double> c1) {
+  Dictionary fn;
+  fn["FunctionType"] = Object(Integer{2});
+  fn["Domain"] = reals({0, 1});
+  fn["C0"] = reals(c0);
+  fn["C1"] = reals(c1);
+  fn["N"] = Object(Real{1});
+  return Object(fn);
+}
+
+} // namespace
+
+// Type 2 (axial): the tint function is sampled into stops spanning black to
+// white, with the axis coordinates carried verbatim.
+TEST(PdfShading, axial_basic) {
+  Dictionary dict;
+  dict["ShadingType"] = Object(Integer{2});
+  dict["ColorSpace"] = Object(Name{"DeviceRGB"});
+  dict["Coords"] = reals({10, 20, 110, 20});
+  dict["Function"] = linear_function({0, 0, 0}, {1, 1, 1});
+
+  const auto shading = parse_shading(Object(dict), context(), color_context());
+  ASSERT_NE(shading, nullptr);
+  EXPECT_EQ(shading->type, 2);
+  EXPECT_DOUBLE_EQ(shading->coords[0], 10);
+  EXPECT_DOUBLE_EQ(shading->coords[1], 20);
+  EXPECT_DOUBLE_EQ(shading->coords[2], 110);
+  EXPECT_DOUBLE_EQ(shading->coords[3], 20);
+  ASSERT_GE(shading->stops.size(), 2);
+  EXPECT_DOUBLE_EQ(shading->stops.front().offset, 0.0);
+  EXPECT_DOUBLE_EQ(shading->stops.back().offset, 1.0);
+  EXPECT_NEAR(shading->stops.front().rgb[0], 0.0, 1e-6);
+  EXPECT_NEAR(shading->stops.back().rgb[0], 1.0, 1e-6);
+}
+
+// Type 3 (radial): both circles' six coordinates are taken.
+TEST(PdfShading, radial_basic) {
+  Dictionary dict;
+  dict["ShadingType"] = Object(Integer{3});
+  dict["ColorSpace"] = Object(Name{"DeviceRGB"});
+  dict["Coords"] = reals({0, 0, 0, 0, 0, 50});
+  dict["Function"] = linear_function({1, 0, 0}, {0, 0, 1});
+
+  const auto shading = parse_shading(Object(dict), context(), color_context());
+  ASSERT_NE(shading, nullptr);
+  EXPECT_EQ(shading->type, 3);
+  EXPECT_DOUBLE_EQ(shading->coords[2], 0);  // inner radius
+  EXPECT_DOUBLE_EQ(shading->coords[5], 50); // outer radius
+}
+
+// /Domain and /Extend are parsed; defaults apply when absent.
+TEST(PdfShading, domain_and_extend) {
+  Dictionary dict;
+  dict["ShadingType"] = Object(Integer{2});
+  dict["ColorSpace"] = Object(Name{"DeviceRGB"});
+  dict["Coords"] = reals({0, 0, 1, 0});
+  dict["Domain"] = reals({0.25, 0.75});
+  std::vector<Object> extend{Object(Boolean{true}), Object(Boolean{false})};
+  dict["Extend"] = Object(Array(std::move(extend)));
+  dict["Function"] = linear_function({0}, {1});
+
+  const auto shading = parse_shading(Object(dict), context(), color_context());
+  ASSERT_NE(shading, nullptr);
+  EXPECT_DOUBLE_EQ(shading->domain[0], 0.25);
+  EXPECT_DOUBLE_EQ(shading->domain[1], 0.75);
+  EXPECT_TRUE(shading->extend[0]);
+  EXPECT_FALSE(shading->extend[1]);
+}
+
+// /Background is converted through the colour space.
+TEST(PdfShading, background) {
+  Dictionary dict;
+  dict["ShadingType"] = Object(Integer{2});
+  dict["ColorSpace"] = Object(Name{"DeviceRGB"});
+  dict["Coords"] = reals({0, 0, 1, 0});
+  dict["Background"] = reals({1, 0, 0});
+  dict["Function"] = linear_function({0}, {1});
+
+  const auto shading = parse_shading(Object(dict), context(), color_context());
+  ASSERT_NE(shading, nullptr);
+  ASSERT_TRUE(shading->has_background);
+  EXPECT_NEAR(shading->background[0], 1.0, 1e-6);
+  EXPECT_NEAR(shading->background[1], 0.0, 1e-6);
+}
+
+// Shading types other than 2/3 are not modelled and yield null.
+TEST(PdfShading, unsupported_type_is_null) {
+  Dictionary dict;
+  dict["ShadingType"] = Object(Integer{1});
+  dict["ColorSpace"] = Object(Name{"DeviceRGB"});
+  dict["Function"] = linear_function({0}, {1});
+  EXPECT_EQ(parse_shading(Object(dict), context(), color_context()), nullptr);
+}
+
+// Too few /Coords for the type makes the shading unusable.
+TEST(PdfShading, short_coords_is_null) {
+  Dictionary dict;
+  dict["ShadingType"] = Object(Integer{2});
+  dict["ColorSpace"] = Object(Name{"DeviceRGB"});
+  dict["Coords"] = reals({0, 0}); // axial needs four
+  dict["Function"] = linear_function({0}, {1});
+  EXPECT_EQ(parse_shading(Object(dict), context(), color_context()), nullptr);
+}
+
+// An unsupported tint function makes the whole shading null (no silent wrong
+// colours).
+TEST(PdfShading, bad_function_is_null) {
+  Dictionary fn;
+  fn["FunctionType"] = Object(Integer{9}); // unsupported
+
+  Dictionary dict;
+  dict["ShadingType"] = Object(Integer{2});
+  dict["ColorSpace"] = Object(Name{"DeviceRGB"});
+  dict["Coords"] = reals({0, 0, 1, 0});
+  dict["Function"] = Object(fn);
+  EXPECT_EQ(parse_shading(Object(dict), context(), color_context()), nullptr);
+}


### PR DESCRIPTION
🤖 Generated with [Claude Code](https://claude.com/claude-code)

Stage 4.9 of the PDF→HTML pipeline: render **axial (type 2)** and **radial (type 3)** shadings as SVG gradients, both via the `sh` operator and via `/PatternType 2` shading patterns selected by `scn`. Stacked on #572 (4.8); targets `pdf-stage-4.8`.

## What

- **`pdf_shading.{hpp,cpp}`** — `parse_shading` resolves a `/Shading` dictionary and pre-samples its tint `/Function` across `/Domain` into 32 sRGB colour stops, so the renderer needs no function evaluator. Shading types other than 2/3 and malformed shadings return null; `/Extend`, `/Background` and `/BBox` are parsed.
- **Parser** — `parse_resources` now builds the `/Shading` and `/Pattern` resource tables (after `/ColorSpace`, so a named colour space resolves). A shading pattern resolves its `/Shading`; a tiling pattern is recognized and deferred to 4.10. `GraphicsState::Color` carries the `/Pattern` name selected by `scn`.
- **Extractor** — `scn` records the pattern name; `paint_path` resolves a shading pattern to `PathElement::fill_shading` plus the pattern `/Matrix`; the `sh` operator emits a `ShadingElement` flooding the current clip.
- **HTML** — a `GradientRegistry` emits `<linearGradient>`/`<radialGradient>` defs with `gradientUnits="userSpaceOnUse"`; a shading-pattern fill paints the path through `fill="url(#…)"`, and `sh` paints a clipped `<rect>`. `/Extend` is approximated by SVG's `pad` spread.

## Tests

- `PdfShading`: axial/radial parsing, domain/extend, background, unsupported type, short coords, bad function → null.
- `PdfPageExtractor`: shading-pattern fill resolves `fill_shading` + matrix, unknown pattern leaves a plain fill, `sh` emits a `ShadingElement` at the CTM, unknown shading emits nothing.

All 197 PDF tests pass; full suite green.

## Notes

- Reference-output submodules are intentionally **not** bumped here (left for regeneration by the maintainer).
- Mesh/function shadings (types 1, 4–7) and tiling patterns (`/PatternType 1`, next in 4.10) are out of scope.