### PR TITLE
PDF: resolve an image's named /ColorSpace against the resource table

### DIFF
--- a/src/odr/internal/pdf/AGENTS.md
+++ b/src/odr/internal/pdf/AGENTS.md
@@ -291,7 +291,10 @@ it.
   re-encoded as PNG; inline images (`BI`/`ID`/`EI`); `/ImageMask` stencils painted
   in the current fill colour; `/SMask` and `/Mask` (stencil + colour-key)
   composited into RGBA on the raster path (a mask on a JPEG base is left alone —
-  decoding the JPEG to composite is out of scope).
+  decoding the JPEG to composite is out of scope). An image's `/ColorSpace` may
+  be a device space, an inline array (Indexed/ICCBased/…), or a *name* resolved
+  against the enclosing `/Resources /ColorSpace` table (the table is parsed
+  before the `/XObject` table and threaded into image parsing).
 - **Shadings** (axial type 2, radial type 3): `parse_shading` pre-samples the
   tint function into sRGB stops, so the renderer needs no evaluator. `sh` floods
   the clip (a `<rect>` filled with the gradient); a `/PatternType 2` shading
@@ -674,16 +677,6 @@ The next feature cluster — needs destinations from the page tree, little else.
   `/W2`/`/DW2` vertical metrics and a perpendicular pen advance, which the
   horizontal-only `extract_text` and space inference assume away). No corpus
   fixture needs either yet; revisit when one does.
-- **Annotations** are collected but their content is not interpreted (stage 5).
-- **Image colour space from a named resource** (deferred from stage 4.6): a
-  decodable raster image whose `/ColorSpace` is a *name* (e.g. `/CS0`, defined in
-  the enclosing `/Resources /ColorSpace`) is dropped instead of PNG-encoded.
-  `parse_image_data` builds a `ColorSpaceContext` with no `named` resolver
-  (device spaces and inline Indexed/ICCBased arrays resolve fine), because the
-  XObject is parsed before — and without access to — the resource ColorSpace
-  table (`parse_resources` parses the `/XObject` table at the top, the
-  `/ColorSpace` table further down). A proper fix reorders `parse_resources` to
-  build the ColorSpace table first and threads it into `parse_x_object`, or
-  defers image colour-space resolution to `Do`-invocation time where the
-  resource chain is known. Inline images and JPEG pass-through are unaffected.
+- **Annotations** are collected but their content is not interpreted
+  (*Interaction & navigation*).
 - Revisit the reference-by-lookahead parsing and `read_stream(-1)` fallback.

