### PR TITLE
docs: add AGENTS.md for odf and ooxml modules

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -56,8 +56,8 @@ bytes ─▶ magic/open_strategy ─▶ DecodedFile ─▶ Document ─▶ Eleme
 | `src/odr/internal/magic.*`, `open_strategy.*` | File-type detection + open/dispatch. |
 | `src/odr/internal/html/` | Generic HTML renderer. |
 | `src/odr/internal/cfb/`, `zip/` | Container formats (CFB, ZIP). |
-| `src/odr/internal/odf/` | OpenDocument (odt/ods/odp/odg). |
-| `src/odr/internal/ooxml/` | OOXML (docx/pptx/xlsx). |
+| `src/odr/internal/odf/` | OpenDocument (odt/ods/odp/odg); see [`odf/AGENTS.md`](src/odr/internal/odf/AGENTS.md). |
+| `src/odr/internal/ooxml/` | OOXML (docx/pptx/xlsx); see [`ooxml/AGENTS.md`](src/odr/internal/ooxml/AGENTS.md) + per-format docs. |
 | `src/odr/internal/oldms/` | **Legacy MS binary** (.doc/.ppt/.xls). |
 | `src/odr/internal/oldms_wvware/` | Alternative .doc decoder via wvWare. |
 | `src/odr/internal/pdf/`, `pdf_poppler/` | PDF (own parser + poppler/pdf2htmlEX path). |

