### PR TITLE
feat(pdf): per-page HTML views and a general page range limit

### DIFF
--- a/.github/workflows/build_test.yml
+++ b/.github/workflows/build_test.yml
@@ -206,7 +206,6 @@ jobs:
         with:
           token: ${{ secrets.PAT_ANDIWAND }}
           submodules: true
-          lfs: true
 
       - name: ubuntu install tidy
         if: runner.os == 'Linux'

--- a/src/odr/html.hpp
+++ b/src/odr/html.hpp
@@ -121,6 +121,12 @@ struct HtmlConfig {
   std::string background_image_format{"png"};
   double background_image_dpi{144.0};
 
+  // Paged-document page range (currently honored by the PDF pipeline): render
+  // only pages with 0-based index in `[page_range_begin, page_range_end)`.
+  // Page views and `#pN` anchors keep their document-global page numbers.
+  std::uint32_t page_range_begin{0};
+  std::optional<std::uint32_t> page_range_end;
+
   // PDF text mode
   PdfTextMode pdf_text_mode{PdfTextMode::dual_layer};
   // `dual_layer`'s invisible selection-layer text is rendered in a local

--- a/src/odr/internal/html/common.cpp
+++ b/src/odr/internal/html/common.cpp
@@ -45,6 +45,15 @@ std::string html::escape_attribute(std::string value) {
   return value;
 }
 
+std::string
+html::fill_path_variables(const std::string &path,
+                          const std::optional<std::uint32_t> index) {
+  std::string result = path;
+  util::string::replace_all(result, "{index}",
+                            index ? std::to_string(*index) : "");
+  return result;
+}
+
 std::string html::color(const Color &color) {
   std::stringstream ss;
   ss << "#";

--- a/src/odr/internal/html/common.hpp
+++ b/src/odr/internal/html/common.hpp
@@ -1,6 +1,8 @@
 #pragma once
 
+#include <cstdint>
 #include <iosfwd>
+#include <optional>
 #include <string>
 
 #include <odr/html.hpp>
@@ -40,6 +42,11 @@ std::string escape_text(std::string text);
 std::string escape_attribute(std::string value);
 
 std::string color(const Color &color);
+
+/// Substitute `{index}` in an output file name pattern (e.g.
+/// `page{index}.html`) with `index`, or with "" when absent.
+std::string fill_path_variables(const std::string &path,
+                                std::optional<std::uint32_t> index = {});
 
 std::string file_to_url(const std::string &file, const std::string &mime_type);
 std::string file_to_url(std::istream &file, const std::string &mime_type);

--- a/src/odr/internal/html/document.cpp
+++ b/src/odr/internal/html/document.cpp
@@ -147,14 +147,6 @@ void back(const Document &document, const WritingState &state) {
   out.write_end();
 }
 
-std::string fill_path_variables(const std::string &path,
-                                const std::optional<std::uint32_t> index = {}) {
-  std::string result = path;
-  util::string::replace_all(result, "{index}",
-                            index ? std::to_string(*index) : "");
-  return result;
-}
-
 class HtmlFragmentBase {
 public:
   HtmlFragmentBase(std::string name, const std::size_t index, std::string path,

--- a/src/odr/internal/html/pdf_file.cpp
+++ b/src/odr/internal/html/pdf_file.cpp
@@ -76,6 +76,43 @@ struct LinkOut {
 /// standalone page. Returns "" to drop the link (target page not rendered).
 using PageHref = std::function<std::string(std::size_t)>;
 
+/// The href navigating from the document at `from` to `to` (both output-root
+/// relative, '/'-separated): drops their shared directory prefix and climbs
+/// out of `from`'s remaining directories. The browser resolves an href
+/// against the current document's directory, so an output-root-relative path
+/// must not be emitted as-is.
+std::string relative_href(const std::string &from, const std::string &to) {
+  const auto split = [](const std::string &path) {
+    std::vector<std::string> segments;
+    for (std::size_t begin = 0; begin <= path.size();) {
+      const std::size_t end = std::min(path.find('/', begin), path.size());
+      segments.push_back(path.substr(begin, end - begin));
+      begin = end + 1;
+    }
+    return segments;
+  };
+  const std::vector<std::string> from_segments = split(from);
+  const std::vector<std::string> to_segments = split(to);
+  const std::size_t from_dirs = from_segments.size() - 1;
+  const std::size_t to_dirs = to_segments.size() - 1;
+  std::size_t common = 0;
+  while (common < from_dirs && common < to_dirs &&
+         from_segments[common] == to_segments[common]) {
+    ++common;
+  }
+  std::string href;
+  for (std::size_t i = common; i < from_dirs; ++i) {
+    href += "../";
+  }
+  for (std::size_t i = common; i < to_segments.size(); ++i) {
+    if (i != common) {
+      href += '/';
+    }
+    href += to_segments[i];
+  }
+  return href;
+}
+
 /// Resolves a link annotation's destination to a page: a `page-object ->
 /// 0-based index` map plus the catalog's named-destination table (`/Dests`
 /// dictionary and the `/Names /Dests` name tree, ISO 32000-1 12.3.2.3).
@@ -1240,12 +1277,17 @@ public:
   }
 
   /// One standalone page (the `page{index}.html` view); internal links
-  /// navigate between the page files.
+  /// navigate between the page files, relative to this page's own path (the
+  /// browser resolves an href against the current document, so a nested
+  /// `page_output_file_name` must not be emitted output-root-relative).
   HtmlResources write_page(const std::size_t page_index,
                            HtmlWriter &out) const {
-    const PageHref page_href = [this](const std::size_t index) {
+    const std::string &from = m_views[page_index + 1].path();
+    const PageHref page_href = [this, &from](const std::size_t index) {
       return page_rendered(index)
-                 ? fill_path_variables(config().page_output_file_name, index)
+                 ? relative_href(
+                       from, fill_path_variables(config().page_output_file_name,
+                                                 index))
                  : std::string();
     };
     const std::vector<pdf::Page *> pages{m_pages[page_index]};

--- a/src/odr/internal/html/pdf_file.cpp
+++ b/src/odr/internal/html/pdf_file.cpp
@@ -26,8 +26,10 @@
 #include <array>
 #include <cctype>
 #include <cmath>
+#include <functional>
 #include <map>
 #include <memory>
+#include <mutex>
 #include <sstream>
 #include <string>
 #include <string_view>
@@ -63,9 +65,16 @@ struct LinkOut {
   double top{0};
   double width{0};
   double height{0};
-  std::string href; ///< external URI or internal "#pN"; already attr-escaped
-  bool internal{false}; ///< true for a `#pN` target (needs `target="_self"`)
+  std::string href;     ///< external URI or an internal target (a "#pN" anchor
+                        ///< or a "pageN.html" page view); already attr-escaped
+  bool internal{false}; ///< true for an internal target (needs
+                        ///< `target="_self"`)
 };
+
+/// Maps a link's 0-based target page index to the href navigating to it: a
+/// "#pN" anchor in the combined document, a page-view file name in a
+/// standalone page. Returns "" to drop the link (target page not rendered).
+using PageHref = std::function<std::string(std::size_t)>;
 
 /// Resolves a link annotation's destination to a page: a `page-object ->
 /// 0-based index` map plus the catalog's named-destination table (`/Dests`
@@ -206,11 +215,12 @@ bool is_safe_uri(std::string_view uri) {
 
 /// Resolve a page's `/Link` annotations (ISO 32000-1 12.5.6.5) to positioned
 /// overlays: a `/URI` action becomes an external link, a `/GoTo` action or a
-/// direct `/Dest` an internal `#pN` link. `to_box` maps PDF user space to the
-/// page box (points, y-down).
+/// direct `/Dest` an internal link via `page_href`. `to_box` maps PDF user
+/// space to the page box (points, y-down).
 std::vector<LinkOut> collect_page_links(const pdf::Page &page,
                                         const util::math::Transform2D &to_box,
-                                        LinkResolver &resolver) {
+                                        LinkResolver &resolver,
+                                        const PageHref &page_href) {
   std::vector<LinkOut> links;
   pdf::DocumentParser &parser = resolver.parser;
   for (const pdf::Annotation *annotation : page.annotations) {
@@ -245,7 +255,7 @@ std::vector<LinkOut> collect_page_links(const pdf::Page &page,
           }
         } else if (kind == "GoTo" && a.has_value("D")) {
           if (const auto index = resolver.resolve_dest_page(a.get("D"))) {
-            href = "#p" + std::to_string(*index + 1);
+            href = page_href(*index);
             internal = true;
           }
         }
@@ -254,7 +264,7 @@ std::vector<LinkOut> collect_page_links(const pdf::Page &page,
     if (href.empty() && dictionary.has_value("Dest")) {
       if (const auto index =
               resolver.resolve_dest_page(dictionary.get("Dest"))) {
-        href = "#p" + std::to_string(*index + 1);
+        href = page_href(*index);
         internal = true;
       }
     }
@@ -1131,51 +1141,125 @@ public:
   HtmlServiceImpl(PdfFile pdf_file, HtmlConfig config,
                   std::shared_ptr<Logger> logger)
       : HtmlService(std::move(config), std::move(logger)),
-        m_pdf_file{std::move(pdf_file)} {
-    m_views.emplace_back(
-        std::make_shared<HtmlView>(*this, "document", 0, "document.html"));
+        m_pdf_file{std::move(pdf_file)} {}
+
+  /// Parses the document once, applies the `[page_range_begin,
+  /// page_range_end)` page range and builds the view list: the combined
+  /// document plus one standalone view per rendered page. The parser and its
+  /// object cache are kept for the service's lifetime so the page views
+  /// render off one shared parse.
+  void warmup() const override {
+    std::lock_guard lock(m_mutex);
+
+    if (m_document != nullptr) {
+      return;
+    }
+
+    const auto &pdf_file =
+        dynamic_cast<const pdf::PdfFile &>(*m_pdf_file.impl());
+    m_parser = pdf_file.create_parser(*m_logger);
+    m_document = m_parser->parse_document();
+
+    const std::vector<pdf::Page *> pages = m_document->collect_pages();
+    m_link_resolver = std::make_unique<LinkResolver>(
+        build_link_resolver(*m_parser, *m_document, pages));
+    const std::size_t begin =
+        std::min<std::size_t>(config().page_range_begin, pages.size());
+    const std::size_t end =
+        config().page_range_end
+            ? std::clamp<std::size_t>(*config().page_range_end, begin,
+                                      pages.size())
+            : pages.size();
+    m_first_page = begin;
+    m_pages.assign(pages.begin() + static_cast<std::ptrdiff_t>(begin),
+                   pages.begin() + static_cast<std::ptrdiff_t>(end));
+
+    m_views.emplace_back(std::make_shared<HtmlView>(
+        *this, "document", 0, config().document_output_file_name));
+    for (std::size_t i = 0; i < m_pages.size(); ++i) {
+      const std::size_t page = m_first_page + i;
+      m_views.emplace_back(std::make_shared<HtmlView>(
+          *this, "page" + std::to_string(page + 1), page + 1,
+          fill_path_variables(config().page_output_file_name, page)));
+    }
   }
 
-  void warmup() const override {}
-
-  [[nodiscard]] const HtmlViews &list_views() const override { return m_views; }
+  [[nodiscard]] const HtmlViews &list_views() const override {
+    warmup();
+    return m_views;
+  }
 
   [[nodiscard]] bool exists(const std::string &path) const override {
-    if (path == "document.html") {
-      return true;
-    }
-    return false;
+    warmup();
+    return std::ranges::any_of(
+        m_views, [&path](const auto &view) { return view.path() == path; });
   }
 
   [[nodiscard]] std::string mimetype(const std::string &path) const override {
-    if (path == "document.html") {
+    if (exists(path)) {
       return "text/html";
     }
     throw FileNotFound("Unknown path: " + path);
   }
 
   void write(const std::string &path, std::ostream &out) const override {
-    if (path == "document.html") {
-      HtmlWriter writer(out, config());
-      write_document(writer);
-      return;
-    }
-    throw FileNotFound("Unknown path: " + path);
+    HtmlWriter writer(out, config());
+    write_html(path, writer);
   }
 
   HtmlResources write_html(const std::string &path,
                            HtmlWriter &out) const override {
-    if (path == "document.html") {
+    warmup();
+    // The parser's object cache is shared mutable state; renders are
+    // serialized.
+    std::lock_guard lock(m_mutex);
+    if (path == config().document_output_file_name) {
       return write_document(out);
+    }
+    for (std::size_t i = 0; i < m_pages.size(); ++i) {
+      if (path == m_views[i + 1].path()) {
+        return write_page(i, out);
+      }
     }
     throw FileNotFound("Unknown path: " + path);
   }
 
+  /// Whether the 0-based page index falls inside the rendered page range.
+  [[nodiscard]] bool page_rendered(const std::size_t index) const {
+    return index >= m_first_page && index < m_first_page + m_pages.size();
+  }
+
+  /// The combined document: every rendered page, internal links as `#pN`
+  /// anchors (dropped when the target page is outside the page range).
   HtmlResources write_document(HtmlWriter &out) const {
+    const PageHref page_href = [this](const std::size_t index) {
+      return page_rendered(index) ? "#p" + std::to_string(index + 1)
+                                  : std::string();
+    };
+    return write_pages(out, m_pages, m_first_page + 1, page_href);
+  }
+
+  /// One standalone page (the `page{index}.html` view); internal links
+  /// navigate between the page files.
+  HtmlResources write_page(const std::size_t page_index,
+                           HtmlWriter &out) const {
+    const PageHref page_href = [this](const std::size_t index) {
+      return page_rendered(index)
+                 ? fill_path_variables(config().page_output_file_name, index)
+                 : std::string();
+    };
+    const std::vector<pdf::Page *> pages{m_pages[page_index]};
+    return write_pages(out, pages, m_first_page + page_index + 1, page_href);
+  }
+
+  HtmlResources write_pages(HtmlWriter &out,
+                            const std::vector<pdf::Page *> &pages,
+                            const std::size_t first_page_number,
+                            const PageHref &page_href) const {
     if (config().pdf_text_mode == PdfTextMode::single_layer) {
-      return write_document_single_layer(out);
+      return write_pages_single_layer(out, pages, first_page_number, page_href);
     }
-    return write_document_dual_layer(out);
+    return write_pages_dual_layer(out, pages, first_page_number, page_href);
   }
 
   // =========================================================================
@@ -1245,15 +1329,14 @@ public:
     std::vector<LinkOut> links;
   };
 
-  HtmlResources write_document_dual_layer(HtmlWriter &out) const {
+  HtmlResources write_pages_dual_layer(HtmlWriter &out,
+                                       const std::vector<pdf::Page *> &pages,
+                                       const std::size_t first_page_number,
+                                       const PageHref &page_href) const {
     HtmlResources resources;
 
-    const auto &pdf_file =
-        dynamic_cast<const pdf::PdfFile &>(*m_pdf_file.impl());
-    pdf::DocumentParser parser = pdf_file.create_parser(*m_logger);
-    const std::unique_ptr<pdf::Document> document = parser.parse_document();
-    const std::vector<pdf::Page *> pages = document->collect_pages();
-    LinkResolver link_resolver = build_link_resolver(parser, *document, pages);
+    pdf::DocumentParser &parser = *m_parser;
+    LinkResolver &link_resolver = *m_link_resolver;
 
     AtomicStyles styles;
     std::vector<DualPageOut> pages_out;
@@ -1310,7 +1393,8 @@ public:
       page_out.classes = pb.classes;
       page_out.width = width;
       page_out.height = height;
-      page_out.links = collect_page_links(*page, to_box, link_resolver);
+      page_out.links =
+          collect_page_links(*page, to_box, link_resolver, page_href);
 
       std::string stream;
       for (const auto &ref : page->contents_reference) {
@@ -1675,13 +1759,13 @@ public:
     };
 
     out.write_body_begin();
-    std::size_t page_number = 0;
+    std::size_t page_number = first_page_number;
     for (const DualPageOut &page : pages_out) {
       out.write_element_begin(
           "div",
           HtmlElementOptions()
               .set_class(page.classes)
-              .set_extra(R"(id="p)" + std::to_string(++page_number) + R"(")"));
+              .set_extra(R"(id="p)" + std::to_string(page_number++) + R"(")"));
 
       // Visual layer: paint-order graphics and unselectable glyphs.
       out.write_element_begin("div",
@@ -1763,15 +1847,14 @@ public:
     std::vector<LinkOut> links;
   };
 
-  HtmlResources write_document_single_layer(HtmlWriter &out) const {
+  HtmlResources write_pages_single_layer(HtmlWriter &out,
+                                         const std::vector<pdf::Page *> &pages,
+                                         const std::size_t first_page_number,
+                                         const PageHref &page_href) const {
     HtmlResources resources;
 
-    const auto &pdf_file =
-        dynamic_cast<const pdf::PdfFile &>(*m_pdf_file.impl());
-    pdf::DocumentParser parser = pdf_file.create_parser(*m_logger);
-    const std::unique_ptr<pdf::Document> document = parser.parse_document();
-    const std::vector<pdf::Page *> pages = document->collect_pages();
-    LinkResolver link_resolver = build_link_resolver(parser, *document, pages);
+    pdf::DocumentParser &parser = *m_parser;
+    LinkResolver &link_resolver = *m_link_resolver;
 
     // ---- Font registration ------------------------------------------------
     // A real-Unicode scalar gets a cmap entry only inside the BMP and outside
@@ -1910,7 +1993,8 @@ public:
       page_out.classes = pb.classes;
       page_out.width = width;
       page_out.height = height;
-      page_out.links = collect_page_links(page, to_box, link_resolver);
+      page_out.links =
+          collect_page_links(page, to_box, link_resolver, page_href);
 
       ClipRegistry clips(static_cast<std::uint32_t>(pages_out.size()));
       GradientRegistry gradients(static_cast<std::uint32_t>(pages_out.size()));
@@ -2199,13 +2283,13 @@ public:
     };
 
     out.write_body_begin();
-    std::size_t page_number = 0;
+    std::size_t page_number = first_page_number;
     for (const SinglePageOut &page : pages_out) {
       out.write_element_begin(
           "div",
           HtmlElementOptions()
               .set_class(page.classes)
-              .set_extra(R"(id="p)" + std::to_string(++page_number) + R"(")"));
+              .set_extra(R"(id="p)" + std::to_string(page_number++) + R"(")"));
       write_page_items(out, page.clip_defs, page.items, page.width, page.height,
                        write_line);
       write_page_links(out, page.links);
@@ -2638,7 +2722,18 @@ public:
 
 protected:
   PdfFile m_pdf_file;
-  HtmlViews m_views;
+
+  // Lazily initialized by `warmup()` (all guarded by `m_mutex`): one parse
+  // shared by the combined-document and per-page renders.
+  mutable std::mutex m_mutex;
+  mutable std::unique_ptr<pdf::DocumentParser> m_parser;
+  mutable std::unique_ptr<pdf::Document> m_document;
+  mutable std::unique_ptr<LinkResolver> m_link_resolver;
+  /// The rendered pages (`[page_range_begin, page_range_end)`) and the 0-based
+  /// document-global index of the first one.
+  mutable std::vector<pdf::Page *> m_pages;
+  mutable std::size_t m_first_page{0};
+  mutable HtmlViews m_views;
 };
 
 } // namespace

--- a/src/odr/internal/html/pdf_file.cpp
+++ b/src/odr/internal/html/pdf_file.cpp
@@ -6,6 +6,7 @@
 
 #include <odr/internal/abstract/file.hpp>
 #include <odr/internal/abstract/font.hpp>
+#include <odr/internal/common/path.hpp>
 #include <odr/internal/font/cff_font.hpp>
 #include <odr/internal/font/cff_transform.hpp>
 #include <odr/internal/font/sfnt_font.hpp>
@@ -75,43 +76,6 @@ struct LinkOut {
 /// "#pN" anchor in the combined document, a page-view file name in a
 /// standalone page. Returns "" to drop the link (target page not rendered).
 using PageHref = std::function<std::string(std::size_t)>;
-
-/// The href navigating from the document at `from` to `to` (both output-root
-/// relative, '/'-separated): drops their shared directory prefix and climbs
-/// out of `from`'s remaining directories. The browser resolves an href
-/// against the current document's directory, so an output-root-relative path
-/// must not be emitted as-is.
-std::string relative_href(const std::string &from, const std::string &to) {
-  const auto split = [](const std::string &path) {
-    std::vector<std::string> segments;
-    for (std::size_t begin = 0; begin <= path.size();) {
-      const std::size_t end = std::min(path.find('/', begin), path.size());
-      segments.push_back(path.substr(begin, end - begin));
-      begin = end + 1;
-    }
-    return segments;
-  };
-  const std::vector<std::string> from_segments = split(from);
-  const std::vector<std::string> to_segments = split(to);
-  const std::size_t from_dirs = from_segments.size() - 1;
-  const std::size_t to_dirs = to_segments.size() - 1;
-  std::size_t common = 0;
-  while (common < from_dirs && common < to_dirs &&
-         from_segments[common] == to_segments[common]) {
-    ++common;
-  }
-  std::string href;
-  for (std::size_t i = common; i < from_dirs; ++i) {
-    href += "../";
-  }
-  for (std::size_t i = common; i < to_segments.size(); ++i) {
-    if (i != common) {
-      href += '/';
-    }
-    href += to_segments[i];
-  }
-  return href;
-}
 
 /// Resolves a link annotation's destination to a page: a `page-object ->
 /// 0-based index` map plus the catalog's named-destination table (`/Dests`
@@ -1277,17 +1241,18 @@ public:
   }
 
   /// One standalone page (the `page{index}.html` view); internal links
-  /// navigate between the page files, relative to this page's own path (the
-  /// browser resolves an href against the current document, so a nested
+  /// navigate between the page files, rebased onto this page's own directory
+  /// (the browser resolves an href against the current document, so a nested
   /// `page_output_file_name` must not be emitted output-root-relative).
   HtmlResources write_page(const std::size_t page_index,
                            HtmlWriter &out) const {
-    const std::string &from = m_views[page_index + 1].path();
-    const PageHref page_href = [this, &from](const std::size_t index) {
+    const RelPath from_dir = RelPath(m_views[page_index + 1].path()).parent();
+    const PageHref page_href = [this, &from_dir](const std::size_t index) {
       return page_rendered(index)
-                 ? relative_href(
-                       from, fill_path_variables(config().page_output_file_name,
-                                                 index))
+                 ? RelPath(fill_path_variables(config().page_output_file_name,
+                                               index))
+                       .rebase(from_dir)
+                       .string()
                  : std::string();
     };
     const std::vector<pdf::Page *> pages{m_pages[page_index]};

--- a/src/odr/internal/html/pdf_file.cpp
+++ b/src/odr/internal/html/pdf_file.cpp
@@ -31,6 +31,7 @@
 #include <map>
 #include <memory>
 #include <mutex>
+#include <span>
 #include <sstream>
 #include <string>
 #include <string_view>
@@ -151,7 +152,7 @@ void collect_dest_name_tree(pdf::DocumentParser &parser,
 /// catalog's named destinations.
 LinkResolver build_link_resolver(pdf::DocumentParser &parser,
                                  const pdf::Document &document,
-                                 const std::vector<pdf::Page *> &pages) {
+                                 const std::span<pdf::Page *const> pages) {
   LinkResolver resolver{parser, {}, {}};
   for (std::size_t i = 0; i < pages.size(); ++i) {
     resolver.page_index.emplace(pages[i]->object_reference, i);
@@ -1255,12 +1256,12 @@ public:
                        .string()
                  : std::string();
     };
-    const std::vector<pdf::Page *> pages{m_pages[page_index]};
+    const std::array<pdf::Page *, 1> pages{m_pages[page_index]};
     return write_pages(out, pages, m_first_page + page_index + 1, page_href);
   }
 
   HtmlResources write_pages(HtmlWriter &out,
-                            const std::vector<pdf::Page *> &pages,
+                            const std::span<pdf::Page *const> pages,
                             const std::size_t first_page_number,
                             const PageHref &page_href) const {
     if (config().pdf_text_mode == PdfTextMode::single_layer) {
@@ -1337,7 +1338,7 @@ public:
   };
 
   HtmlResources write_pages_dual_layer(HtmlWriter &out,
-                                       const std::vector<pdf::Page *> &pages,
+                                       const std::span<pdf::Page *const> pages,
                                        const std::size_t first_page_number,
                                        const PageHref &page_href) const {
     HtmlResources resources;
@@ -1854,10 +1855,9 @@ public:
     std::vector<LinkOut> links;
   };
 
-  HtmlResources write_pages_single_layer(HtmlWriter &out,
-                                         const std::vector<pdf::Page *> &pages,
-                                         const std::size_t first_page_number,
-                                         const PageHref &page_href) const {
+  HtmlResources write_pages_single_layer(
+      HtmlWriter &out, const std::span<pdf::Page *const> pages,
+      const std::size_t first_page_number, const PageHref &page_href) const {
     HtmlResources resources;
 
     pdf::DocumentParser &parser = *m_parser;

--- a/src/odr/internal/html/pdf_file.cpp
+++ b/src/odr/internal/html/pdf_file.cpp
@@ -1159,7 +1159,8 @@ public:
 
     const auto &pdf_file =
         dynamic_cast<const pdf::PdfFile &>(*m_pdf_file.impl());
-    m_parser = pdf_file.create_parser(*m_logger);
+    m_parser = std::make_unique<pdf::DocumentParser>(
+        pdf_file.create_parser(*m_logger));
     m_document = m_parser->parse_document();
 
     const std::vector<pdf::Page *> pages = m_document->collect_pages();

--- a/src/odr/internal/pdf/pdf_file.cpp
+++ b/src/odr/internal/pdf/pdf_file.cpp
@@ -175,10 +175,8 @@ bool PdfFile::is_decodable() const noexcept {
   return m_encryption_state != EncryptionState::encrypted;
 }
 
-std::unique_ptr<DocumentParser>
-PdfFile::create_parser(const Logger &logger) const {
-  return std::make_unique<DocumentParser>(m_file->stream(), m_decryptor,
-                                          logger);
+DocumentParser PdfFile::create_parser(const Logger &logger) const {
+  return DocumentParser(m_file->stream(), m_decryptor, logger);
 }
 
 } // namespace odr::internal::pdf

--- a/src/odr/internal/pdf/pdf_file.cpp
+++ b/src/odr/internal/pdf/pdf_file.cpp
@@ -175,8 +175,10 @@ bool PdfFile::is_decodable() const noexcept {
   return m_encryption_state != EncryptionState::encrypted;
 }
 
-DocumentParser PdfFile::create_parser(const Logger &logger) const {
-  return DocumentParser(m_file->stream(), m_decryptor, logger);
+std::unique_ptr<DocumentParser>
+PdfFile::create_parser(const Logger &logger) const {
+  return std::make_unique<DocumentParser>(m_file->stream(), m_decryptor,
+                                          logger);
 }
 
 } // namespace odr::internal::pdf

--- a/src/odr/internal/pdf/pdf_file.hpp
+++ b/src/odr/internal/pdf/pdf_file.hpp
@@ -29,7 +29,7 @@ public:
 
   [[nodiscard]] bool is_decodable() const noexcept override;
 
-  [[nodiscard]] std::unique_ptr<DocumentParser>
+  [[nodiscard]] DocumentParser
   create_parser(const Logger &logger = Logger::null()) const;
 
 private:

--- a/src/odr/internal/pdf/pdf_file.hpp
+++ b/src/odr/internal/pdf/pdf_file.hpp
@@ -29,7 +29,7 @@ public:
 
   [[nodiscard]] bool is_decodable() const noexcept override;
 
-  [[nodiscard]] DocumentParser
+  [[nodiscard]] std::unique_ptr<DocumentParser>
   create_parser(const Logger &logger = Logger::null()) const;
 
 private:

--- a/src/odr/internal/pdf/pdf_object_parser.cpp
+++ b/src/odr/internal/pdf/pdf_object_parser.cpp
@@ -11,8 +11,13 @@
 
 namespace odr::internal::pdf {
 
-ObjectParser::ObjectParser(std::istream &in)
-    : m_in{&in}, m_se(in, true), m_sb{in.rdbuf()} {}
+ObjectParser::ObjectParser(std::istream &in) : m_in{&in}, m_sb{in.rdbuf()} {
+  // One-time stream preparation (flush tied streams, state check) for the
+  // raw-streambuf reads below; a sentry's effects live entirely in its
+  // constructor, so it is not kept as state (it would also make the parser
+  // immovable).
+  const std::istream::sentry se(in, true);
+}
 
 std::istream &ObjectParser::in() { return *m_in; }
 

--- a/src/odr/internal/pdf/pdf_object_parser.hpp
+++ b/src/odr/internal/pdf/pdf_object_parser.hpp
@@ -104,7 +104,6 @@ public:
 
 private:
   std::istream *m_in{nullptr};
-  std::istream::sentry m_se;
   std::streambuf *m_sb{nullptr};
 };
 

--- a/test/src/html_output_test.cpp
+++ b/test/src/html_output_test.cpp
@@ -172,6 +172,7 @@ TEST_P(HtmlOutputTests, html_meta) {
   config.relative_resource_paths = true;
   config.editable = true;
   config.spreadsheet_limit = TableDimensions(4000, 500);
+  config.page_range_end = 100;
   config.format_html = true;
   config.html_indent = 1;
   config.html_indent_string = "\t";

--- a/test/src/internal/pdf/pdf_file.cpp
+++ b/test/src/internal/pdf/pdf_file.cpp
@@ -190,6 +190,34 @@ TEST(PdfFile, page_views_are_listed) {
   EXPECT_EQ(views.at(3).path(), "page2.html");
 }
 
+// With a nested `page_output_file_name`, cross-page hrefs are emitted
+// relative to the current page's own directory (the browser resolves them
+// against the current document, not the output root).
+TEST(PdfFile, page_views_nested_output_pattern_links_relatively) {
+  const std::string pdf = link_annotations_mini_pdf();
+
+  {
+    // Constant directory: siblings link by bare file name.
+    HtmlConfig config;
+    config.page_output_file_name = "pages/page{index}.html";
+    const HtmlService service = make_service(pdf, config);
+    EXPECT_EQ(service.list_views().at(1).path(), "pages/page0.html");
+    const std::string html = render_path(service, "pages/page0.html");
+    EXPECT_TRUE(contains(html, R"(href="page1.html" target="_self")"));
+    EXPECT_FALSE(contains(html, R"(href="pages/page1.html")"));
+  }
+
+  {
+    // Per-page directory: siblings climb out of their own directory.
+    HtmlConfig config;
+    config.page_output_file_name = "p{index}/index.html";
+    const HtmlService service = make_service(pdf, config);
+    const std::string html = render_path(service, "p0/index.html");
+    EXPECT_TRUE(contains(html, R"(href="../p1/index.html" target="_self")"));
+    EXPECT_TRUE(contains(html, R"(href="../p2/index.html" target="_self")"));
+  }
+}
+
 // `page_range_end` caps the rendered pages and views; internal links to pages
 // beyond the range are dropped rather than left dangling.
 TEST(PdfFile, page_range_end_caps_pages_views_and_links) {

--- a/test/src/internal/pdf/pdf_file.cpp
+++ b/test/src/internal/pdf/pdf_file.cpp
@@ -1,3 +1,4 @@
+#include <odr/exceptions.hpp>
 #include <odr/file.hpp>
 #include <odr/html.hpp>
 #include <odr/logger.hpp>
@@ -24,16 +25,23 @@ std::shared_ptr<pdf::PdfFile> open_pdf(const std::string &bytes) {
   return std::make_shared<pdf::PdfFile>(std::make_shared<MemoryFile>(bytes));
 }
 
-std::string render_html(const std::string &bytes, const PdfTextMode mode) {
+HtmlService make_service(const std::string &bytes, const HtmlConfig &config) {
   const odr::PdfFile file(open_pdf(bytes));
+  const std::shared_ptr<Logger> logger = Logger::create_null();
+  return internal::html::create_pdf_service(file, "", config, logger);
+}
+
+std::string render_path(const HtmlService &service, const std::string &path) {
+  std::ostringstream out;
+  service.write(path, out);
+  return std::move(out).str();
+}
+
+std::string render_html(const std::string &bytes, const PdfTextMode mode,
+                        const std::string &path = "document.html") {
   HtmlConfig config;
   config.pdf_text_mode = mode;
-  const std::shared_ptr<Logger> logger = Logger::create_null();
-  const HtmlService service =
-      internal::html::create_pdf_service(file, "", config, logger);
-  std::ostringstream out;
-  service.write("document.html", out);
-  return std::move(out).str();
+  return render_path(make_service(bytes, config), path);
 }
 
 bool contains(const std::string &haystack, const std::string &needle) {
@@ -148,4 +156,79 @@ TEST(PdfFile, link_annotations_render_as_anchors) {
     EXPECT_FALSE(contains(html, "javascript:alert"))
         << "mode " << static_cast<int>(mode);
   }
+}
+
+// A standalone page view (`page{index}.html`) resolves internal links to the
+// target's page view file instead of a `#pN` anchor; the page div keeps its
+// document-global `id`.
+TEST(PdfFile, page_views_link_between_page_files) {
+  const std::string pdf = link_annotations_mini_pdf();
+  const std::string html = render_html(pdf, PdfTextMode::dual_layer,
+                                       /*path=*/"page0.html");
+  EXPECT_TRUE(contains(html, R"(id="p1")"));
+  EXPECT_FALSE(contains(html, R"(id="p2")"));
+  EXPECT_TRUE(contains(html, R"(href="page1.html" target="_self")"));
+  EXPECT_TRUE(contains(html, R"(href="page2.html" target="_self")"));
+
+  const std::string page3 = render_html(pdf, PdfTextMode::dual_layer,
+                                        /*path=*/"page2.html");
+  EXPECT_TRUE(contains(page3, R"(id="p3")"));
+}
+
+// The service exposes the combined document plus one view per page; the views
+// carry the page file names.
+TEST(PdfFile, page_views_are_listed) {
+  const HtmlService service =
+      make_service(link_annotations_mini_pdf(), HtmlConfig());
+  const HtmlViews &views = service.list_views();
+  ASSERT_EQ(views.size(), 4);
+  EXPECT_EQ(views.at(0).name(), "document");
+  EXPECT_EQ(views.at(0).path(), "document.html");
+  EXPECT_EQ(views.at(1).name(), "page1");
+  EXPECT_EQ(views.at(1).path(), "page0.html");
+  EXPECT_EQ(views.at(3).name(), "page3");
+  EXPECT_EQ(views.at(3).path(), "page2.html");
+}
+
+// `page_range_end` caps the rendered pages and views; internal links to pages
+// beyond the range are dropped rather than left dangling.
+TEST(PdfFile, page_range_end_caps_pages_views_and_links) {
+  HtmlConfig config;
+  config.page_range_end = 2;
+  const HtmlService service = make_service(link_annotations_mini_pdf(), config);
+
+  const HtmlViews &views = service.list_views();
+  ASSERT_EQ(views.size(), 3);
+  EXPECT_EQ(views.at(2).path(), "page1.html");
+
+  const std::string html = render_path(service, "document.html");
+  EXPECT_TRUE(contains(html, R"(id="p2")"));
+  EXPECT_FALSE(contains(html, R"(id="p3")"));
+  // The direct `/Dest` to page 2 stays; the `/GoTo` to page 3 is dropped.
+  EXPECT_TRUE(contains(html, R"(href="#p2")"));
+  EXPECT_FALSE(contains(html, R"(href="#p3")"));
+
+  EXPECT_THROW(render_path(service, "page2.html"), FileNotFound);
+}
+
+// `page_range_begin` skips leading pages while page views, ids and anchors
+// keep their document-global numbering.
+TEST(PdfFile, page_range_begin_keeps_global_numbering) {
+  HtmlConfig config;
+  config.page_range_begin = 1;
+  const HtmlService service = make_service(link_annotations_mini_pdf(), config);
+
+  const HtmlViews &views = service.list_views();
+  ASSERT_EQ(views.size(), 3);
+  EXPECT_EQ(views.at(1).name(), "page2");
+  EXPECT_EQ(views.at(1).path(), "page1.html");
+  EXPECT_EQ(views.at(2).name(), "page3");
+  EXPECT_EQ(views.at(2).path(), "page2.html");
+
+  const std::string html = render_path(service, "document.html");
+  EXPECT_FALSE(contains(html, R"(id="p1")"));
+  EXPECT_TRUE(contains(html, R"(id="p2")"));
+  EXPECT_TRUE(contains(html, R"(id="p3")"));
+
+  EXPECT_THROW(render_path(service, "page0.html"), FileNotFound);
 }


### PR DESCRIPTION
🤖 Generated with [Claude Code](https://claude.com/claude-code)

## Why

CI is blocked on the GitHub LFS bandwidth quota: every run pulled the 124 MB `Core_v5.1.pdf/document.html` reference (LFS quotas are account-wide and identical for public/private repos). The file is not bloated output — the document simply has 2985 pages (~42 KB/page). On top of that, the visual compare only ever saw the first ~10000 px (≈8 pages) of that file due to the browser viewport cap.

## What

- **Per-page views**: the native PDF pipeline now exposes one standalone `page{index}.html` view per page next to the combined `document.html`, mirroring the slide/sheet fragment pattern. The document is parsed once and cached in the service; each page renders self-contained (per-page styles/fonts). Internal links resolve to `#pN` anchors in the combined document, to the target's page file in page views, and are dropped when the target page is not rendered.
- **General page range**: `HtmlConfig` gains `[page_range_begin, page_range_end)` (0-based, half-open; sibling of `spreadsheet_limit`). Page files, `id="pN"` and anchors keep document-global numbering. The test harness caps reference outputs at 100 pages.
- **LFS removed**: the largest reference file drops 124 MB → 5.2 MB, both reference-output repos are regenerated (page files added, `.gitattributes`/LFS tracking deleted, stale pdf2htmlEX leftovers gone) and the checkout step drops `lfs: true`.
- `PdfFile::create_parser` returns `std::unique_ptr<DocumentParser>` (the parser is immovable and now outlives a single render).

Effects on the compare job: unchanged pages short-circuit on the byte compare, only changed pages get rendered, and each page is now *fully* visually compared instead of the first 8 pages of a 124 MB document. Rendering `Core_v5.1.pdf` refs takes ~1.5 s locally.

## Testing

- 5 new unit tests (page views, cross-page links, range begin/end semantics, dangling-link dropping); `PdfFile.*` and `html.views` pass.
- Full `HtmlOutputTests` suite: 231 passed; `document.html` stays byte-identical for PDFs within the range.
- Reference repos regenerated from that run (also catches refs up to the pptx #603/#604 attribute drift, which is visually identical).

https://claude.ai/code/session_01YDzC6Kq9FGCjTWGFwTpkgf