### PR TITLE
Guard empty asset data paths; default ODR_BUNDLE_ASSETS to OFF

### DIFF
--- a/.github/workflows/build_test.yml
+++ b/.github/workflows/build_test.yml
@@ -95,6 +95,7 @@ jobs:
           -DODR_WITH_PDF2HTMLEX=ON
           -DODR_WITH_WVWARE=ON
           -DODR_WITH_LIBMAGIC=ON
+          -DODR_BUNDLE_ASSETS=ON
 
       - name: cmake
         if: runner.os == 'Windows'

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -292,18 +292,25 @@ function(odr_resolve_data_path out_var injected pkg subpath)
         return()
     endif ()
 
-    string(TOUPPER "${CMAKE_BUILD_TYPE}" _config)
-    set(_folder "${${pkg}_PACKAGE_FOLDER_${_config}}")
-    if (_folder AND EXISTS "${_folder}/${subpath}")
-        set(${out_var} "${_folder}/${subpath}" PARENT_SCOPE)
-        return()
-    endif ()
+    # `CMAKE_BUILD_TYPE` is empty for multi-config generators (Ninja Multi-Config,
+    # Xcode, ...), so try every candidate configuration for which CMakeDeps may
+    # have emitted a `<pkg>_PACKAGE_FOLDER_<CONFIG>` variable.
+    set(_configs ${CMAKE_BUILD_TYPE} ${CMAKE_CONFIGURATION_TYPES}
+            Release RelWithDebInfo Debug MinSizeRel)
+    foreach (_config IN LISTS _configs)
+        string(TOUPPER "${_config}" _config)
+        set(_folder "${${pkg}_PACKAGE_FOLDER_${_config}}")
+        if (_folder AND EXISTS "${_folder}/${subpath}")
+            set(${out_var} "${_folder}/${subpath}" PARENT_SCOPE)
+            return()
+        endif ()
+    endforeach ()
 
     message(FATAL_ERROR
             "ODR_BUNDLE_ASSETS is ON but the data path for '${pkg}' could not be "
             "resolved. Provide it explicitly (e.g. via the matching -D...=<path> "
             "variable) or build through the conan recipe. Tried the injected value "
-            "and '${_folder}/${subpath}'.")
+            "and '<${pkg}_PACKAGE_FOLDER_<CONFIG>>/${subpath}'.")
 endfunction()
 
 if (ODR_WITH_PDF2HTMLEX)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -265,6 +265,47 @@ set(ODR_BUILD_ODR_DATA_PATH "${CMAKE_CURRENT_BINARY_DIR}/data")
 file(COPY "${odr.js_SOURCE_DIR}/" DESTINATION "${ODR_BUILD_ODR_DATA_PATH}")
 set(ODR_INSTALL_ODR_DATA_PATH "${CMAKE_INSTALL_DATADIR}")
 
+# Resolve the on-disk location of a dependency's bundled data files.
+#
+# Historically these paths (FONTCONFIG_DATA_PATH, POPPLER_DATA_PATH, ...) had to
+# be injected from outside via `-D...=` — our conanfile.py bridges them from the
+# dependency runenv. Any consumer that builds odrcore without that bridge left
+# the variable empty, and `file(COPY "${empty}/" ...)` degraded to `file(COPY
+# "/" ...)`, i.e. an attempt to recursively copy the whole root filesystem (see
+# issue #599). This resolver keeps the injected value as the primary source but
+# otherwise derives the path from the conan `<pkg>_PACKAGE_FOLDER_<CONFIG>`
+# variable exposed by find_package(), so find_package() alone is sufficient. It
+# fails fast with an actionable message instead of copying "/".
+#
+#   out_var  variable to populate with the resolved absolute path
+#   injected value of the externally-injected path variable (may be empty)
+#   pkg      conan package/prefix (e.g. fontconfig, poppler-data, libmagic)
+#   subpath  location of the data relative to the package folder
+function(odr_resolve_data_path out_var injected pkg subpath)
+    if (injected)
+        if (NOT EXISTS "${injected}")
+            message(FATAL_ERROR
+                    "ODR_BUNDLE_ASSETS is ON but the injected data path for '${pkg}' "
+                    "does not exist: '${injected}'.")
+        endif ()
+        set(${out_var} "${injected}" PARENT_SCOPE)
+        return()
+    endif ()
+
+    string(TOUPPER "${CMAKE_BUILD_TYPE}" _config)
+    set(_folder "${${pkg}_PACKAGE_FOLDER_${_config}}")
+    if (_folder AND EXISTS "${_folder}/${subpath}")
+        set(${out_var} "${_folder}/${subpath}" PARENT_SCOPE)
+        return()
+    endif ()
+
+    message(FATAL_ERROR
+            "ODR_BUNDLE_ASSETS is ON but the data path for '${pkg}' could not be "
+            "resolved. Provide it explicitly (e.g. via the matching -D...=<path> "
+            "variable) or build through the conan recipe. Tried the injected value "
+            "and '${_folder}/${subpath}'.")
+endfunction()
+
 if (ODR_WITH_PDF2HTMLEX)
     find_package(pdf2htmlEX REQUIRED)
     find_package(poppler REQUIRED)