--- a/src/odr/internal/odf/AGENTS.md
+++ b/src/odr/internal/odf/AGENTS.md
@@ -1,0 +1,120 @@
+# OpenDocument (`odf/`) — design & open work
+
+The **why** and the roadmap; what is concretely done lives in the code and the
+per-feature checklist in [`README.md`](README.md). Shared architecture (the
+element-adapter pattern, build/test loop, conventions) is in the top-level
+[`AGENTS.md`](../../../../AGENTS.md); read it first.
+
+**Scope.** One engine (`DecoderEngine::odr`) reading **all four ODF document
+types** — text (`.odt`), presentation (`.odp`), spreadsheet (`.ods`), graphics
+(`.odg`) — plus their template and legacy StarOffice variants, through the
+abstract model. Reader + style resolver + a **partial editor** (text-content
+edits, save). Relies on [ZIP](../zip/) (container) and [SVM](../svm/) (embedded
+StarView metafile images).
+
+## The load-bearing decision: a pugixml-node-backed registry
+
+Unlike the binary engines (`oldms/`, `pdf/`), which parse bytes into their own
+structures, ODF keeps the parsed **`content.xml` / `styles.xml` DOMs resident**
+(`Document` owns `m_content_xml`, `m_styles_xml`). The `ElementRegistry` is a
+thin *index over* that DOM: every `ElementRegistry::Element` stores a live
+`pugi::xml_node` alongside its tree ids. Style/content/attribute access always
+goes back to the node. **This is why ODF alone can edit and save**: a text edit
+is a local DOM splice, and `save` re-serialises the mutated tree. The other
+engines throw away the source, so their models are read-only.
+
+Everything else follows the shared registry/adapter pattern: flat
+`std::vector<Element>`, id = index + 1, `null_element_id == 0`, parent/child/
+sibling ids, per-subtype side maps (`m_texts`, `m_tables`, `m_sheets`,
+`m_sheet_cells`). One mega `ElementAdapter` multiply-inherits every abstract
+per-type adapter and dispatches by returning `this`/`nullptr` on `element_type`.
+
+## Design decisions
+
+**Parsing is a name-keyed dispatch table.** `odf_parser.cpp` holds a static
+`unordered_map<std::string, TreeParser>` mapping XML tag → builder; unknown tags
+are **skipped** (recursion continues into children). Many tags collapse onto a
+generic type — `text:h` → paragraph, `text:section`/`toc`/date fields → `group`,
+`draw:g` → frame. Container types get bespoke children-parsers
+(`parse_presentation_children` walks only `draw:page`, etc.).
+
+**Text runs are coalesced.** A maximal run of consecutive text nodes
+(`node_pcdata`, `text:s`, `text:tab`) becomes **one** `text` Element spanning
+`[first, last]` (the end stored in `Text.last`); `text:line-break` is its own
+element and breaks the run. Reading expands `text:s`→N spaces (via `text:c`),
+`text:tab`→`\t`.
+
+**Sheets are modelled sparsely, off-tree.** A `Sheet` side-struct holds
+position-keyed `columns`/`rows`/`cells` maps rather than a child chain. Repeated
+columns/rows/cells are stored **once** at a range key and resolved with
+`lookup_greater_than`, so a 5000-row `number-columns-repeated` doesn't inflate.
+Only non-empty cells get a real `sheet_cell` Element; empty ones are recorded as
+repeated ranges. Cells carry a `TablePosition` + `is_repeated` flag.
+
+**Styles resolve to a flattened `ResolvedStyle`, eagerly.** `StyleRegistry`
+first builds name→node indices from *both* files (automatic and named styles land
+in the same `m_index_style` map — distinguished only by name, not origin), then
+constructs a `Style` for every entry. Each `Style` **recursively resolves its
+`style:parent-style-name` (then `style:family` default) first, copies that
+resolved base, and overlays its own node's properties** — inheritance is a
+flatten-at-build, not a runtime walk. Parent beats family as the copy source. A
+*second*, separate cascade runs at query time: `get_intermediate_style` walks the
+**element** parent chain and `.override()`s partial styles down to the target.
+Font names are indirected through `style:font-face` → `svg:font-family`.
+Master pages are parsed into the element tree *and* the style index.
+
+**Percent units are special-cased**: percent font-size multiplies the inherited
+size; percent margins/line-height are currently **dropped** (open work).
+
+**Decryption is manifest-driven, two layouts.** `odf_crypto.cpp` supports either
+a single `encrypted-package` blob (decrypt → inflate → new ZIP filesystem) or
+**lazy per-file** decryption (a `DecryptedFilesystem` wrapper decrypting on
+`open()`, validating the password up-front against the smallest encrypted file).
+Algorithms: AES256-CBC/GCM, Triple-DES-CBC, Blowfish-CFB; key derivation PBKDF2
+and Argon2id (LibreOffice `loext:` extension); start-key SHA1/SHA256 (+1K
+variants). Unknown algorithm → throw.
+
+**Fail-fast on structure, tolerate content.** Registry-id violations, an
+already-parented child, unknown crypto, wrong password, a missing
+content.xml/manifest/mimetype all **throw**. Unknown tags, unparsable
+measures/colours (→ `nullopt`), missing style/font references, unknown mimetypes
+are **tolerated** to keep rendering best-effort.
+
+## Module layout
+
+| File (`odf/`) | Role |
+|---|---|
+| `odf_file.{hpp,cpp}` | `OpenDocumentFile`: entry point; type/encryption; `decrypt()`; builds `Document` per type |
+| `odf_meta.cpp` | `parse_file_meta`: mimetype→FileType, doc type, page/table counts, encryption flag |
+| `odf_manifest.{hpp,cpp}` | `META-INF/manifest.xml` → per-file crypto entries, smallest-file tracking |
+| `odf_crypto.cpp` | Decryption: hashing, key derivation, cipher dispatch, package-vs-lazy filesystem |
+| `odf_element_registry.{hpp,cpp}` | Flat element store + Text/Table/Sheet/SheetCell side maps; sparse repeated-range maps |
+| `odf_parser.{hpp,cpp}` | `content.xml` → registry: name dispatch table, text-run coalescing, sheet cursor |
+| `odf_document.{hpp,cpp}` | `Document` (owns DOMs + registries + adapter); the mega `ElementAdapter`; edit + `save` |
+| `odf_style.{hpp,cpp}` | `StyleRegistry` + `Style`: indices, eager parent/family flatten, master pages, `ResolvedStyle` readers |
+
+## Status & open work
+
+Feature coverage (element/style checkboxes) is tracked in [`README.md`](README.md).
+The structural/foundational gaps, roughly by value:
+
+1. **Editing is text-content only.** No structural edits (insert/delete/move
+   elements), no attribute or style editing. `text_set_content` splices the DOM
+   for one text run; that's the whole editor.
+2. **Spreadsheet editing is force-disabled** (`is_editable` hardcodes `false`
+   for spreadsheets — `odf_document.cpp`, `// TODO fix spreadsheet editability`).
+3. **Save never re-encrypts.** Plain `save` strips all `manifest:encryption-data`
+   and emits an unencrypted package; `save(path, password)` throws
+   `UnsupportedOperation`. `save` also doesn't yet guard `is_savable`. Only
+   `content.xml` is re-serialised, so hypothetical style edits wouldn't persist.
+4. **No streaming.** Crypto and save read whole files into memory and round-trip
+   the entire filesystem through a rebuilt ZIP (`// TODO stream` throughout).
+5. **Repeated / covered spreadsheet cells are heuristic.** Several
+   `// TODO covered cells` / `// TODO mark as repeated` in `odf_parser.cpp`;
+   empty-row/cell detection is approximate.
+6. **Style gaps beyond missing properties**: percent margins/line-height dropped;
+   `transparent`/alpha colours → `nullopt`; the Style-vs-element cascade layering
+   is provisional (`// TODO use override?`). List/outline numbering is indexed but
+   not rendered as numbers.
+7. **StarOffice/template mimetypes** are aliased onto the four base types; they
+   may deserve distinct `FileType`s (`odf_meta.cpp`).

