### PR TITLE
PDF: expose /Info + page count through file_meta().document_meta

### DIFF
--- a/src/odr/file.hpp
+++ b/src/odr/file.hpp
@@ -144,6 +144,17 @@ struct DocumentMeta final {
 
   DocumentType document_type{DocumentType::unknown};
   std::optional<std::uint32_t> entry_count;
+
+  // Document information properties (e.g. a PDF `/Info` dictionary). All
+  // optional; a backend leaves unset what it does not carry.
+  std::optional<std::string> title;
+  std::optional<std::string> author;
+  std::optional<std::string> subject;
+  std::optional<std::string> keywords;
+  std::optional<std::string> creator;
+  std::optional<std::string> producer;
+  std::optional<std::string> creation_date;
+  std::optional<std::string> modification_date;
 };
 
 /// @brief Meta information about a file.

--- a/src/odr/internal/pdf/AGENTS.md
+++ b/src/odr/internal/pdf/AGENTS.md
@@ -28,8 +28,15 @@ inline SVG per page. Experimental and not production-quality.
 ## What works
 
 - `.pdf` is detected by file magic and opened as `PdfFile`
-  (`DecoderEngine::odr`); `is_decodable()` returns `false` and `file_meta()`
-  carries only the file type. All parsing is lazy, on HTML request.
+  (`DecoderEngine::odr`); `is_decodable()` returns `false`. Page-tree/content
+  parsing is lazy (on HTML request), but `file_meta()` carries a best-effort
+  `document_meta`: the page count (root `/Pages /Count`, a single lookup) and
+  the `/Info` document-information strings (Title/Author/Subject/Keywords/
+  Creator/Producer/CreationDate/ModDate, decoded from UTF-16BE-BOM or
+  PDFDocEncoding via `decode_text_string`), read once at construction (an
+  owner-locked file is unlocked with the empty password first so its `/Info`
+  decrypts). A malformed structure simply leaves `document_meta` minimal. XMP
+  metadata is not yet parsed (see *Other known gaps*).
 - **Object syntax**: null, booleans, integers/reals, names (incl. `#xx`
   escapes), literal strings (the `\n \r \t \b \f` control escapes, `\ddd`
   octal, escaped delimiters, and `\`-before-EOL line continuation — Table 3),
@@ -616,7 +623,6 @@ The next feature cluster — needs destinations from the page tree, little else.
   *interactivity* stays out of scope (read-only).
 - **Document outline** (`/Outlines`) → navigation anchors/sidebar.
 - **Optional content groups** (layers): honor default visibility; no toggle UI.
-- **Metadata** (`/Info`, XMP) into `file_meta()`.
 - **Output scaling**: monolithic HTML vs. per-page lazy loading for large
   documents (check what odr's HTML service model already provides first).
 
@@ -679,4 +685,7 @@ The next feature cluster — needs destinations from the page tree, little else.
   fixture needs either yet; revisit when one does.
 - **Annotations** are collected but their content is not interpreted
   (*Interaction & navigation*).
+- **XMP metadata** (`/Metadata` XML packet) is not parsed; `file_meta()`'s
+  `document_meta` comes from the `/Info` dictionary only. XMP would supplement
+  or override `/Info` for producers that write it.
 - Revisit the reference-by-lookahead parsing and `read_stream(-1)` fallback.

--- a/src/odr/internal/pdf/pdf_encoding.cpp
+++ b/src/odr/internal/pdf/pdf_encoding.cpp
@@ -9,6 +9,113 @@
 
 namespace odr::internal {
 
+char32_t pdf::pdf_doc_encoding_to_unicode(const std::uint8_t byte) {
+  switch (byte) {
+  case 0x18:
+    return U'˘'; // breve
+  case 0x19:
+    return U'ˇ'; // caron
+  case 0x1A:
+    return U'ˆ'; // circumflex
+  case 0x1B:
+    return U'˙'; // dot above
+  case 0x1C:
+    return U'˝'; // double acute
+  case 0x1D:
+    return U'˛'; // ogonek
+  case 0x1E:
+    return U'˚'; // ring above
+  case 0x1F:
+    return U'˜'; // small tilde
+  case 0x80:
+    return U'•'; // bullet
+  case 0x81:
+    return U'†'; // dagger
+  case 0x82:
+    return U'‡'; // double dagger
+  case 0x83:
+    return U'…'; // ellipsis
+  case 0x84:
+    return U'—'; // em dash
+  case 0x85:
+    return U'–'; // en dash
+  case 0x86:
+    return U'ƒ'; // florin
+  case 0x87:
+    return U'⁄'; // fraction slash
+  case 0x88:
+    return U'‹'; // single left angle quote
+  case 0x89:
+    return U'›'; // single right angle quote
+  case 0x8A:
+    return U'−'; // minus
+  case 0x8B:
+    return U'‰'; // per mille
+  case 0x8C:
+    return U'„'; // double low-9 quote
+  case 0x8D:
+    return U'“'; // left double quote
+  case 0x8E:
+    return U'”'; // right double quote
+  case 0x8F:
+    return U'‘'; // left single quote
+  case 0x90:
+    return U'’'; // right single quote
+  case 0x91:
+    return U'‚'; // single low-9 quote
+  case 0x92:
+    return U'™'; // trademark
+  case 0x93:
+    return U'ﬁ'; // fi ligature
+  case 0x94:
+    return U'ﬂ'; // fl ligature
+  case 0x95:
+    return U'Ł'; // L with stroke
+  case 0x96:
+    return U'Œ'; // OE
+  case 0x97:
+    return U'Š'; // S with caron
+  case 0x98:
+    return U'Ÿ'; // Y with diaeresis
+  case 0x99:
+    return U'Ž'; // Z with caron
+  case 0x9A:
+    return U'ı'; // dotless i
+  case 0x9B:
+    return U'ł'; // l with stroke
+  case 0x9C:
+    return U'œ'; // oe
+  case 0x9D:
+    return U'š'; // s with caron
+  case 0x9E:
+    return U'ž'; // z with caron
+  case 0xA0:
+    return U'€'; // euro
+  default:
+    return byte;
+  }
+}
+
+std::string pdf::decode_text_string(const std::string &string) {
+  if (string.size() >= 2 && static_cast<std::uint8_t>(string[0]) == 0xFE &&
+      static_cast<std::uint8_t>(string[1]) == 0xFF) {
+    std::u16string units;
+    units.reserve((string.size() - 2) / 2);
+    for (std::size_t i = 2; i + 1 < string.size(); i += 2) {
+      units.push_back(
+          static_cast<char16_t>((static_cast<std::uint8_t>(string[i]) << 8) |
+                                static_cast<std::uint8_t>(string[i + 1])));
+    }
+    return util::string::u16string_to_string(units);
+  }
+  std::string result;
+  for (const char c : string) {
+    util::string::append_c32(
+        pdf::pdf_doc_encoding_to_unicode(static_cast<std::uint8_t>(c)), result);
+  }
+  return result;
+}
+
 const std::array<std::string_view, 256> &
 pdf::base_encoding_table(const BaseEncoding encoding) {
   switch (encoding) {

--- a/src/odr/internal/pdf/pdf_encoding.hpp
+++ b/src/odr/internal/pdf/pdf_encoding.hpp
@@ -27,6 +27,17 @@ base_encoding_table(BaseEncoding encoding);
 [[nodiscard]] std::optional<BaseEncoding>
 base_encoding_from_name(std::string_view name);
 
+/// Map a single PDFDocEncoding byte to its Unicode code point (ISO 32000-1
+/// Annex D.2). Agrees with Latin-1 over ASCII and 0xA1–0xFF; only the diacritic
+/// block (0x18–0x1F), the typographic block (0x80–0x9E) and the euro (0xA0)
+/// differ. The few undefined slots (0x7F, 0x9F, 0xAD) pass through.
+[[nodiscard]] char32_t pdf_doc_encoding_to_unicode(std::uint8_t byte);
+
+/// Decode a PDF text string (ISO 32000-1 7.9.2.2) to UTF-8: UTF-16BE when it
+/// opens with the `FE FF` byte-order mark, otherwise PDFDocEncoding. Used for
+/// `/ActualText` and `/Info` document-information strings.
+[[nodiscard]] std::string decode_text_string(const std::string &string);
+
 /// Glyph name -> Unicode (UTF-16) via the Adobe Glyph List, plus the
 /// algorithmic `uniXXXX` / `uXXXXXX` forms (ISO 32000-1 9.10.2 / the AGL
 /// specification). Returns an empty string for a name with no mapping — the

--- a/src/odr/internal/pdf/pdf_file.cpp
+++ b/src/odr/internal/pdf/pdf_file.cpp
@@ -80,6 +80,16 @@ DocumentMeta parse_document_meta(DocumentParser &parser) {
   return meta;
 }
 
+/// Fill `meta.document_meta` best-effort (page count + `/Info`) from a readable
+/// parser. Never fatal: a malformed structure simply leaves it unset.
+void populate_document_meta(DocumentParser &parser, FileMeta &meta) {
+  try {
+    meta.document_meta = parse_document_meta(parser);
+  } catch (...) { // NOLINT(bugprone-empty-catch): metadata is best-effort, a
+                  // malformed file simply carries no `document_meta`.
+  }
+}
+
 } // namespace
 
 PdfFile::PdfFile(std::shared_ptr<abstract::File> file)
@@ -98,7 +108,10 @@ PdfFile::PdfFile(std::shared_ptr<abstract::File> file)
     // password first; if it opens the file, no password is required. Install
     // the resulting decryptor on `parser` so the metadata read below decrypts,
     // and keep a copy so rendering needs neither the password nor decrypt().
-    const bool unlocked = parser.authenticate("");
+    // A file with an unsupported `/Encrypt` handler has no authenticator: it
+    // stays encrypted (and not decodable), rather than throwing here.
+    const bool unlocked =
+        m_authenticator.has_value() && parser.authenticate("");
     if (unlocked) {
       m_decryptor = parser.decryptor();
     }
@@ -108,13 +121,9 @@ PdfFile::PdfFile(std::shared_ptr<abstract::File> file)
   }
 
   // Best-effort document metadata (page count + `/Info`), only when the file is
-  // readable. Never fatal: a malformed structure leaves the metadata minimal.
+  // readable.
   if (m_encryption_state != EncryptionState::encrypted) {
-    try {
-      m_file_meta.document_meta = parse_document_meta(parser);
-    } catch (...) { // NOLINT(bugprone-empty-catch): metadata is best-effort, a
-                    // malformed file simply carries no `document_meta`.
-    }
+    populate_document_meta(parser, m_file_meta);
   }
 }
 
@@ -153,6 +162,12 @@ PdfFile::decrypt(const std::string &password) const {
   decrypted->m_decryptor = std::move(decryptor);
   decrypted->m_encryption_state = EncryptionState::decrypted;
   decrypted->m_file_meta.password_encrypted = false;
+
+  // The file is readable now, so fill in the best-effort document metadata that
+  // construction had to skip while it was locked.
+  DocumentParser parser(m_file->stream(), decrypted->m_decryptor);
+  populate_document_meta(parser, decrypted->m_file_meta);
+
   return decrypted;
 }
 

--- a/src/odr/internal/pdf/pdf_file.cpp
+++ b/src/odr/internal/pdf/pdf_file.cpp
@@ -1,15 +1,86 @@
 #include <odr/internal/pdf/pdf_file.hpp>
 
 #include <odr/exceptions.hpp>
+#include <odr/file.hpp>
 
 #include <odr/internal/abstract/file.hpp>
 #include <odr/internal/pdf/pdf_document_parser.hpp>
+#include <odr/internal/pdf/pdf_encoding.hpp>
 #include <odr/internal/pdf/pdf_encryption.hpp>
+#include <odr/internal/pdf/pdf_object.hpp>
 
+#include <cstdint>
 #include <memory>
+#include <optional>
 #include <string>
 
 namespace odr::internal::pdf {
+
+namespace {
+
+/// One `/Info` string entry, resolved and decoded to UTF-8 (`nullopt` when
+/// absent, not a string, or empty).
+std::optional<std::string> info_string(DocumentParser &parser,
+                                       const Dictionary &info,
+                                       const std::string &key) {
+  if (!info.has_value(key)) {
+    return std::nullopt;
+  }
+  const Object value = parser.resolve_object_copy(info.get(key));
+  if (!value.is_string()) {
+    return std::nullopt;
+  }
+  std::string decoded = decode_text_string(value.as_string());
+  if (decoded.empty()) {
+    return std::nullopt;
+  }
+  return decoded;
+}
+
+/// Document metadata from the trailer: the page count (the root `/Pages
+/// /Count`, a single lookup — no tree walk) and the `/Info` document
+/// information dictionary (ISO 32000-1 14.3.3). Reads may throw on a malformed
+/// file; the caller treats that as "no metadata".
+DocumentMeta parse_document_meta(DocumentParser &parser) {
+  DocumentMeta meta;
+  meta.document_type = DocumentType::text;
+
+  const Dictionary &trailer = parser.trailer();
+
+  if (trailer.has_value("Root")) {
+    const Object root = parser.resolve_object_copy(trailer.get("Root"));
+    if (root.is_dictionary() && root.as_dictionary().has_value("Pages")) {
+      const Object pages =
+          parser.resolve_object_copy(root.as_dictionary().get("Pages"));
+      if (pages.is_dictionary() && pages.as_dictionary().has_value("Count")) {
+        const Object count =
+            parser.resolve_object_copy(pages.as_dictionary().get("Count"));
+        if (count.is_integer() && count.as_integer() >= 0) {
+          meta.entry_count = static_cast<std::uint32_t>(count.as_integer());
+        }
+      }
+    }
+  }
+
+  if (trailer.has_value("Info")) {
+    const Object info = parser.resolve_object_copy(trailer.get("Info"));
+    if (info.is_dictionary()) {
+      const Dictionary &d = info.as_dictionary();
+      meta.title = info_string(parser, d, "Title");
+      meta.author = info_string(parser, d, "Author");
+      meta.subject = info_string(parser, d, "Subject");
+      meta.keywords = info_string(parser, d, "Keywords");
+      meta.creator = info_string(parser, d, "Creator");
+      meta.producer = info_string(parser, d, "Producer");
+      meta.creation_date = info_string(parser, d, "CreationDate");
+      meta.modification_date = info_string(parser, d, "ModDate");
+    }
+  }
+
+  return meta;
+}
+
+} // namespace
 
 PdfFile::PdfFile(std::shared_ptr<abstract::File> file)
     : m_file{std::move(file)} {
@@ -17,24 +88,33 @@ PdfFile::PdfFile(std::shared_ptr<abstract::File> file)
     throw std::invalid_argument("pdf: file is null");
   }
 
