### PR TITLE
font: return std::string from serializers, drop istream inputs

### DIFF
--- a/src/odr/internal/font/cff_font.cpp
+++ b/src/odr/internal/font/cff_font.cpp
@@ -3,14 +3,11 @@
 #include <odr/internal/font/cff_standard_strings.hpp>
 #include <odr/internal/pdf/pdf_encoding.hpp>
 #include <odr/internal/util/byte_string.hpp>
-#include <odr/internal/util/stream_util.hpp>
 
 #include <cmath>
 #include <cstdint>
-#include <istream>
 #include <iterator>
 #include <map>
-#include <memory>
 #include <stdexcept>
 #include <utility>
 #include <vector>
@@ -215,14 +212,6 @@ bool CffFont::is_cff(const std::string_view data) {
          static_cast<std::uint8_t>(data[2]) >= 4 &&
          static_cast<std::uint8_t>(data[3]) >= 1 &&
          static_cast<std::uint8_t>(data[3]) <= 4;
-}
-
-CffFont::CffFont(std::unique_ptr<std::istream> stream) {
-  if (stream == nullptr) {
-    throw std::invalid_argument("cff: null input stream");
-  }
-  m_data = util::stream::read(*stream);
-  parse();
 }
 
 CffFont::CffFont(std::string data) : m_data{std::move(data)} { parse(); }

--- a/src/odr/internal/font/cff_font.hpp
+++ b/src/odr/internal/font/cff_font.hpp
@@ -3,8 +3,6 @@
 #include <odr/internal/abstract/font.hpp>
 
 #include <cstdint>
-#include <iosfwd>
-#include <memory>
 #include <optional>
 #include <string>
 #include <string_view>
@@ -29,8 +27,6 @@ public:
   /// Cheap magic test: a CFF header (major version 1, sane `hdrSize`).
   [[nodiscard]] static bool is_cff(std::string_view data);
 
-  /// Parse the facts from @p stream; the raw bytes are retained for `data()`.
-  explicit CffFont(std::unique_ptr<std::istream> stream);
   /// Parse the facts from an in-memory CFF blob (retained for `data()`).
   explicit CffFont(std::string data);
 

--- a/src/odr/internal/font/cff_transform.cpp
+++ b/src/odr/internal/font/cff_transform.cpp
@@ -7,7 +7,6 @@
 #include <algorithm>
 #include <cstdint>
 #include <map>
-#include <sstream>
 #include <string>
 #include <utility>
 #include <vector>
@@ -189,9 +188,7 @@ std::string cff::wrap_to_otf(const CffFont &font,
                                     static_cast<std::uint16_t>(first),
                                     static_cast<std::uint16_t>(last)));
 
-  std::ostringstream out;
-  build_sfnt(out, 0x4f54544f /* 'OTTO' */, std::move(tables));
-  return std::move(out).str();
+  return build_sfnt(0x4f54544f /* 'OTTO' */, std::move(tables));
 }
 
 } // namespace odr::internal::font

--- a/src/odr/internal/font/font_file.cpp
+++ b/src/odr/internal/font/font_file.cpp
@@ -1,8 +1,11 @@
 #include <odr/internal/font/font_file.hpp>
 
+#include <odr/internal/abstract/file.hpp>
 #include <odr/internal/abstract/font.hpp>
 #include <odr/internal/font/sfnt_font.hpp>
+#include <odr/internal/util/stream_util.hpp>
 