--- a/src/odr/internal/ooxml/AGENTS.md
+++ b/src/odr/internal/ooxml/AGENTS.md
@@ -1,0 +1,78 @@
+# Office Open XML (`ooxml/`) — shared design & conventions
+
+The **why** for the OOXML engine; per-feature checklists live in the
+[`README.md`](README.md) files. Shared architecture (element-adapter pattern,
+build/test, conventions) is in the top-level [`AGENTS.md`](../../../../AGENTS.md);
+read it first.
+
+**Scope.** One engine (`DecoderEngine::odr`) reading the three OOXML document
+types — word (`.docx`), presentation (`.pptx`), spreadsheet (`.xlsx`). The three
+formats **share almost nothing beyond packaging, encryption, and type
+detection**; each is a self-contained module with its own `AGENTS.md`:
+
+| Module | Format | Editable | Agent doc |
+|---|---|:--:|---|
+| [`text/`](text/) | `.docx` (Word) | text + save | [text/AGENTS.md](text/AGENTS.md) |
+| [`presentation/`](presentation/) | `.pptx` (PowerPoint) | read-only | [presentation/AGENTS.md](presentation/AGENTS.md) |
+| [`spreadsheet/`](spreadsheet/) | `.xlsx` (Excel) | read-only | [spreadsheet/AGENTS.md](spreadsheet/AGENTS.md) |
+
+## Shared element model (same as ODF)
+
+Like [`odf/`](../odf/), every format keeps its parsed XML parts **resident** and
+the `ElementRegistry` is a thin index over them: each `Element` holds a live
+`pugi::xml_node` plus its tree ids (flat vector, id = index + 1,
+`null_element_id == 0`, parent/child/sibling ids, per-subtype side maps). One
+mega `ElementAdapter` per format multiply-inherits the abstract per-type adapters
+and dispatches by returning `this`/`nullptr` on `element_type`. Parsing is a
+static `unordered_map<tag, TreeParser>` dispatch table; unknown tags are skipped
+(children still visited). Text runs are coalesced into one `text` Element over a
+`[first, last]` node span. **Editing, where present, splices these live nodes;**
+`save` re-serialises only the mutated part and byte-copies the rest.
+
+## OPC relationships (the cross-part mechanic)
+
+OOXML packages are split across parts (`document.xml`, `slideN.xml`,
+`sheetN.xml`, `drawingN.xml`, `sharedStrings.xml`, …) wired by
+`_rels/*.rels`. `parse_relationships` (`ooxml_util`) reads a part's `.rels`
+sibling into an `rId → target-path` map. Cross-part references — a slide's
+`r:id`, a sheet, a drawing, an image `r:embed` — resolve through it, relative to
+the *referencing part's* path. `spreadsheet` threads a per-part `ParseContext`
+(path + its relations + the global part cache) so paths resolve correctly;
+`presentation` uses a thinner `rId → xml` map.
+
+## Shared files
+
+| File (`ooxml/`) | Role |
+|---|---|
+| `ooxml_file.{hpp,cpp}` | `OfficeOpenXmlFile` entry point: meta, encryption state, `decrypt()`, dispatch to the per-format `Document` on `file_type()` |
+| `ooxml_meta.cpp` | `parse_file_meta`: **sentinel-path** type detection (`/word/document.xml`→docx, `/ppt/presentation.xml`→pptx, `/xl/workbook.xml`→xlsx); encrypted-package detection (`/EncryptionInfo`+`/EncryptedPackage`) |
+| `ooxml_util.{hpp,cpp}` | Stateless pugixml attribute readers: OOXML unit systems (half-points, hundredth-points, EMUs `/914400in`, twips `/1440in`, percents), colours, borders, font weight/style, relationship parsing |
+| `ooxml_crypto.{hpp,cpp}` | Decryption (see below) |
+
+## Encryption
+
+Only **ECMA-376 _standard_ encryption** (AES-ECB + SHA1) is implemented
+(`ECMA376Standard`, selected by `VersionInfo` major ∈ {2,3,4} & minor == 2). Key
+derivation: password→UTF16LE, salt-prefixed SHA1, **50000** hash iterations, then
+the block-key derivation with `0x36`/`0x5c` pads. The encryption container is a
+[CFB](../cfb/) compound file (`open_strategy.cpp` routes encrypted packages
+through the cfb filesystem, plain packages through [zip](../zip/)); `decrypt()`
+verifies the password, AES-decrypts `/EncryptedPackage`, and re-opens the plain
+ZIP in memory.
+
+**Rejected / unsupported (throw `MsUnsupportedCryptoAlgorithm`)**: *agile*
+(4.4) and *extensible* encryption. **Big-endian hosts throw `UnsupportedEndian`**
+— the crypto structs are `#pragma pack(1)` + `memcpy`/`reinterpret_cast`
+(`// TODO support big endian`).
+
+## Shared open work
+
+- **Agile encryption** — the common modern scheme; currently rejected. Highest-
+  value shared gap.
+- **Big-endian hosts** — crypto (and the `reinterpret_cast` reads) assume
+  little-endian; guarded by a runtime throw.
+- **Document statistics** (page / table counts) are not produced for any format.
+- `Crypto::Util` is rebuilt per `decrypt()` call (`// TODO cache`).
+
+Per-format element/style coverage and format-specific open work live in each
+module's own `AGENTS.md`.