-  const DocumentParser parser(m_file->stream());
+  DocumentParser parser(m_file->stream());
 
   m_file_meta.type = FileType::portable_document_format;
 
-  // Most "protected" PDFs are owner-locked only, so try the empty user
-  // password first; if it opens the file, no password is required.
   m_authenticator = parser.authenticator();
-  if (m_authenticator.has_value()) {
-    m_decryptor = m_authenticator->authenticate("");
+  if (parser.is_encrypted()) {
+    // Most "protected" PDFs are owner-locked only, so try the empty user
+    // password first; if it opens the file, no password is required. Install
+    // the resulting decryptor on `parser` so the metadata read below decrypts,
+    // and keep a copy so rendering needs neither the password nor decrypt().
+    const bool unlocked = parser.authenticate("");
+    if (unlocked) {
+      m_decryptor = parser.decryptor();
+    }
+    m_file_meta.password_encrypted = !unlocked;
+    m_encryption_state =
+        unlocked ? EncryptionState::not_encrypted : EncryptionState::encrypted;
   }
 
-  if (parser.is_encrypted()) {
-    // Owner-locked only: opens with the empty user password. Keep the
-    // decryptor so rendering needs neither the password nor a decrypt() call.
-    m_file_meta.password_encrypted = !m_decryptor.has_value();
-    m_encryption_state = m_decryptor.has_value()
-                             ? EncryptionState::not_encrypted
-                             : EncryptionState::encrypted;
+  // Best-effort document metadata (page count + `/Info`), only when the file is
+  // readable. Never fatal: a malformed structure leaves the metadata minimal.
+  if (m_encryption_state != EncryptionState::encrypted) {
+    try {
+      m_file_meta.document_meta = parse_document_meta(parser);
+    } catch (...) { // NOLINT(bugprone-empty-catch): metadata is best-effort, a
+                    // malformed file simply carries no `document_meta`.
+    }
   }
 }
 

--- a/src/odr/internal/pdf/pdf_page_extractor.cpp
+++ b/src/odr/internal/pdf/pdf_page_extractor.cpp
@@ -4,6 +4,7 @@
 
 #include <odr/internal/pdf/pdf_color.hpp>
 #include <odr/internal/pdf/pdf_document_element.hpp>
+#include <odr/internal/pdf/pdf_encoding.hpp>
 #include <odr/internal/pdf/pdf_filter.hpp>
 #include <odr/internal/pdf/pdf_graphics_operator.hpp>
 #include <odr/internal/pdf/pdf_graphics_operator_parser.hpp>
@@ -32,120 +33,6 @@ Font *lookup_font(const Resources &resources, const std::string &name,
                             "', emitting raw codes");
   }
   return nullptr;
