### PR TITLE
Let conan consumers turn the cli off

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -436,6 +436,9 @@ install(
 set(ODR_INSTALL_TARGETS odr)
 if (ODR_CLI)
     list(APPEND ODR_INSTALL_TARGETS meta translate back_translate)
+    if (ODR_WITH_HTTP_SERVER)
+        list(APPEND ODR_INSTALL_TARGETS server)
+    endif ()
 endif ()
 install(
         TARGETS ${ODR_INSTALL_TARGETS}

--- a/conanfile.py
+++ b/conanfile.py
@@ -21,6 +21,7 @@ class OpenDocumentCoreConan(ConanFile):
         "with_wvWare": [True, False],
         "with_libmagic": [True, False],
         "with_http_server": [True, False],
+        "with_cli": [True, False],
         "with_python": [True, False],
         "with_jni": [True, False],
         "bundle_assets": [True, False],
@@ -32,6 +33,7 @@ class OpenDocumentCoreConan(ConanFile):
         "with_wvWare": True,
         "with_libmagic": True,
         "with_http_server": True,
+        "with_cli": True,
         "with_python": False,
         "with_jni": False,
         "bundle_assets": False,
@@ -85,6 +87,7 @@ class OpenDocumentCoreConan(ConanFile):
         tc.variables["ODR_WITH_WVWARE"] = self.options.get_safe("with_wvWare", False)
         tc.variables["ODR_WITH_LIBMAGIC"] = self.options.get_safe("with_libmagic", False)
         tc.variables["ODR_WITH_HTTP_SERVER"] = self.options.get_safe("with_http_server", False)
+        tc.variables["ODR_CLI"] = self.options.get_safe("with_cli", True)
         tc.variables["ODR_PYTHON"] = self.options.get_safe("with_python", False)
         tc.variables["ODR_JNI"] = self.options.get_safe("with_jni", False)
         tc.variables["ODR_BUNDLE_ASSETS"] = self.options.get_safe("bundle_assets", False)


### PR DESCRIPTION
🤖 Generated with [Claude Code](https://claude.com/claude-code)

## Why

Follow-up to feedback from [OpenDocument.ios#125](https://github.com/opendocument-app/OpenDocument.ios/pull/125):

> `ODR_CLI=OFF` would be tidier but odrcore 5.5.0 installs the cli targets whether or not it built them — worth fixing upstream.

The install half of that is already fixed on `main` (`ODR_INSTALL_TARGETS`, since 5.7.0). What is still missing is that **nothing could set `ODR_CLI` in the first place** through conan: the recipe never passed it to CMake, so every package builds and installs `meta`, `translate`, `back_translate` and `server` — dead weight for a consumer that only links the library, and on iOS the `server` tool has to be linked against frameworks the app has no other use for.

## What

- `conanfile.py`: `with_cli` option, default `True`, wired to `ODR_CLI`.
- `CMakeLists.txt`: install `server` with the other cli tools when `ODR_WITH_HTTP_SERVER` is on. It was being built and then dropped at install time.

The consumer-side counterpart is [conan-odr-index#113](https://github.com/opendocument-app/conan-odr-index/pull/113) — the recipe the apps actually resolve.

## Verified

Configured both ways against the existing conan toolchain and read back `cmake_install.cmake`:

- `-DODR_CLI=OFF` → headers, `libodr.a`, data dir only
- `-DODR_CLI=ON -DODR_WITH_HTTP_SERVER=ON` → `bin/meta`, `bin/translate`, `bin/back_translate`, `bin/server`