--- a/src/odr/internal/ooxml/presentation/AGENTS.md
+++ b/src/odr/internal/ooxml/presentation/AGENTS.md
@@ -1,0 +1,65 @@
+# `.pptx` (PowerPoint) support — design & open work
+
+The **why**; the feature checklist is in [`README.md`](README.md), the shared
+OOXML mechanics (registry/adapter pattern, OPC relationships, encryption) in
+[`../AGENTS.md`](../AGENTS.md). **Read-only.**
+
+**Scope.** Read `ppt/presentation.xml` and each slide's shape tree into the
+abstract model so the generic renderer lays out positioned frames. Paragraphs,
+runs, tables (see caveat below), inline text styling.
+
+## Design decisions
+
+**Parsing follows the slide-id list.** The `Document` ctor loads every
+relationship target of `presentation.xml` into an `rId → xml` map (masters,
+layouts, theme included — only slides are actually walked). Slide **order = the
+document order of `p:sldId` in `p:sldIdLst`** (not filename/rId order); each
+slide's `r:id` looks up its part, and parsing descends `p:cSld/p:spTree`.
+Dispatch table: `p:sp`→**frame** (shapes are frames), `p:txBody`→group,
+`a:p`→paragraph, `a:r`→span, `a:t`→text, `a:tbl`→table.
+
+**Styles are resolved inline — there is no `StyleRegistry`.** Free functions in
+the document read `a:rPr` / `a:pPr` attributes directly (font, size in
+hundredth-points, bold/italic/underline/strike/shadow/colour/highlight; align,
+`a:ind` margins in twips). The element-parent cascade
+(`get_intermediate_style` → `.override()`) is the same shape as ODF/docx but
+computed on-demand from the XML with no cached or master/default-style
+contribution.
+
+**Frame positioning is EMU-based.** `p:spPr/a:xfrm/a:off` + `a:ext` give
+`x/y/width/height` in EMUs; anchor type is always `at_page`.
+
+## Module layout
+
+| File (`presentation/`) | Role |
+|---|---|
+| `ooxml_presentation_document.{hpp,cpp}` | `Document` (loads XML + relationships) + `ElementAdapter`; inline style resolution |
+| `ooxml_presentation_parser.{hpp,cpp}` | `ParseContext` (slides map) + tag dispatch; presentation.xml → slides → spTree |
+| `ooxml_presentation_element_registry.{hpp,cpp}` | Flat element store + Table/Text side maps |
+
+(No style translation unit.)
+
+## Status & open work
+
+Coverage is in [`README.md`](README.md). Foundational gaps, roughly by value:
+
+1. **Slide geometry is hardcoded.** `slide_page_layout` returns a fixed
+   11.02in × 8.27in; `slide_master_page` and `slide_name` return empty. Real
+   slide size (`p:presentation/p:sldSz`), master/layout inheritance, and slide
+   names are all TODO.
+2. **Tables are broken.** `a:tbl` is created with the plain builder, not
+   `create_table_element`, so no `m_tables` entry exists and `table_first_column`
+   throws; `table_dimensions` iterates ODF names (`table:table-column/-row`,
+   copy-paste from ODF) → 0×0. Despite the README checkbox, tables need real
+   wiring (`create_table_element`/`append_column` + `a:gridCol`/`a:tr`/`a:tc`
+   parsers).
+3. **Images not modelled** — no `p:pic`/`a:blip` parser entry; `image_href`
+   reads ODF-style `xlink:href` (wrong for pptx `r:embed`).
+4. **`is_text_node` copy-paste bug.** It matches `w:t`/`w:tab` (wordprocessing)
+   instead of `a:t`/`a:tab`, so consecutive `a:t` runs are never coalesced —
+   each becomes its own text Element (harmless, but an artifact to fix).
+5. **Read-only, inconsistently.** `Document::is_editable`/`save` say no, yet the
+   adapter's `element_is_editable` returns true and `text_set_content` is fully
+   implemented — the machinery for text editing exists but is not exposed. Wiring
+   edit + save (mirroring docx) is a natural next step.
+6. **Listings, comments/annotations** not modelled.