-}
-
-/// Map a single PDFDocEncoding byte to its Unicode code point (ISO 32000-1
-/// Annex D.2). It agrees with Latin-1 over ASCII and 0xA1–0xFF, so only the
-/// diacritic block (0x18–0x1F), the typographic block (0x80–0x9E), and the
-/// euro (0xA0) need overriding; every other byte stands for the code point of
-/// the same value. The few undefined slots (0x7F, 0x9F, 0xAD) pass through.
-char32_t pdf_doc_encoding_to_unicode(const std::uint8_t byte) {
-  switch (byte) {
-  case 0x18:
-    return U'˘'; // breve
-  case 0x19:
-    return U'ˇ'; // caron
-  case 0x1A:
-    return U'ˆ'; // circumflex
-  case 0x1B:
-    return U'˙'; // dot above
-  case 0x1C:
-    return U'˝'; // double acute
-  case 0x1D:
-    return U'˛'; // ogonek
-  case 0x1E:
-    return U'˚'; // ring above
-  case 0x1F:
-    return U'˜'; // small tilde
-  case 0x80:
-    return U'•'; // bullet
-  case 0x81:
-    return U'†'; // dagger
-  case 0x82:
-    return U'‡'; // double dagger
-  case 0x83:
-    return U'…'; // ellipsis
-  case 0x84:
-    return U'—'; // em dash
-  case 0x85:
-    return U'–'; // en dash
-  case 0x86:
-    return U'ƒ'; // florin
-  case 0x87:
-    return U'⁄'; // fraction slash
-  case 0x88:
-    return U'‹'; // single left angle quote
-  case 0x89:
-    return U'›'; // single right angle quote
-  case 0x8A:
-    return U'−'; // minus
-  case 0x8B:
-    return U'‰'; // per mille
-  case 0x8C:
-    return U'„'; // double low-9 quote
-  case 0x8D:
-    return U'“'; // left double quote
-  case 0x8E:
-    return U'”'; // right double quote
-  case 0x8F:
-    return U'‘'; // left single quote
-  case 0x90:
-    return U'’'; // right single quote
-  case 0x91:
-    return U'‚'; // single low-9 quote
-  case 0x92:
-    return U'™'; // trademark
-  case 0x93:
-    return U'ﬁ'; // fi ligature
-  case 0x94:
-    return U'ﬂ'; // fl ligature
-  case 0x95:
-    return U'Ł'; // L with stroke
-  case 0x96:
-    return U'Œ'; // OE
-  case 0x97:
-    return U'Š'; // S with caron
-  case 0x98:
-    return U'Ÿ'; // Y with diaeresis
-  case 0x99:
-    return U'Ž'; // Z with caron
-  case 0x9A:
-    return U'ı'; // dotless i
-  case 0x9B:
-    return U'ł'; // l with stroke
-  case 0x9C:
-    return U'œ'; // oe
-  case 0x9D:
-    return U'š'; // s with caron
-  case 0x9E:
-    return U'ž'; // z with caron
-  case 0xA0:
-    return U'€'; // euro
-  default:
-    return byte;
-  }
-}
-
-/// Decode a PDF text string (ISO 32000-1 7.9.2.2) to UTF-8: UTF-16BE when it
-/// opens with the `FE FF` byte-order mark, otherwise PDFDocEncoding.
-std::string decode_text_string(const std::string &string) {
-  if (string.size() >= 2 && static_cast<std::uint8_t>(string[0]) == 0xFE &&
-      static_cast<std::uint8_t>(string[1]) == 0xFF) {
-    std::u16string units;
-    units.reserve((string.size() - 2) / 2);
-    for (std::size_t i = 2; i + 1 < string.size(); i += 2) {
-      units.push_back(
-          static_cast<char16_t>((static_cast<std::uint8_t>(string[i]) << 8) |
-                                static_cast<std::uint8_t>(string[i + 1])));
-    }
-    return util::string::u16string_to_string(units);
-  }
-  std::string result;
-  for (const char c : string) {
-    util::string::append_c32(
-        pdf_doc_encoding_to_unicode(static_cast<std::uint8_t>(c)), result);
-  }
-  return result;
 }
 
 /// `/ActualText` of a `BDC` property-list dictionary, decoded to UTF-8, or

