### PR TITLE
Make the HTTP server optional via ODR_WITH_HTTP_SERVER

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -13,6 +13,7 @@ set(CMAKE_CXX_EXTENSIONS OFF)
 option(BUILD_SHARED_LIBS "Build using shared libraries" ON)
 option(ODR_TEST "enable tests" OFF)
 option(ODR_CLI "enable command line interface" ON)
+option(ODR_WITH_HTTP_SERVER "Build the HTTP server (requires cpp-httplib)" ON)
 option(ODR_CLANG_TIDY "Run clang-tidy static analysis" OFF)
 option(WITH_PDF2HTMLEX "Deprecated: `ODR_WITH_PDF2HTMLEX` instead! Build with pdf2htmlEX" ON)
 option(WITH_WVWARE "Deprecated: `ODR_WITH_WVWARE` instead! Build with wvWare" ON)
@@ -55,7 +56,6 @@ find_package(nlohmann_json REQUIRED)
 find_package(vincentlaucsb-csv-parser REQUIRED)
 find_package(uchardet REQUIRED)
 find_package(utf8cpp REQUIRED)
-find_package(httplib REQUIRED)
 find_package(argon2 REQUIRED)
 
 include(FetchContent)
@@ -89,7 +89,6 @@ set(ODR_SOURCE_FILES
         "src/odr/filesystem.cpp"
         "src/odr/global_params.cpp"
         "src/odr/html.cpp"
-        "src/odr/http_server.cpp"
         "src/odr/logger.cpp"
         "src/odr/odr.cpp"
         "src/odr/quantity.cpp"
@@ -257,7 +256,6 @@ target_link_libraries(odr
         vincentlaucsb-csv-parser::vincentlaucsb-csv-parser
         uchardet::uchardet
         utf8::cpp
-        httplib::httplib
         argon2::argon2
 )
 
@@ -289,6 +287,21 @@ function(odr_require_data_path path name)
     endif ()
 endfunction()
 
+if (ODR_WITH_HTTP_SERVER)
+    find_package(httplib REQUIRED)
+    target_sources(odr
+            PRIVATE
+            "src/odr/http_server.cpp"
+    )
+    target_link_libraries(odr
+            PRIVATE
+            httplib::httplib
+    )
+    target_compile_definitions(odr
+            PRIVATE
+            ODR_WITH_HTTP_SERVER
+    )
+endif ()
 if (ODR_WITH_PDF2HTMLEX)
     find_package(pdf2htmlEX REQUIRED)
     find_package(poppler REQUIRED)
@@ -397,10 +410,15 @@ if (ODR_CLANG_TIDY)
     add_subdirectory("static_analysis/clang-tidy")
 endif ()
 
+if (NOT ODR_WITH_HTTP_SERVER)
+    # Don't ship the public header for an API that wasn't built.
+    set(ODR_HEADER_EXCLUDE PATTERN "http_server.hpp" EXCLUDE)
+endif ()
 install(
         DIRECTORY src/ "${CMAKE_CURRENT_BINARY_DIR}/src/"
         DESTINATION "${CMAKE_INSTALL_INCLUDEDIR}"
         FILES_MATCHING PATTERN "*.hpp"
+        ${ODR_HEADER_EXCLUDE}
 )
 install(
         TARGETS odr meta translate back_translate

--- a/cli/CMakeLists.txt
+++ b/cli/CMakeLists.txt
@@ -25,13 +25,15 @@ target_include_directories(back_translate
         ../src
 )
 
-add_executable(server src/server.cpp)
-target_link_libraries(server
-        PRIVATE
-        odr
-        httplib::httplib
-)
-target_include_directories(server
-        PRIVATE
-        ../src
-)
+if (ODR_WITH_HTTP_SERVER)
+    add_executable(server src/server.cpp)
+    target_link_libraries(server
+            PRIVATE
+            odr
+            httplib::httplib
+    )
+    target_include_directories(server
+            PRIVATE
+            ../src
+    )
+endif ()

--- a/conanfile.py
+++ b/conanfile.py
@@ -20,6 +20,7 @@ class OpenDocumentCoreConan(ConanFile):
         "with_pdf2htmlEX": [True, False],
         "with_wvWare": [True, False],
         "with_libmagic": [True, False],
+        "with_http_server": [True, False],
         "bundle_assets": [True, False],
     }
     default_options = {
@@ -28,6 +29,7 @@ class OpenDocumentCoreConan(ConanFile):
         "with_pdf2htmlEX": True,
         "with_wvWare": True,
         "with_libmagic": True,
+        "with_http_server": True,
         "bundle_assets": False,
     }
 
@@ -52,7 +54,8 @@ class OpenDocumentCoreConan(ConanFile):
             self.requires("pdf2htmlex/0.18.8.rc1-odr-git-732fd68")
         if self.options.get_safe("with_wvWare", False):
             self.requires("wvware/1.2.9-odr")
-        self.requires("cpp-httplib/0.16.3")
+        if self.options.get_safe("with_http_server", False):
+            self.requires("cpp-httplib/0.16.3")
         self.requires("argon2/20190702-odr")
         if self.options.get_safe("with_libmagic", False):
             self.requires("libmagic/5.45")
@@ -75,6 +78,7 @@ class OpenDocumentCoreConan(ConanFile):
         tc.variables["ODR_WITH_PDF2HTMLEX"] = self.options.get_safe("with_pdf2htmlEX", False)
         tc.variables["ODR_WITH_WVWARE"] = self.options.get_safe("with_wvWare", False)
         tc.variables["ODR_WITH_LIBMAGIC"] = self.options.get_safe("with_libmagic", False)
+        tc.variables["ODR_WITH_HTTP_SERVER"] = self.options.get_safe("with_http_server", False)
         tc.variables["ODR_BUNDLE_ASSETS"] = self.options.get_safe("bundle_assets", False)
 
         # Get runenv info, exported by package_info() of dependencies


### PR DESCRIPTION
## Summary

Makes the HTTP server optional behind a new `ODR_WITH_HTTP_SERVER` CMake option (default `ON`, so the default build is unchanged).

The HTTP server is self-contained — `src/odr/http_server.cpp`, the `server` CLI, and its only dependency `cpp-httplib` — and nothing else in `libodr` references `HttpServer`. Gating it lets consumers that don't need the server drop the `cpp-httplib` dependency entirely.

This also sidesteps a link failure on Apple platforms: recent `cpp-httplib` compiles a CFHost-based DNS resolver that needs `CoreFoundation`/`CFNetwork`, which is awkward to satisfy for consumers that don't use the server at all (e.g. the iOS build).

## Behavior

With `-DODR_WITH_HTTP_SERVER=OFF`:
- `cpp-httplib` is not searched for (`find_package`) or linked
- `http_server.cpp` is not compiled
- the `server` CLI target is not built
- the public `http_server.hpp` header is not installed (the API it declares isn't available)

## Notes

The dependency is wired as a single self-contained block next to the other optional dependencies (`pdf2htmlEX`, `wvWare`, `libmagic`), following their `find_package` + `target_sources` + `target_link_libraries` + `target_compile_definitions` pattern.