--- a/src/odr/internal/ooxml/spreadsheet/AGENTS.md
+++ b/src/odr/internal/ooxml/spreadsheet/AGENTS.md
@@ -1,0 +1,67 @@
+# `.xlsx` (Excel) support — design & open work
+
+The **why**; the feature checklist is in [`README.md`](README.md), the shared
+OOXML mechanics (registry/adapter pattern, OPC relationships, encryption) in
+[`../AGENTS.md`](../AGENTS.md). **Read-only.**
+
+**Scope.** Read `xl/workbook.xml`, its sheets, the shared-string table and
+drawings into the abstract model — a table per sheet. Cell styles resolved from
+`xl/styles.xml`.
+
+## Design decisions
+
+**Parsing threads a per-part `ParseContext`.** The ctor pre-parses and caches
+every part (`workbook.xml`, each `sheetN.xml` + its `drawing`, `styles.xml`,
+`sharedStrings.xml`) into `m_xml_documents_and_relations`, and loads the shared
+strings into a positionally-indexed `vector<xml_node>` of `<si>` nodes. Because
+relationship targets are relative to the referencing part, a **fresh
+`ParseContext` (path + its relations) is built per sheet and per drawing**. Sheet
+**order = document order of `<sheet>`** in `workbook.xml`.
+
+**Cells live off-tree in a coordinate map** (mirrors `oldms/spreadsheet`).
+`append_sheet_cell` sets only the cell's `parent_id`; it does **not** wire
+sibling links, so cells are *not* reachable by child iteration — they're reached
+via `Sheet.cells` (`(col,row) → {node, element_id}`). Columns are a
+`map<column_max, Column>` keyed by the *max* of a `min..max` span and resolved
+with `lookup_greater_or_equals`. Shapes hang off the sheet in a separate chain
+(`first_shape_id`). Dimensions come from `<dimension ref>`.
+
+**Values are always strings.** A cell with `t="s"` reads `<v>` as an index into
+the shared-string table and parses the referenced `<si>`; otherwise its own
+`<v>`/`<is>` children. `get_text` concatenates `t` and `v` nodes verbatim, so a
+**formula's cached `<v>` result is shown and `<f>` is never evaluated**. No
+numeric/date/bool typing — `sheet_cell_value_type` is hardcoded to `string`.
+
+**Style resolution: styles.xml index vectors.** `StyleRegistry` loads positional
+`fonts`/`fills`/`borders`/`cellStyleXfs`/`cellXfs`. A cell's `s` attribute
+indexes `cellXfs`; the `xf` picks `fontId`/`fillId`/`borderId`/`alignment`,
+each resolved via its index vector. Font/border/alignment are gated by
+`applyFont`/`applyBorder`/`applyAlignment`; **fill is applied unconditionally**.
+A legacy indexed colour palette is hardcoded. Named-style masters
+(`cellStyleXfs`) are loaded but **never consulted** (no master-style
+inheritance).
+
+## Module layout
+
+| File (`spreadsheet/`) | Role |
+|---|---|
+| `ooxml_spreadsheet_document.{hpp,cpp}` | `Document`: caches all parts + shared strings + style registry; `ElementAdapter`; image-href resolution via relationship origin |
+| `ooxml_spreadsheet_parser.{hpp,cpp}` | Per-part `ParseContext` + dispatch; sheets/shared-strings/drawings via relationships; cell coordinate-map + shape chain |
+| `ooxml_spreadsheet_element_registry.{hpp,cpp}` | Flat element store + Sheet (col/row/cell maps, shape chain) / Text / SheetCell / ElementRelations side maps |
+| `ooxml_spreadsheet_style.{hpp,cpp}` | `StyleRegistry`: styles.xml index vectors, `cell_style(i)`, indexed colour palette |
+
+## Status & open work
+
+Coverage is in [`README.md`](README.md). Foundational gaps, roughly by value:
+
+1. **Cell value types & formulas.** Everything is a string; numeric/date/bool
+   typing and formula evaluation are absent (`sheet_cell_value_type` → `string`).
+2. **Content-range detection.** `sheet_content` ignores the requested range and
+   returns the full `<dimension>` — no trim to the populated range.
+3. **Merged cells.** `sheet_cell_span` → `{1,1}`, `sheet_cell_is_covered` →
+   false; `mergeCells` not read.
+4. **No named/master cell-style inheritance** (`cellStyleXfs` loaded but unused);
+   borders rendered as `0.75pt solid` regardless of actual style (`// TODO thin
+   only`); cell protection unhandled.
+5. **Read-only.** `text_set_content` is a no-op stub; `save` throws. Links and
+   comments/annotations not modelled.

