### PR TITLE
fix(html): open fixed-size PDF and image content fit-to-width on mobile

### DIFF
--- a/src/odr/internal/html/image_file.cpp
+++ b/src/odr/internal/html/image_file.cpp
@@ -73,8 +73,7 @@ public:
     out.write_header_charset("UTF-8");
     out.write_header_target("_blank");
     out.write_header_title("odr");
-    out.write_header_viewport(
-        "width=device-width,initial-scale=1.0,user-scalable=yes");
+    out.write_header_viewport("width=device-width,user-scalable=yes");
     out.write_header_end();
 
     out.write_body_begin();

--- a/src/odr/internal/html/pdf_file.cpp
+++ b/src/odr/internal/html/pdf_file.cpp
@@ -2527,8 +2527,7 @@ public:
     out.write_header_charset("UTF-8");
     out.write_header_target("_blank");
     out.write_header_title("odr");
-    out.write_header_viewport(
-        "width=device-width,initial-scale=1.0,user-scalable=yes");
+    out.write_header_viewport("width=device-width,user-scalable=yes");
     out.write_header_style_begin();
     out.out() << "body{margin:0;background:#525659}";
     out.out() << ".p{position:relative;margin:16px auto;background:#fff;"


### PR DESCRIPTION
🤖 Generated with [Claude Code](https://claude.com/claude-code)

The PDF and image pipelines locked the viewport meta tag to `initial-scale=1.0`, so page-shaped content (an A4 page is ≈793 CSS px, a phone ~360–430 CSS px) opened zoomed into the top-left corner on mobile. `document.cpp` already omits `initial-scale` for paged content so mobile browsers auto-fit the content width — this applies the same viewport to the PDF and image pipelines.

Reference outputs regenerated on `fix/html-viewport-fit-width` branches of both output repos; all 540 changed files differ only in the viewport meta line. (Pre-existing unrelated diff in `odr-public doc/empty.doc` — font-size 10pt vs 11pt — left untouched.)

Stacked on #613.