+#include <istream>
 #include <utility>
 
 namespace odr::internal::font {
@@ -12,7 +15,8 @@ FontFile::FontFile(std::shared_ptr<abstract::File> file,
     : m_file{std::move(file)}, m_file_type{file_type} {
   // Parse eagerly: a parse failure is how detection rejects a non-font, so the
   // open-strategy try/catch can fall through.
-  m_font = std::make_shared<sfnt::SfntFont>(m_file->stream());
+  m_font =
+      std::make_shared<sfnt::SfntFont>(util::stream::read(*m_file->stream()));
 }
 
 std::shared_ptr<abstract::File> FontFile::file() const noexcept {

--- a/src/odr/internal/font/sfnt_font.cpp
+++ b/src/odr/internal/font/sfnt_font.cpp
@@ -2,14 +2,10 @@
 
 #include <odr/internal/font/sfnt_transform.hpp>
 #include <odr/internal/util/byte_string.hpp>
-#include <odr/internal/util/stream_util.hpp>
 #include <odr/internal/util/string_util.hpp>
 
 #include <algorithm>
 #include <cstdint>
-#include <istream>
-#include <memory>
-#include <ostream>
 #include <stdexcept>
 #include <string>
 #include <string_view>
@@ -177,14 +173,6 @@ bool SfntFont::is_sfnt(const std::string_view data) {
   const std::string_view tag = data.substr(0, 4);
   return tag == std::string_view("\x00\x01\x00\x00", 4) || tag == "OTTO" ||
          tag == "true" || tag == "ttcf" || tag == "typ1";
-}
-
-SfntFont::SfntFont(std::unique_ptr<std::istream> stream) {
-  if (stream == nullptr) {
-    throw std::invalid_argument("sfnt: null input stream");
-  }
-  m_data = util::stream::read(*stream);
-  parse();
 }
 
 SfntFont::SfntFont(std::string data) : m_data{std::move(data)} { parse(); }
@@ -506,7 +494,7 @@ void SfntFont::set_cmap(std::map<char32_t, std::uint16_t> cmap) {
   update_reverse();
 }
 
-void SfntFont::write(std::ostream &out) const {
+std::string SfntFont::write() const {
   std::vector<std::pair<std::string, std::string>> tables;
   tables.reserve(m_tables.size() + 1);
   for (const auto &[tag, location] : m_tables) {
@@ -543,7 +531,7 @@ void SfntFont::write(std::ostream &out) const {
   const std::uint32_t version = m_format == FontFormat::opentype_cff
                                     ? 0x4f54544fU /* 'OTTO' */
                                     : 0x00010000U;
-  build_sfnt(out, version, std::move(tables));
+  return build_sfnt(version, std::move(tables));
 }
 
 std::optional<SfntFont::Table>

--- a/src/odr/internal/font/sfnt_font.hpp
+++ b/src/odr/internal/font/sfnt_font.hpp
@@ -4,9 +4,7 @@
 
 #include <cstdint>
 #include <functional>
-#include <iosfwd>
 #include <map>
-#include <memory>
 #include <optional>
 #include <string>
 #include <string_view>
@@ -26,9 +24,6 @@ public:
   /// Cheap magic test: a recognised SFNT version tag at the head of @p data.
   [[nodiscard]] static bool is_sfnt(std::string_view data);
 
-  /// Reads @p stream fully into an in-memory buffer and parses the facts from
-  /// it; the bytes are retained for pass-through (see `write()`).
-  explicit SfntFont(std::unique_ptr<std::istream> stream);
   /// Parses the facts from an in-memory SFNT blob (retained for `write()`).
   explicit SfntFont(std::string data);
 
@@ -55,11 +50,10 @@ public:
   /// font (see `sfnt_transform.hpp`'s `reencode_to_pua`), then `write()`.
   void set_cmap(std::map<char32_t, std::uint16_t> cmap);
 
-  /// Serialize the current state to @p out: the (possibly mutated) `cmap`
-  /// rebuilt from `cmap()`, every other table copied verbatim from the source
-  /// stream, with a freshly computed table directory and checksums. @p out need
-  /// only be a forward sink (see `build_sfnt`).
-  void write(std::ostream &out) const;
+  /// Serialize the current state and return the bytes: the (possibly mutated)
+  /// `cmap` rebuilt from `cmap()`, every other table copied verbatim from the
+  /// source stream, with a freshly computed table directory and checksums.
+  [[nodiscard]] std::string write() const;
 
 private:
   /// Parse the facts from `m_data` (called by both constructors).

--- a/src/odr/internal/font/sfnt_transform.cpp
+++ b/src/odr/internal/font/sfnt_transform.cpp
@@ -7,7 +7,6 @@
 #include <bit>
 #include <cstdint>
 #include <map>
-#include <ostream>
 #include <ranges>
 #include <stdexcept>
 #include <utility>
@@ -71,8 +70,9 @@ char32_t font::pua_code_point(const std::uint16_t glyph) noexcept {
   return pua_base + glyph;
 }
 
-void font::build_sfnt(std::ostream &out, const std::uint32_t sfnt_version,
-                      std::vector<std::pair<std::string, std::string>> tables) {
+std::string
+font::build_sfnt(const std::uint32_t sfnt_version,
+                 std::vector<std::pair<std::string, std::string>> tables) {
   std::ranges::sort(
       tables, {}, [](const auto &e) -> const std::string & { return e.first; });
 
@@ -127,11 +127,14 @@ void font::build_sfnt(std::ostream &out, const std::uint32_t sfnt_version,
     bs::write_u32_be(tables[head_index].second, 8, 0xb1b0afbaU - file_checksum);
   }
 
-  out.write(header.data(), static_cast<std::streamsize>(header.size()));
-  out.write(directory.data(), static_cast<std::streamsize>(directory.size()));
+  std::string out;
+  out.reserve(offset); // `offset` has accumulated to the whole-file size
+  out.append(header);
+  out.append(directory);
   for (const auto &data : tables | std::views::values) {
-    out.write(data.data(), static_cast<std::streamsize>(data.size()));
+    out.append(data);
   }
+  return out;
 }
 
 std::string font::serialize_cmap(const std::map<char32_t, std::uint16_t> &map) {

--- a/src/odr/internal/font/sfnt_transform.hpp
+++ b/src/odr/internal/font/sfnt_transform.hpp
@@ -1,7 +1,6 @@
 #pragma once
 
 #include <cstdint>
-#include <iosfwd>
 #include <map>
 #include <string>
 #include <utility>
@@ -20,16 +19,18 @@ class SfntFont;
 /// per-font table needed.
 [[nodiscard]] char32_t pua_code_point(std::uint16_t glyph) noexcept;
 
-/// Serialize an SFNT from its tables to @p out, computing the table directory,
-/// per-table checksums and `head.checkSumAdjustment`. @p tables need not be
-/// sorted; a `head` table is patched in place with the final adjustment.
+/// Serialize an SFNT from its tables, computing the table directory, per-table
+/// checksums and `head.checkSumAdjustment`, and return the assembled bytes.
+/// @p tables need not be sorted; a `head` table is patched in place with the
+/// final adjustment.
 ///
 /// The whole-file checksum is additive over the 4-byte-aligned table layout, so
 /// it equals `checksum(header+directory) + Σ checksum(table)` — computed
-/// analytically and the adjustment patched into `head` before the single
-/// forward write, so @p out need only be a forward sink (no seek, no tee).
-void build_sfnt(std::ostream &out, std::uint32_t sfnt_version,
-                std::vector<std::pair<std::string, std::string>> tables);
+/// analytically and the adjustment patched into `head` before the bytes are
+/// concatenated.
+[[nodiscard]] std::string
+build_sfnt(std::uint32_t sfnt_version,
+           std::vector<std::pair<std::string, std::string>> tables);
 
 /// Serialize a code point -> glyph map into a `cmap` table.
 ///

--- a/src/odr/internal/html/font_file.cpp
+++ b/src/odr/internal/html/font_file.cpp
@@ -11,10 +11,11 @@
 #include <odr/internal/html/common.hpp>
 #include <odr/internal/html/html_service.hpp>
 #include <odr/internal/html/html_writer.hpp>
+#include <odr/internal/util/stream_util.hpp>
 
 #include <algorithm>
+#include <istream>
 #include <memory>
-#include <sstream>
 #include <string>
 
 namespace odr::internal::html {
@@ -95,11 +96,10 @@ public:
       // Re-encode a fresh parse: reencode_to_pua mutates the cmap in place, and
       // the grid below still reads each glyph's original Unicode from
       // `font`.
-      font::sfnt::SfntFont embed(m_font_file.impl()->file()->stream());
+      font::sfnt::SfntFont embed(
+          util::stream::read(*m_font_file.impl()->file()->stream()));
       font::reencode_to_pua(embed);
-      std::ostringstream sfnt_out;
-      embed.write(sfnt_out);
-      reencoded = sfnt_out.str();
+      reencoded = embed.write();
     } catch (...) {
       out.out() << "<p>font has too many glyphs to display</p>";
       out.write_body_end();

--- a/src/odr/internal/html/pdf_file.cpp
+++ b/src/odr/internal/html/pdf_file.cpp
@@ -658,8 +658,7 @@ public:
         std::map<char32_t, std::uint16_t> original_cmap = sfnt->cmap();
         try {
           font::reencode_to_pua(*sfnt);
-          std::ostringstream sfnt_out;
-          sfnt->write(sfnt_out);
+          (void)sfnt->write();
           usable = true;
         } catch (...) {
           usable = false;
@@ -1083,9 +1082,7 @@ public:
       if (auto sfnt = std::dynamic_pointer_cast<font::sfnt::SfntFont>(
               font->embedded_font)) {
         font::reencode_to_pua(*sfnt, extra);
-        std::ostringstream sfnt_out;
-        sfnt->write(sfnt_out);
-        reencoded = std::move(sfnt_out).str();
+        reencoded = sfnt->write();
       } else if (auto cff = std::dynamic_pointer_cast<font::cff::CffFont>(
                      font->embedded_font)) {
         reencoded = font::cff::wrap_to_otf(*cff, extra);

--- a/test/src/internal/font/cff_font.cpp
+++ b/test/src/internal/font/cff_font.cpp
@@ -10,8 +10,6 @@
 #include <gtest/gtest.h>
 
 #include <cstdint>
-#include <memory>
-#include <sstream>
 #include <string>
 #include <vector>
 
@@ -432,7 +430,7 @@ TEST(CffFontTest, WrapsToLoadableOtf) {
   // The wrap is a valid OTTO that parses back as an SFNT carrying the CFF as a
   // pass-through table and a uniform PUA cmap over every glyph.
   ASSERT_TRUE(sfnt::SfntFont::is_sfnt(otf));
-  const sfnt::SfntFont wrapped{std::make_unique<std::istringstream>(otf)};
+  const sfnt::SfntFont wrapped{otf};
   EXPECT_EQ(wrapped.format(), FontFormat::opentype_cff);
   EXPECT_EQ(wrapped.glyph_count(), cff.glyph_count());
   // PUA code point U+E000+glyph maps back to that glyph.
@@ -451,7 +449,7 @@ TEST(CffFontTest, WrapDropsExtraEntriesPastGlyphCount) {
   const std::string otf = cff::wrap_to_otf(cff, {{U'A', 1}, {U'B', 5}});
 
   ASSERT_TRUE(sfnt::SfntFont::is_sfnt(otf));
-  const sfnt::SfntFont wrapped{std::make_unique<std::istringstream>(otf)};
+  const sfnt::SfntFont wrapped{otf};
   EXPECT_EQ(wrapped.glyph_for_code_point('A'), 1);
   EXPECT_EQ(wrapped.glyph_for_code_point('B'), 0); // dropped: not mapped
   EXPECT_EQ(wrapped.glyph_for_code_point(pua_code_point(1)), 1);

--- a/test/src/internal/font/font_file.cpp
+++ b/test/src/internal/font/font_file.cpp
@@ -110,9 +110,7 @@ std::string name_table(const std::string &ascii) {
 std::string
 build_sfnt_bytes(std::uint32_t version,
                  std::vector<std::pair<std::string, std::string>> tables) {
-  std::ostringstream out;
-  build_sfnt(out, version, std::move(tables));
-  return out.str();
+  return build_sfnt(version, std::move(tables));
 }
 
 std::string sample_ttf() {

--- a/test/src/internal/font/sfnt_transform.cpp
+++ b/test/src/internal/font/sfnt_transform.cpp
@@ -7,9 +7,7 @@
 
 #include <cstdint>
 #include <map>
-#include <memory>
 #include <optional>
-#include <sstream>
 #include <string>
 #include <utility>
 #include <vector>
@@ -20,28 +18,23 @@ namespace {
 
 namespace bs = odr::internal::util::byte_string;
 
-/// Parse a font from its in-memory bytes (the reader consumes an
-/// `std::istream`).
+/// Parse a font from its in-memory bytes.
 sfnt::SfntFont parse(std::string bytes) {
-  return sfnt::SfntFont(std::make_unique<std::istringstream>(std::move(bytes)));
+  return sfnt::SfntFont(std::move(bytes));
 }
 
-/// Serialize an SFNT to bytes (the writer emits to an `std::ostream`).
+/// Serialize an SFNT to bytes.
 std::string
 build_font(std::uint32_t version,
            std::vector<std::pair<std::string, std::string>> tables) {
-  std::ostringstream out;
-  build_sfnt(out, version, std::move(tables));
-  return out.str();
+  return build_sfnt(version, std::move(tables));
 }
 
 /// Parse @p bytes, re-encode it to the PUA in place, and write it back out.
 std::string reencoded(std::string bytes) {
   sfnt::SfntFont font = parse(std::move(bytes));
   reencode_to_pua(font);
-  std::ostringstream out;
-  font.write(out);
-  return out.str();
+  return font.write();
 }
 
 std::string head_table() {
@@ -234,10 +227,8 @@ TEST(SfntTransform, reencode_with_extra_round_trips_through_write) {
   sfnt::SfntFont font = parse(sample_font());
   // 'A' is adjacent to nothing; 'Z' forces a second cmap segment past the PUA.
   reencode_to_pua(font, {{U'A', 1}, {U'Z', 2}});
-  std::ostringstream out;
-  font.write(out);
 
-  const sfnt::SfntFont parsed = parse(std::move(out).str());
+  const sfnt::SfntFont parsed = parse(font.write());
   EXPECT_EQ(parsed.glyph_for_code_point('A'), 1);
   EXPECT_EQ(parsed.glyph_for_code_point('Z'), 2);
   EXPECT_EQ(parsed.glyph_for_code_point(pua_code_point(1)), 1);
@@ -286,11 +277,10 @@ TEST(SfntTransform, write_keeps_existing_post) {
 
   sfnt::SfntFont parsed = parse(font);
   reencode_to_pua(parsed);
-  std::ostringstream out;
-  parsed.write(out);
+  const std::string out = parsed.write();
 
   // The source `post` is copied through verbatim, not replaced.
-  EXPECT_EQ(table(out.str(), "post"), original_post);
+  EXPECT_EQ(table(out, "post"), original_post);
 }
 
 TEST(SfntTransform, write_synthesizes_os2_when_absent) {
@@ -326,9 +316,8 @@ TEST(SfntTransform, write_keeps_existing_os2) {
 
   sfnt::SfntFont parsed = parse(font);
   reencode_to_pua(parsed);
-  std::ostringstream out;
-  parsed.write(out);
+  const std::string out = parsed.write();
 
   // The source `OS/2` is copied through verbatim, not replaced.
-  EXPECT_EQ(table(out.str(), "OS/2"), original_os2);
+  EXPECT_EQ(table(out, "OS/2"), original_os2);
 }

--- a/test/src/internal/pdf/pdf_font.cpp
+++ b/test/src/internal/pdf/pdf_font.cpp
@@ -7,7 +7,6 @@
 
 #include <cstdint>
 #include <memory>
-#include <sstream>
 #include <string>
 #include <utility>
 #include <vector>
@@ -120,8 +119,7 @@ std::shared_ptr<abstract::Font> sample_font() {
                                  {"hhea", hhea_table(5)},
                                  {"hmtx", hmtx_table(5)},
                                  {"maxp", maxp_table(5)}});
-  return std::make_shared<font::sfnt::SfntFont>(
-      std::make_unique<std::istringstream>(std::move(sfnt)));
+  return std::make_shared<font::sfnt::SfntFont>(std::move(sfnt));
 }
 
 /// Big-endian 2-byte codes, as a composite font's character codes appear.


### PR DESCRIPTION
🤖 Generated with [Claude Code](https://claude.com/claude-code)

## Summary

Orthogonal cleanup split off from the PDF text-selection work. Now that all font *inputs* are `std::string`, the stream-based *outputs* no longer earn their keep.

**Output side** — `SfntFont::write()`, `build_sfnt(...)`, and `cff::wrap_to_otf` now return `std::string`:
- Every caller already funneled the `std::ostream` through an `ostringstream` just to recover the bytes.
- `build_sfnt` assembled the entire file in memory (header + directory + all table bodies) before the single write, so the ostream provided no streaming/memory benefit — it was a `std::string` builder wearing an ostream costume.
- Dropping it removes the boilerplate and one buffer copy at all 8 call sites, and makes `SfntFont::write` symmetric with its `std::string` constructor and consistent with `wrap_to_otf`.

**Input side** — removed the `unique_ptr<istream>` constructors:
- `CffFont`'s was dead code (all CFFs are built from `std::string`).
- `SfntFont`'s two callers now read the file stream into a string themselves via `util::stream::read`, leaving the `std::string` ctor as the single entry point.

Pruned the now-unused `<ostream>`/`<istream>`/`<sstream>`/`<iosfwd>`/`<memory>`/`stream_util.hpp` includes throughout, and updated the four tests that constructed fonts via `istringstream`.

Net **−50 lines**.

## Testing

Full font/pdf test suite green (59 tests).