--- a/src/odr/internal/ooxml/text/AGENTS.md
+++ b/src/odr/internal/ooxml/text/AGENTS.md
@@ -1,0 +1,72 @@
+# `.docx` (Word) support — design & open work
+
+The **why**; the feature checklist is in [`README.md`](README.md), the shared
+OOXML mechanics (registry/adapter pattern, OPC relationships, encryption) in
+[`../AGENTS.md`](../AGENTS.md). This is the **only editable OOXML format**.
+
+**Scope.** Read `word/document.xml` into the abstract model, resolve styles from
+`word/styles.xml`, edit text content, and save. Content coverage (headings,
+runs, tables, images, hyperlinks, bookmarks, sdt-as-group, list nesting) per the
+README.
+
+## Design decisions
+
+**Parsing: tag dispatch table.** `parse_tree` walks `w:body` via a static
+`unordered_map<tag, TreeParser>`: `w:p`→paragraph, `w:r`→span, `w:br`→line_break,
+`w:hyperlink`→link, `w:tbl`→table, `w:sdt`/`w:sdtContent`→group,
+`w:drawing`→frame, `a:graphicData`→image. `w:t`/`w:tab` coalesce into one text
+Element; `get_text` maps `w:tab`→`\t`. Unknown tags are skipped (children still
+visited).
+
+**Lists are detected structurally**, before the tag table: a paragraph with
+`w:pPr/w:numPr` is a list item, nesting synthesised from the `w:ilvl` level.
+
+**Style resolution mixes a static hierarchy with a runtime cascade.**
+`StyleRegistry` indexes `w:style` by `w:styleId` and pre-flattens the
+`w:basedOn` chain: each `Style` recursively resolves its parent, copies the
+parent's `ResolvedStyle`, then overlays its own. The default comes from
+`w:docDefaults` (`rPrDefault`/`pPrDefault`/…), fallback font-size 12pt.
+Partial styles overlay a `wStyle` reference with the element's direct props —
+paragraphs additionally fold in the paragraph-mark run props (`w:pPr/w:rPr`).
+The *element-tree* cascade is then computed live: `get_intermediate_style` walks
+the element parent chain from docDefaults down, `.override()`-ing each partial.
+Table styles are direct-only (no `w:tblStyle` reference resolution).
+
+**Editing & save.** `is_editable` → true. `text_set_content` tokenises the new
+string and splices `w:t` (with `xml:space="preserve"` for spaces) / `w:tab` nodes
+into the live `m_document_xml`, updating the registry's node pointers. `save`
+re-zips the package, re-serialising **only** `word/document.xml` from the mutated
+DOM; everything else is byte-copied. No structural edits; `save(path, password)`
+throws (no re-encryption).
+
+## Module layout
+
+| File (`text/`) | Role |
+|---|---|
+| `ooxml_text_document.{hpp,cpp}` | `Document`: loads XML, drives parse, hosts the `ElementAdapter`, text edit + save |
+| `ooxml_text_parser.{hpp,cpp}` | `parse_tree`: tag dispatch, list/text/table special parsers |
+| `ooxml_text_element_registry.{hpp,cpp}` | Flat element store + Table/Text side maps |
+| `ooxml_text_style.{hpp,cpp}` | `StyleRegistry`/`Style`: `w:styleId` index, `w:basedOn` flatten, docDefaults, partial-style readers |
+
+## Status & open work
+
+Style/element coverage is in [`README.md`](README.md). Foundational gaps:
+
+1. **Numbering.** `w:numPr` levels drive list *nesting*, but `numbering.xml` is
+   never parsed, so list formats are not resolved to actual numbers (bullets
+   only). The nested-level construction in the parser is partly stubbed
+   (`/* TODO fix lists */`).
+2. **No structural editing**; save doesn't stream (buffers document.xml, re-zips
+   the whole package); no re-encryption on save.
+3. **Theme fonts unhandled.** `w:rFonts w:asciiTheme="minorHAnsi"` (etc.) is
+   ignored — only literal `w:ascii` names are read (README example
+   `Sample large docx.docx`).
+4. **Latent copy-paste from the ODF adapter.** The table/cell adapter methods
+   query ODF node names (`table:covered-table-cell`, `office:value-type`,
+   `table:number-columns-repeated`) that never match docx `w:` nodes, so
+   dimension/span/covered-cell logic is effectively dead for docx. Verify and
+   rewrite against `w:` names when tables get proper attention.
+5. **Style stubs**: `resolve_table_row_style_` and `resolve_graphic_style_` are
+   empty; table cell width is parsed but not applied; the `w:default="1"` style
+   flag is ignored.
+6. **Comments / annotations** not modelled.