@@ -284,6 +325,10 @@ if (ODR_WITH_PDF2HTMLEX)
     )
 
     if (ODR_BUNDLE_ASSETS)
+        odr_resolve_data_path(FONTCONFIG_DATA_PATH "${FONTCONFIG_DATA_PATH}" fontconfig "res/etc/fonts")
+        odr_resolve_data_path(POPPLER_DATA_PATH "${POPPLER_DATA_PATH}" poppler-data "share/poppler")
+        odr_resolve_data_path(PDF2HTMLEX_DATA_PATH "${PDF2HTMLEX_DATA_PATH}" pdf2htmlex "share/pdf2htmlEX")
+
         set(ODR_BUILD_FONTCONFIG_DATA_PATH "${ODR_BUILD_ODR_DATA_PATH}/fontconfig")
         set(ODR_BUILD_POPPLER_DATA_PATH "${ODR_BUILD_ODR_DATA_PATH}/poppler")
         set(ODR_BUILD_PDF2HTMLEX_DATA_PATH "${ODR_BUILD_ODR_DATA_PATH}/pdf2htmlex")
@@ -337,6 +382,8 @@ if (ODR_WITH_LIBMAGIC)
     )
 
     if (ODR_BUNDLE_ASSETS)
+        odr_resolve_data_path(LIBMAGIC_DATABASE_PATH "${LIBMAGIC_DATABASE_PATH}" libmagic "res/magic.mgc")
+
         set(ODR_BUILD_LIBMAGIC_DATABASE_PATH "${ODR_BUILD_ODR_DATA_PATH}/magic.mgc")
 
         file(COPY_FILE "${LIBMAGIC_DATABASE_PATH}" "${ODR_BUILD_LIBMAGIC_DATABASE_PATH}")

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -20,7 +20,7 @@ option(WITH_LIBMAGIC "Deprecated: `ODR_WITH_WVWARE` instead! Build with libmagic
 option(ODR_WITH_PDF2HTMLEX "Build with pdf2htmlEX" "${WITH_PDF2HTMLEX}")
 option(ODR_WITH_WVWARE "Build with wvWare" "${WITH_WVWARE}")
 option(ODR_WITH_LIBMAGIC "Build with libmagic" "${WITH_LIBMAGIC}")
-option(ODR_BUNDLE_ASSETS "Bundle assets during build and install" ON)
+option(ODR_BUNDLE_ASSETS "Bundle assets during build and install" OFF)
 
 include(GNUInstallDirs)
 
@@ -265,52 +265,28 @@ set(ODR_BUILD_ODR_DATA_PATH "${CMAKE_CURRENT_BINARY_DIR}/data")
 file(COPY "${odr.js_SOURCE_DIR}/" DESTINATION "${ODR_BUILD_ODR_DATA_PATH}")
 set(ODR_INSTALL_ODR_DATA_PATH "${CMAKE_INSTALL_DATADIR}")
 
-# Resolve the on-disk location of a dependency's bundled data files.
+# Validate an injected data-file path before it is used to bundle assets.
 #
-# Historically these paths (FONTCONFIG_DATA_PATH, POPPLER_DATA_PATH, ...) had to
-# be injected from outside via `-D...=` — our conanfile.py bridges them from the
-# dependency runenv. Any consumer that builds odrcore without that bridge left
-# the variable empty, and `file(COPY "${empty}/" ...)` degraded to `file(COPY
-# "/" ...)`, i.e. an attempt to recursively copy the whole root filesystem (see
-# issue #599). This resolver keeps the injected value as the primary source but
-# otherwise derives the path from the conan `<pkg>_PACKAGE_FOLDER_<CONFIG>`
-# variable exposed by find_package(), so find_package() alone is sufficient. It
+# These paths (FONTCONFIG_DATA_PATH, POPPLER_DATA_PATH, ...) are consumed but
+# never discovered by CMake — they must be injected from outside via `-D...=`;
+# our conanfile.py bridges them from the dependency runenv. A consumer that
+# builds odrcore without that bridge left the variable empty, and
+# `file(COPY "${empty}/" ...)` degraded to `file(COPY "/" ...)`, i.e. an attempt
+# to recursively copy the whole root filesystem (see issue #599). This guard
 # fails fast with an actionable message instead of copying "/".
 #
-#   out_var  variable to populate with the resolved absolute path
-#   injected value of the externally-injected path variable (may be empty)
-#   pkg      conan package/prefix (e.g. fontconfig, poppler-data, libmagic)
-#   subpath  location of the data relative to the package folder
-function(odr_resolve_data_path out_var injected pkg subpath)
-    if (injected)
-        if (NOT EXISTS "${injected}")
-            message(FATAL_ERROR
-                    "ODR_BUNDLE_ASSETS is ON but the injected data path for '${pkg}' "
-                    "does not exist: '${injected}'.")
-        endif ()
-        set(${out_var} "${injected}" PARENT_SCOPE)
-        return()
+#   path  value of the externally-injected path variable (may be empty)
+#   name  name of that variable, for the diagnostic
+function(odr_require_data_path path name)
+    if (NOT path)
+        message(FATAL_ERROR
+                "ODR_BUNDLE_ASSETS is ON but ${name} is not set. Provide it "
+                "explicitly (e.g. -D${name}=<path>) or build through the conan "
+                "recipe, or disable bundling with -DODR_BUNDLE_ASSETS=OFF.")
     endif ()
-
-    # `CMAKE_BUILD_TYPE` is empty for multi-config generators (Ninja Multi-Config,
-    # Xcode, ...), so try every candidate configuration for which CMakeDeps may
-    # have emitted a `<pkg>_PACKAGE_FOLDER_<CONFIG>` variable.
-    set(_configs ${CMAKE_BUILD_TYPE} ${CMAKE_CONFIGURATION_TYPES}
-            Release RelWithDebInfo Debug MinSizeRel)
-    foreach (_config IN LISTS _configs)
-        string(TOUPPER "${_config}" _config)
-        set(_folder "${${pkg}_PACKAGE_FOLDER_${_config}}")
-        if (_folder AND EXISTS "${_folder}/${subpath}")
-            set(${out_var} "${_folder}/${subpath}" PARENT_SCOPE)
-            return()
-        endif ()
-    endforeach ()
-
-    message(FATAL_ERROR
-            "ODR_BUNDLE_ASSETS is ON but the data path for '${pkg}' could not be "
-            "resolved. Provide it explicitly (e.g. via the matching -D...=<path> "
-            "variable) or build through the conan recipe. Tried the injected value "
-            "and '<${pkg}_PACKAGE_FOLDER_<CONFIG>>/${subpath}'.")
+    if (NOT EXISTS "${path}")
+        message(FATAL_ERROR "${name} points to a path that does not exist: '${path}'.")
+    endif ()
 endfunction()
 
 if (ODR_WITH_PDF2HTMLEX)
@@ -332,9 +308,9 @@ if (ODR_WITH_PDF2HTMLEX)
     )
 
     if (ODR_BUNDLE_ASSETS)