--- a/src/odr/internal/pdf/pdf_document_parser.cpp
+++ b/src/odr/internal/pdf/pdf_document_parser.cpp
@@ -656,6 +656,12 @@ Element *parse_page_or_pages(State &state, const ObjectReference &reference,
 // back the in-progress element, so the in-memory graph mirrors the file.
 Resources *parse_resources(State &state, const Object &object);
 
+/// A `ColorSpaceContext` whose `named` resolver looks a base/alternate space up
+/// in `resources`' (being-built) `/ColorSpace` table; a bare parser context
+/// (no `named` resolver) when `resources` is null.
+ColorSpaceContext make_color_space_context(DocumentParser &parser,
+                                           const Resources *resources);
+
 /// Read an integer image-dictionary entry (e.g. `/Width`), resolving an
 /// indirect reference, defaulting to `fallback`.
 std::int32_t image_int(DocumentParser &parser, const Dictionary &dictionary,
@@ -766,9 +772,11 @@ void parse_stencil_mask(DocumentParser &parser, const Dictionary &dictionary,
 /// cannot yet hand off (JPXDecode, CCITTFaxDecode, JBIG2Decode) and unresolved
 /// colour spaces leave the bytes empty, so `Do` skips the image. A `/SMask` or
 /// `/Mask` on a JPEG base is ignored (decoding the JPEG to composite is out of
-/// scope).
+/// scope). `resources` supplies the enclosing `/ColorSpace` table so a `/CS…`
+/// named colour space resolves.
 void parse_image_data(DocumentParser &parser, const Dictionary &dictionary,
-                      const IndirectObject &object, XObject &x_object) {
+                      const IndirectObject &object, XObject &x_object,
+                      const Resources *resources) {
   Object filter;
   if (dictionary.has_key("Filter")) {
     filter = parser.deep_resolve_object_copy(dictionary["Filter"]);
@@ -779,13 +787,12 @@ void parse_image_data(DocumentParser &parser, const Dictionary &dictionary,
   }
 
   // Resolve the raster parameters (a JPEG pass-through ignores them). The
-  // colour space resolves device spaces and inline Indexed/ICCBased arrays; a
-  // bare named resource space is out of scope here (no resource dictionary at
-  // parse time), so the raster path skips such an image.
+  // colour space resolves device spaces, inline Indexed/ICCBased arrays, and —
+  // via `resources` — a bare `/CS…` name into the enclosing `/ColorSpace`
+  // table.
   std::shared_ptr<ColorSpaceDef> color_space;
   if (dictionary.has_value("ColorSpace")) {
-    ColorSpaceContext context;
-    bind_parser_io(context, parser);
+    ColorSpaceContext context = make_color_space_context(parser, resources);
     color_space = parse_color_space(dictionary.get("ColorSpace"), context);
   }
   const std::int32_t width = image_int(parser, dictionary, "Width", 0);
@@ -823,7 +830,8 @@ void parse_image_data(DocumentParser &parser, const Dictionary &dictionary,
   }
 }
 
-XObject *parse_x_object(State &state, const ObjectReference &reference) {
+XObject *parse_x_object(State &state, const ObjectReference &reference,
+                        const Resources *resources) {
   DocumentParser &parser = state.parser();
   Document &document = state.document();
 
@@ -858,7 +866,7 @@ XObject *parse_x_object(State &state, const ObjectReference &reference) {
     if (image_mask) {
       parse_stencil_mask(parser, dictionary, object, *x_object);
     } else {
-      parse_image_data(parser, dictionary, object, *x_object);
+      parse_image_data(parser, dictionary, object, *x_object, resources);
     }
     return x_object;
   }
@@ -906,11 +914,13 @@ ColorSpaceContext make_color_space_context(DocumentParser &parser,
                                            const Resources *resources) {
   ColorSpaceContext context;
   bind_parser_io(context, parser);
-  context.named =
-      [resources](const std::string &name) -> std::shared_ptr<ColorSpaceDef> {
-    const auto it = resources->color_space.find(name);
-    return it != resources->color_space.end() ? it->second : nullptr;
-  };
+  if (resources != nullptr) {
+    context.named =
+        [resources](const std::string &name) -> std::shared_ptr<ColorSpaceDef> {
+      const auto it = resources->color_space.find(name);
+      return it != resources->color_space.end() ? it->second : nullptr;
+    };
+  }
   return context;
 }
 
@@ -1007,7 +1017,10 @@ std::shared_ptr<SoftMaskDef> parse_soft_mask(State &state,
   if (!dictionary.has_value("G") || !dictionary["G"].is_reference()) {
     return nullptr;
   }
-  XObject *group = parse_x_object(state, dictionary["G"].as_reference());
+  // The `/G` group is a form XObject carrying its own `/Resources`; any image
+  // inside it resolves its colour space against that, so no enclosing table.
+  XObject *group =
+      parse_x_object(state, dictionary["G"].as_reference(), nullptr);
   if (group == nullptr || group->subtype != XObject::Subtype::form) {
     return nullptr;
   }
@@ -1042,14 +1055,9 @@ Resources *parse_resources(State &state, const Object &object) {
     }
   }
 
-  if (dictionary.has_value("XObject")) {
-    const Dictionary x_object_table =
-        parser.resolve_object_copy(dictionary["XObject"]).as_dictionary();
-    for (const auto &[key, value] : x_object_table) {
-      resources->x_object[key] = parse_x_object(state, value.as_reference());
-    }
-  }
-
+  // `/ColorSpace` is parsed before `/XObject`, `/Shading` and `/Pattern` so a
+  // named colour space any of them reference (an image's `/ColorSpace /CS…`, a
+  // shading's base space) is already in `resources->color_space`.
   if (dictionary.has_value("ColorSpace")) {
     const Dictionary color_space_table =
         parser.resolve_object_copy(dictionary["ColorSpace"]).as_dictionary();
@@ -1077,8 +1085,15 @@ Resources *parse_resources(State &state, const Object &object) {
     }
   }
 
-  // Shadings and patterns are parsed after `/ColorSpace` so a named colour
-  // space they reference is already in `resources->color_space`.
+  if (dictionary.has_value("XObject")) {
+    const Dictionary x_object_table =
+        parser.resolve_object_copy(dictionary["XObject"]).as_dictionary();
+    for (const auto &[key, value] : x_object_table) {
+      resources->x_object[key] =
+          parse_x_object(state, value.as_reference(), resources);
+    }
+  }
+
   if (dictionary.has_value("Shading")) {
     const Dictionary shading_table =
         parser.resolve_object_copy(dictionary["Shading"]).as_dictionary();

--- a/test/src/internal/pdf/pdf_document_parser.cpp
+++ b/test/src/internal/pdf/pdf_document_parser.cpp
@@ -310,6 +310,25 @@ std::string shared_form_xobject_mini_pdf() {
   return builder.trailer("/Root 1 0 R").build_classic();
 }
 
+/// A mini-PDF whose page defines a named colour space `/CS0` in its
+/// `/Resources /ColorSpace` and an image XObject `Im0` referencing it by name.
+/// The image is a 2x2 RGB raster carried as ASCIIHex so the source stays text.
+std::string named_colorspace_image_mini_pdf() {
+  PdfFileBuilder builder;
+  builder.object("<< /Type /Catalog /Pages 2 0 R >>")
+      .object("<< /Type /Pages /Kids [3 0 R] /Count 1 >>")
+      .object("<< /Type /Page /Parent 2 0 R /MediaBox [0 0 612 792] "
+              "/Resources << /XObject << /Im0 5 0 R >> "
+              "/ColorSpace << /CS0 [/CalRGB << /WhitePoint [1 1 1] >>] >> >> "
+              "/Contents 4 0 R >>")
+      .stream_object("", "/Im0 Do")
+      .stream_object("/Type /XObject /Subtype /Image /Width 2 /Height 2 "
+                     "/BitsPerComponent 8 /ColorSpace /CS0 "
+                     "/Filter /ASCIIHexDecode",
+                     "FF000000FF000000FFFFFFFF>");
+  return builder.trailer("/Root 1 0 R").build_classic();
+}
+
 } // namespace
 
 // A composite (Type0) font is recognized, its descendant CIDFont's
@@ -403,6 +422,24 @@ TEST(DocumentParser, form_xobject_cycle_is_represented_via_cache) {
   // Fm1 -> Fm0 closes the cycle: it resolves to the same cached element.
   ASSERT_NE(fm1->resources, nullptr);
   EXPECT_EQ(fm1->resources->x_object.at("Fm0"), fm0);
+}
+
+// An image XObject whose `/ColorSpace` is a name defined in the enclosing
+// `/Resources /ColorSpace` table resolves — the table is parsed before the
+// `/XObject` table and threaded into image parsing — and the raster is encoded
+// to PNG, rather than being dropped for an unresolved colour space.
+TEST(DocumentParser, image_named_colorspace_resolves_and_encodes) {
+  const std::string pdf = named_colorspace_image_mini_pdf();
+  DocumentParser parser(std::make_unique<std::istringstream>(pdf));
+  const std::unique_ptr<Document> document = parser.parse_document();
+
+  const Page *page = first_page(*document);
+  ASSERT_NE(page->resources, nullptr);
+  const XObject *image = page->resources->x_object.at("Im0");
+  ASSERT_NE(image, nullptr);
+  EXPECT_EQ(image->subtype, XObject::Subtype::image);
+  EXPECT_FALSE(image->image_data.empty());
+  EXPECT_EQ(image->image_mime, "image/png");
 }
 
 // A form XObject shared by two pages is parsed once: both pages' resources


### PR DESCRIPTION
🤖 Generated with [Claude Code](https://claude.com/claude-code)

Stacked on #588.

A decodable raster image whose `/ColorSpace` is a *name* (e.g. `/CS0`, defined in the enclosing `/Resources /ColorSpace`) was **dropped** rather than PNG-encoded. `parse_image_data` built a `ColorSpaceContext` with no `named` resolver, because `parse_resources` parsed the `/XObject` table — which triggers image parsing — *before* the `/ColorSpace` table existed.

## Fix
- Parse `/ColorSpace` **before** `/XObject` in `parse_resources` (shadings/patterns already relied on this ordering).
- Thread the enclosing `Resources` through `parse_x_object` → `parse_image_data`, so a named image colour space resolves via `make_color_space_context` (made null-safe).

## Tests
- New parser test: a page-level named `/CS0` (CalRGB) on a 2×2 image now resolves and encodes to PNG (`image_data` non-empty).
- All 25 odr-engine PDF reference-output snapshots unchanged.

Closes the stage-4.6 gap noted in `AGENTS.md`; doc updated accordingly.