--- a/src/odr/internal/util/odr_meta_util.cpp
+++ b/src/odr/internal/util/odr_meta_util.cpp
@@ -24,6 +24,21 @@ nlohmann::json meta_to_json(const FileMeta &meta) {
     if (document_meta.entry_count) {
       result["entryCount"] = *document_meta.entry_count;
     }
+
+    const auto put = [&](const char *key,
+                         const std::optional<std::string> &value) {
+      if (value) {
+        result[key] = *value;
+      }
+    };
+    put("title", document_meta.title);
+    put("author", document_meta.author);
+    put("subject", document_meta.subject);
+    put("keywords", document_meta.keywords);
+    put("creator", document_meta.creator);
+    put("producer", document_meta.producer);
+    put("creationDate", document_meta.creation_date);
+    put("modificationDate", document_meta.modification_date);
   }
 
   return result;

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -45,6 +45,7 @@ add_executable(odr_test
         "src/internal/pdf/pdf_document_parser.cpp"
         "src/internal/pdf/pdf_encoding.cpp"
         "src/internal/pdf/pdf_encryption.cpp"
+        "src/internal/pdf/pdf_file.cpp"
         "src/internal/pdf/pdf_file_object.cpp"
         "src/internal/pdf/pdf_file_parser.cpp"
         "src/internal/pdf/pdf_filter.cpp"

--- a/test/src/internal/pdf/pdf_file.cpp
+++ b/test/src/internal/pdf/pdf_file.cpp
@@ -1,0 +1,80 @@
+#include <odr/file.hpp>
+
+#include <odr/internal/common/file.hpp>
+#include <odr/internal/pdf/pdf_file.hpp>
+
+#include <internal/pdf/pdf_test_file_builder.hpp>
+
+#include <memory>
+#include <string>
+
+#include <gtest/gtest.h>
+
+using namespace odr;
+using namespace odr::internal;
+using PdfFileBuilder = odr::test::pdf::PdfFileBuilder;
+
+namespace {
+
+std::shared_ptr<pdf::PdfFile> open_pdf(const std::string &bytes) {
+  return std::make_shared<pdf::PdfFile>(std::make_shared<MemoryFile>(bytes));
+}
+
+/// A two-page mini-PDF with an `/Info` dictionary. `/Title` is a UTF-16BE
+/// (BOM) hex string ("HI"), the rest literal (PDFDocEncoding) strings.
+std::string info_mini_pdf() {
+  PdfFileBuilder builder;
+  builder.object("<< /Type /Catalog /Pages 2 0 R >>")
+      .object("<< /Type /Pages /Kids [3 0 R 4 0 R] /Count 2 >>")
+      .object("<< /Type /Page /Parent 2 0 R /MediaBox [0 0 612 792] >>")
+      .object("<< /Type /Page /Parent 2 0 R /MediaBox [0 0 612 792] >>")
+      .object("<< /Title <FEFF00480049> /Author (Ada Lovelace) "
+              "/Producer (odr-test) >>");
+  return builder.trailer("/Root 1 0 R /Info 5 0 R").build_classic();
+}
+
+} // namespace
+
+// `/Info` document-information strings and the page count surface through
+// `file_meta().document_meta`; a `/Title` UTF-16BE string is decoded to UTF-8.
+TEST(PdfFile, file_meta_carries_info_and_page_count) {
+  const std::shared_ptr<pdf::PdfFile> file = open_pdf(info_mini_pdf());
+  const FileMeta meta = file->file_meta();
+
+  EXPECT_EQ(meta.type, FileType::portable_document_format);
+  ASSERT_TRUE(meta.document_meta.has_value());
+  const DocumentMeta &document_meta = *meta.document_meta;
+
+  EXPECT_EQ(document_meta.document_type, DocumentType::text);
+  ASSERT_TRUE(document_meta.entry_count.has_value());
+  EXPECT_EQ(*document_meta.entry_count, 2u);
+
+  ASSERT_TRUE(document_meta.title.has_value());
+  EXPECT_EQ(*document_meta.title, "HI");
+  ASSERT_TRUE(document_meta.author.has_value());
+  EXPECT_EQ(*document_meta.author, "Ada Lovelace");
+  ASSERT_TRUE(document_meta.producer.has_value());
+  EXPECT_EQ(*document_meta.producer, "odr-test");
+  EXPECT_FALSE(document_meta.subject.has_value());
+  EXPECT_FALSE(document_meta.keywords.has_value());
+}
+
+// A file with no `/Info` still reports its page count; the `/Info` strings stay
+// unset rather than empty.
+TEST(PdfFile, file_meta_without_info) {
+  PdfFileBuilder builder;
+  builder.object("<< /Type /Catalog /Pages 2 0 R >>")
+      .object("<< /Type /Pages /Kids [3 0 R] /Count 1 >>")
+      .object("<< /Type /Page /Parent 2 0 R /MediaBox [0 0 612 792] >>");
+  const std::string pdf = builder.trailer("/Root 1 0 R").build_classic();
+
+  const std::shared_ptr<pdf::PdfFile> file = open_pdf(pdf);
+  const FileMeta meta = file->file_meta();
+
+  ASSERT_TRUE(meta.document_meta.has_value());
+  EXPECT_EQ(meta.document_meta->document_type, DocumentType::text);
+  ASSERT_TRUE(meta.document_meta->entry_count.has_value());
+  EXPECT_EQ(*meta.document_meta->entry_count, 1u);
+  EXPECT_FALSE(meta.document_meta->title.has_value());
+  EXPECT_FALSE(meta.document_meta->author.has_value());
+}


### PR DESCRIPTION
🤖 Generated with [Claude Code](https://claude.com/claude-code)

Stacked on #589.

`file_meta()` previously carried only the file type. This populates a best-effort `DocumentMeta` at `PdfFile` construction.

## What lands
- **Page count** from the root `/Pages /Count` (a single lookup — no page-tree walk).
- **`/Info` document-information strings**: Title, Author, Subject, Keywords, Creator, Producer, CreationDate, ModDate — decoded from UTF-16BE (BOM) or PDFDocEncoding.

## Public API
`DocumentMeta` (`odr/file.hpp`) gains optional `title`/`author`/`subject`/`keywords`/`creator`/`producer`/`creation_date`/`modification_date` fields. All optional, default-empty, so other backends are unaffected. `meta_to_json` emits them when present.

## Notes
- The `PdfFile` constructor now authenticates the empty user password on the **single** parser (installing the decryptor) so an owner-locked file's `/Info` decrypts, then reuses that parser for the metadata read. Malformed structure is caught → `document_meta` stays minimal.
- `decode_text_string` / `pdf_doc_encoding_to_unicode` moved from an anonymous namespace in `pdf_page_extractor.cpp` to `pdf_encoding.{hpp,cpp}` so the page extractor and the metadata path share one implementation.
- New `PdfFile` tests (UTF-16BE `/Title`, literal `/Info` strings, page count, no-`/Info` case). Full PDF unit + `style-various-1` HTML snapshot green.
- XMP still deferred (noted in `AGENTS.md` gaps).

PDF is `FileCategory::unknown`, so the `document`-category `document_type` assertion in `html_output_test` doesn't apply. The reference-output submodules' `meta.json` will regenerate separately (out of this repo's scope).