-        odr_resolve_data_path(FONTCONFIG_DATA_PATH "${FONTCONFIG_DATA_PATH}" fontconfig "res/etc/fonts")
-        odr_resolve_data_path(POPPLER_DATA_PATH "${POPPLER_DATA_PATH}" poppler-data "share/poppler")
-        odr_resolve_data_path(PDF2HTMLEX_DATA_PATH "${PDF2HTMLEX_DATA_PATH}" pdf2htmlex "share/pdf2htmlEX")
+        odr_require_data_path("${FONTCONFIG_DATA_PATH}" FONTCONFIG_DATA_PATH)
+        odr_require_data_path("${POPPLER_DATA_PATH}" POPPLER_DATA_PATH)
+        odr_require_data_path("${PDF2HTMLEX_DATA_PATH}" PDF2HTMLEX_DATA_PATH)
 
         set(ODR_BUILD_FONTCONFIG_DATA_PATH "${ODR_BUILD_ODR_DATA_PATH}/fontconfig")
         set(ODR_BUILD_POPPLER_DATA_PATH "${ODR_BUILD_ODR_DATA_PATH}/poppler")
@@ -389,7 +365,7 @@ if (ODR_WITH_LIBMAGIC)
     )
 
     if (ODR_BUNDLE_ASSETS)
