### PR TITLE
fix(pptx): report read-only elements for a read-only document

### DIFF
--- a/src/odr/internal/ooxml/presentation/ooxml_presentation_document.cpp
+++ b/src/odr/internal/ooxml/presentation/ooxml_presentation_document.cpp
@@ -181,7 +181,10 @@ public:
   }
   [[nodiscard]] bool element_is_editable(
       [[maybe_unused]] const ElementIdentifier element_id) const override {
-    return true;
+    // The presentation document is read-only (is_editable/is_savable are
+    // false), so no element is editable. The text_set_content machinery
+    // exists but stays dormant until pptx editing + save are wired up.
+    return false;
   }
   [[nodiscard]]
   DocumentPath


### PR DESCRIPTION
🤖 Generated with [Claude Code](https://claude.com/claude-code)

## What

The presentation `Document` is read-only — `is_editable()` and `is_savable()` return `false`, and `save()` throws `UnsupportedOperation` — yet the adapter's `element_is_editable()` returned `true`. That contradicts the document-level contract: a consumer could observe an editable element on a document that can neither persist an edit nor be saved.

This makes `element_is_editable()` return `false`, matching the document.

## Why not the other direction

The `text_set_content` implementation in this adapter is fully written but unexposed. The alternative fix — flipping `is_editable`/`save` on and wiring pptx editing the way docx does — is a real feature (it needs a `save` that re-zips and re-serialises the mutated slide part, plus tests), not a small consistency fix. That's left as follow-up; `text_set_content` stays in place as dormant machinery for it.

## Impact

None on rendering (read-only traversal never consults this). It only corrects the editing-API signal surfaced through `Element::is_editable()`.

## Relationship to other PRs

Orthogonal to #603 (the `a:t`/`a:tab` coalescing fix) — different file, different concern; both branch off `main`. Both were flagged during the AGENTS.md docs pass (#602).

## Testing

Not built locally: the Conan cache in this environment is broken independent of this change (the `pugixml` package folder was pruned and the `lcms` recipe now requires Conan ≥2.18 vs 2.6.0 installed). The change is a one-line return-value flip with no type or control-flow change. CI will compile it.