### PR DESCRIPTION
🤖 Generated with [Claude Code](https://claude.com/claude-code)

Adds design/orientation docs (`AGENTS.md`) for the ODF and OOXML engines, aligned with the existing `oldms/` and `pdf/` docs: rationale, load-bearing design decisions, and current status/gaps — not a restatement of code. Feature checklists stay in the per-module `README.md`s to avoid duplication.

## New files
- `src/odr/internal/odf/AGENTS.md` — central ODF doc (all four types in one engine)
- `src/odr/internal/ooxml/AGENTS.md` — central OOXML doc (shared packaging / encryption / OPC relationships)
- `src/odr/internal/ooxml/text/AGENTS.md` — docx
- `src/odr/internal/ooxml/presentation/AGENTS.md` — pptx
- `src/odr/internal/ooxml/spreadsheet/AGENTS.md` — xlsx
- top-level `AGENTS.md` directory map now links the new docs

## Framing
- Front-and-center for both engines: unlike `oldms`/`pdf`, ODF and OOXML keep the parsed XML DOM resident and the `ElementRegistry` is a thin index of `pugi::xml_node`s over it — which is *why* ODF and docx alone can edit and save.
- Each doc's status section records **foundational gaps** (things worth planning next), not just missing style checkboxes.

## Notable gaps surfaced from reading the code
- **pptx tables are effectively broken** (built with the plain builder, so `table_first_column` throws; `table_dimensions` still queries ODF `table:` names — copy-pasted from the ODF adapter). The same ODF-name copy-paste is latent in the **docx** table/cell adapter.
- pptx `is_text_node` copy-paste bug (checks `w:t` instead of `a:t`); full but unexposed text-edit machinery.
- Shared: agile encryption and big-endian are the big cross-format gaps; xlsx never types values or evaluates formulas; named cell-style masters are loaded but unused.

These latent-bug items are flagged as "verify and rewrite" rather than asserted as confirmed runtime failures, since they come from code reading, not execution.