-        odr_resolve_data_path(LIBMAGIC_DATABASE_PATH "${LIBMAGIC_DATABASE_PATH}" libmagic "res/magic.mgc")
+        odr_require_data_path("${LIBMAGIC_DATABASE_PATH}" LIBMAGIC_DATABASE_PATH)
 
         set(ODR_BUILD_LIBMAGIC_DATABASE_PATH "${ODR_BUILD_ODR_DATA_PATH}/magic.mgc")
 

--- a/conanfile.py
+++ b/conanfile.py
@@ -20,6 +20,7 @@ class OpenDocumentCoreConan(ConanFile):
         "with_pdf2htmlEX": [True, False],
         "with_wvWare": [True, False],
         "with_libmagic": [True, False],
+        "bundle_assets": [True, False],
     }
     default_options = {
         "shared": False,
@@ -27,6 +28,7 @@ class OpenDocumentCoreConan(ConanFile):
         "with_pdf2htmlEX": True,
         "with_wvWare": True,
         "with_libmagic": True,
+        "bundle_assets": False,
     }
 
     exports_sources = ["cli/*", "cmake/*", "resources/dist/*", "src/*", "CMakeLists.txt"]
@@ -73,6 +75,7 @@ class OpenDocumentCoreConan(ConanFile):
         tc.variables["ODR_WITH_PDF2HTMLEX"] = self.options.get_safe("with_pdf2htmlEX", False)
         tc.variables["ODR_WITH_WVWARE"] = self.options.get_safe("with_wvWare", False)
         tc.variables["ODR_WITH_LIBMAGIC"] = self.options.get_safe("with_libmagic", False)
+        tc.variables["ODR_BUNDLE_ASSETS"] = self.options.get_safe("bundle_assets", False)
 
         # Get runenv info, exported by package_info() of dependencies
         # We need to obtain PDF2HTMLEX_DATA_DIR, POPPLER_DATA_DIR, FONTCONFIG_PATH and WVDATADIR


### PR DESCRIPTION
## Problem

`FONTCONFIG_DATA_PATH`, `POPPLER_DATA_PATH`, `PDF2HTMLEX_DATA_PATH` and `LIBMAGIC_DATABASE_PATH` are *consumed* by CMake but never *discovered* by it — they must be injected from outside (this repo's `conanfile.py` bridges them from the dependency runenv).

With `ODR_BUNDLE_ASSETS=ON` (previously the default), any consumer that built odrcore without that bridge left the variable empty, so:

```cmake
file(COPY "${FONTCONFIG_DATA_PATH}/" DESTINATION ...)   # "${empty}/" == "/"
```

attempted to **recursively copy the entire root filesystem**, failing on the unreadable setuid `sudo`:

```
file COPY cannot find "///usr/bin/sudo": Permission denied.
```

Fixes #599.

## Change

- **Guard, don't auto-discover.** Add `odr_require_data_path()`, called for each path when `ODR_BUNDLE_ASSETS` is ON. If a required path is unset or does not exist, it fails fast with an actionable `FATAL_ERROR` instead of copying `/`.
- **Default `ODR_BUNDLE_ASSETS` to `OFF`** in `CMakeLists.txt`, and expose it as a `bundle_assets` conan option (also defaulting to `False`). A plain build no longer requires the injected data paths; bundling is opt-in.

## Verification

The guard was validated with `cmake -P`: a valid path passes; an empty path errors with `... is not set`; a nonexistent path errors with `... does not exist`. With `ODR_BUNDLE_ASSETS=OFF` (the new default) the asset-copy blocks are skipped entirely.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01WnANaTYn7fYfH2KwJjUsyK