### PR TITLE
feat(http-server)!: split listen into bind and listen

### DIFF
--- a/cli/src/server.cpp
+++ b/cli/src/server.cpp
@@ -5,6 +5,7 @@
 #include <odr/html.hpp>
 #include <odr/http_server.hpp>
 
+#include <cstdint>
 #include <iostream>
 #include <string>
 
@@ -43,6 +44,11 @@ int main(const int argc, char **argv) {
     HttpServer::Config server_config;
     HttpServer server(server_config);
 
+    // bind before anything is printed: the port is only known once the socket
+    // is, and it is not necessarily the one that was asked for
+    const std::uint32_t port = server.bind("localhost", 8080);
+    const std::string base_url = "http://localhost:" + std::to_string(port);
+
     HtmlConfig html_config;
     html_config.embed_images = false;
     html_config.embed_shipped_resources = true;
@@ -56,8 +62,7 @@ int main(const int argc, char **argv) {
           server.serve_file(decoded_file, prefix, html_config);
       ODR_INFO(*logger, "hosted decoded file with id: " << prefix);
       for (const auto &view : views) {
-        ODR_INFO(*logger,
-                 "http://localhost:8080/file/" << prefix << "/" << view.path());
+        ODR_INFO(*logger, base_url << "/file/" << prefix << "/" << view.path());
       }
     }
 
@@ -74,12 +79,11 @@ int main(const int argc, char **argv) {
       server.connect_service(filesystem_service, prefix);
       ODR_INFO(*logger, "hosted filesystem with id: " << prefix);
       for (const auto &view : filesystem_service.list_views()) {
-        ODR_INFO(*logger,
-                 "http://localhost:8080/file/" << prefix << "/" << view.path());
+        ODR_INFO(*logger, base_url << "/file/" << prefix << "/" << view.path());
       }
     }
 
-    server.listen("localhost", 8080);
+    server.listen();
 
     return 0;
   } catch (const std::exception &e) {

--- a/cli/src/server.cpp
+++ b/cli/src/server.cpp
@@ -6,6 +6,7 @@
 #include <odr/http_server.hpp>
 
 #include <cstdint>
+#include <filesystem>
 #include <iostream>
 #include <string>
 
@@ -41,8 +42,13 @@ int main(const int argc, char **argv) {
       }
     }
 
-    HttpServer::Config server_config;
-    HttpServer server(server_config);
+    const HttpServer server{HttpServer::Config{}, logger};
+
+    // the server does not own a cache any more, so the translation goes
+    // somewhere of our choosing
+    const std::filesystem::path cache_path =
+        std::filesystem::temp_directory_path() / "odr-server";
+    std::filesystem::remove_all(cache_path);
 
     // bind before anything is printed: the port is only known once the socket
     // is, and it is not necessarily the one that was asked for
@@ -58,8 +64,13 @@ int main(const int argc, char **argv) {
 
     {
       const std::string prefix = "file";
-      const HtmlViews views =
-          server.serve_file(decoded_file, prefix, html_config);
+      const std::string prefix_cache_path = (cache_path / prefix).string();
+      std::filesystem::create_directories(prefix_cache_path);
+
+      const HtmlService service =
+          html::translate(decoded_file, prefix_cache_path, html_config, logger);
+      server.connect_service(service, prefix);
+      const HtmlViews views = service.list_views();
       ODR_INFO(*logger, "hosted decoded file with id: " << prefix);
       for (const auto &view : views) {
         ODR_INFO(*logger, base_url << "/file/" << prefix << "/" << view.path());
@@ -73,9 +84,11 @@ int main(const int argc, char **argv) {
               : decoded_file.as_archive_file().archive().as_filesystem();
 
       const std::string prefix = "filesystem";
+      const std::string prefix_cache_path = (cache_path / prefix).string();
+      std::filesystem::create_directories(prefix_cache_path);
+
       const HtmlService filesystem_service =
-          html::translate(filesystem, server_config.cache_path + "/" + prefix,
-                          html_config, logger);
+          html::translate(filesystem, prefix_cache_path, html_config, logger);
       server.connect_service(filesystem_service, prefix);
       ODR_INFO(*logger, "hosted filesystem with id: " << prefix);
       for (const auto &view : filesystem_service.list_views()) {

--- a/cli/src/server.cpp
+++ b/cli/src/server.cpp
@@ -42,7 +42,7 @@ int main(const int argc, char **argv) {
       }
     }
 
-    const HttpServer server{HttpServer::Config{}, logger};
+    const HttpServer server{{}, logger};
 
     // the server does not own a cache any more, so the translation goes
     // somewhere of our choosing

--- a/jni/java/app/opendocument/core/HttpServer.java
+++ b/jni/java/app/opendocument/core/HttpServer.java
@@ -14,6 +14,18 @@ public final class HttpServer extends NativeResource {
     public String cachePath = "/tmp/odr";
   }
 
+  /** Mirrors {@code odr::HttpServer::Options}: socket options for {@link #bind}. */
+  public static final class Options {
+    /** SO_REUSEADDR, so a port held only by sockets in TIME_WAIT can be bound again. */
+    public boolean reuseAddress = true;
+
+    /**
+     * SO_REUSEPORT where the platform has it. Two live servers on one port share the
+     * incoming connections between them, hence off.
+     */
+    public boolean reusePort = false;
+  }
+
   public HttpServer(Config config) {
     super(create(config.cachePath), null, HttpServer::destroy);
   }
@@ -39,9 +51,23 @@ public final class HttpServer extends NativeResource {
     return result;
   }
 
+  /**
+   * Binds the socket and returns the port it got - pass {@code 0} for any free one.
+   * Connections are accepted into the backlog from here on, before {@link #listen()}
+   * runs, so a caller can hand out the port as soon as this returns.
+   */
+  public int bind(String host, int port) {
+    return bind(host, port, new Options());
+  }
+
+  /** Binds with explicit socket options. */
+  public int bind(String host, int port, Options options) {
+    return bindNative(handle(), host, port, options.reuseAddress, options.reusePort);
+  }
+
   /** Blocks serving requests until {@link #stop()} is called from another thread. */
-  public void listen(String host, int port) {
-    listenNative(handle(), host, port);
+  public void listen() {
+    listenNative(handle());
   }
 
   public void clear() {
@@ -63,7 +89,10 @@ public final class HttpServer extends NativeResource {
   private native long[] serveFileNative(
       long handle, long fileHandle, String prefix, HtmlConfig config);
 
-  private native void listenNative(long handle, String host, int port);
+  private native int bindNative(
+      long handle, String host, int port, boolean reuseAddress, boolean reusePort);
+
+  private native void listenNative(long handle);
 
   private native void clearNative(long handle);
 

--- a/jni/java/app/opendocument/core/HttpServer.java
+++ b/jni/java/app/opendocument/core/HttpServer.java
@@ -1,18 +1,17 @@
 package app.opendocument.core;
 
-import java.util.ArrayList;
-import java.util.List;
-
 /**
  * Serves translated files over HTTP. Mirrors {@code odr::HttpServer}. Only
  * available when the native library was built with the HTTP server
  * ({@link Odr#hasHttpServer()}).
  */
 public final class HttpServer extends NativeResource {
-  /** Mirrors {@code odr::HttpServer::Config}. */
-  public static final class Config {
-    public String cachePath = "/tmp/odr";
-  }
+  /**
+   * Mirrors {@code odr::HttpServer::Config}. Empty since the cache path went with
+   * {@code serveFile}: what a service was translated into belongs to whoever
+   * translated it.
+   */
+  public static final class Config {}
 
   /** Mirrors {@code odr::HttpServer::Options}: socket options for {@link #bind}. */
   public static final class Options {
@@ -27,28 +26,12 @@ public final class HttpServer extends NativeResource {
   }
 
   public HttpServer(Config config) {
-    super(create(config.cachePath), null, HttpServer::destroy);
-  }
-
-  public Config config() {
-    Config config = new Config();
-    config.cachePath = cachePathNative(handle());
-    return config;
+    super(create(), null, HttpServer::destroy);
   }
 
   /** Hosts the service under {@code /<prefix>/<view path>}. */
   public void connectService(HtmlService service, String prefix) {
     connectServiceNative(handle(), service.handle(), prefix);
-  }
-
-  /** Translates a decoded file and hosts it under {@code /file/<prefix>/<view path>}. */
-  public List<HtmlView> serveFile(DecodedFile file, String prefix, HtmlConfig config) {
-    long[] handles = serveFileNative(handle(), file.handle(), prefix, config);
-    List<HtmlView> result = new ArrayList<>(handles.length);
-    for (long h : handles) {
-      result.add(new HtmlView(h, this));
-    }
-    return result;
   }
 
   /**
@@ -78,16 +61,11 @@ public final class HttpServer extends NativeResource {
     stopNative(handle());
   }
 
-  private static native long create(String cachePath);
+  private static native long create();
 
   private static native void destroy(long handle);
 
-  private native String cachePathNative(long handle);
-
   private native void connectServiceNative(long handle, long serviceHandle, String prefix);
-
-  private native long[] serveFileNative(
-      long handle, long fileHandle, String prefix, HtmlConfig config);
 
   private native int bindNative(
       long handle, String host, int port, boolean reuseAddress, boolean reusePort);

--- a/jni/java/app/opendocument/core/HttpServer.java
+++ b/jni/java/app/opendocument/core/HttpServer.java
@@ -25,6 +25,10 @@ public final class HttpServer extends NativeResource {
     public boolean reusePort = false;
   }
 
+  public HttpServer() {
+    this(new Config());
+  }
+
   public HttpServer(Config config) {
     super(create(), null, HttpServer::destroy);
   }

--- a/jni/src/jni_http_server.cpp
+++ b/jni/src/jni_http_server.cpp
@@ -87,14 +87,25 @@ Java_app_opendocument_core_HttpServer_serveFileNative(JNIEnv *env, jobject,
   });
 }
 
+extern "C" JNIEXPORT jint JNICALL
+Java_app_opendocument_core_HttpServer_bindNative(JNIEnv *env, jobject,
+                                                 jlong handle, jstring host,
+                                                 jint port,
+                                                 jboolean reuse_address,
+                                                 jboolean reuse_port) {
+  return guarded(env, [&] {
+    odr::HttpServer::Options options;
+    options.reuse_address = reuse_address == JNI_TRUE;
+    options.reuse_port = reuse_port == JNI_TRUE;
+    return static_cast<jint>(server(handle).bind(
+        to_string(env, host), static_cast<std::uint32_t>(port), options));
+  });
+}
+
 extern "C" JNIEXPORT void JNICALL
 Java_app_opendocument_core_HttpServer_listenNative(JNIEnv *env, jobject,
-                                                   jlong handle, jstring host,
-                                                   jint port) {
-  guarded(env, [&] {
-    server(handle).listen(to_string(env, host),
-                          static_cast<std::uint32_t>(port));
-  });
+                                                   jlong handle) {
+  guarded(env, [&] { server(handle).listen(); });
 }
 
 extern "C" JNIEXPORT void JNICALL
@@ -154,9 +165,16 @@ Java_app_opendocument_core_HttpServer_serveFileNative(JNIEnv *env, jobject,
   return odr_jni::guarded(env, [&]() -> jlongArray { unsupported(); });
 }
 
+extern "C" JNIEXPORT jint JNICALL
+Java_app_opendocument_core_HttpServer_bindNative(JNIEnv *env, jobject, jlong,
+                                                 jstring, jint, jboolean,
+                                                 jboolean) {
+  return odr_jni::guarded(env, [&]() -> jint { unsupported(); });
+}
+
 extern "C" JNIEXPORT void JNICALL
-Java_app_opendocument_core_HttpServer_listenNative(JNIEnv *env, jobject, jlong,
-                                                   jstring, jint) {
+Java_app_opendocument_core_HttpServer_listenNative(JNIEnv *env, jobject,
+                                                   jlong) {
   odr_jni::guarded(env, [&] { unsupported(); });
 }
 

--- a/jni/src/jni_http_server.cpp
+++ b/jni/src/jni_http_server.cpp
@@ -8,15 +8,12 @@
 #include <odr/html.hpp>
 #include <odr/http_server.hpp>
 
-#include <vector>
-
 namespace {
 
 using odr_jni::destroy_handle;
 using odr_jni::from_handle;
 using odr_jni::guarded;
 using odr_jni::make_handle;
-using odr_jni::to_jstring;
 using odr_jni::to_string;
 
 odr::HttpServer &server(jlong handle) {
@@ -30,25 +27,16 @@ Java_app_opendocument_core_Odr_hasHttpServer(JNIEnv *, jclass) {
   return JNI_TRUE;
 }
 
-extern "C" JNIEXPORT jlong JNICALL Java_app_opendocument_core_HttpServer_create(
-    JNIEnv *env, jclass, jstring cache_path) {
+extern "C" JNIEXPORT jlong JNICALL
+Java_app_opendocument_core_HttpServer_create(JNIEnv *env, jclass) {
   return guarded(env, [&] {
-    odr::HttpServer::Config config;
-    config.cache_path = to_string(env, cache_path);
-    return make_handle(odr::HttpServer(config));
+    return make_handle(odr::HttpServer(odr::HttpServer::Config{}));
   });
 }
 
 extern "C" JNIEXPORT void JNICALL
 Java_app_opendocument_core_HttpServer_destroy(JNIEnv *, jclass, jlong handle) {
   destroy_handle<odr::HttpServer>(handle);
-}
-
-extern "C" JNIEXPORT jstring JNICALL
-Java_app_opendocument_core_HttpServer_cachePathNative(JNIEnv *env, jobject,
-                                                      jlong handle) {
-  return guarded(
-      env, [&] { return to_jstring(env, server(handle).config().cache_path); });
 }
 
 extern "C" JNIEXPORT void JNICALL
@@ -59,31 +47,6 @@ Java_app_opendocument_core_HttpServer_connectServiceNative(JNIEnv *env, jobject,
   guarded(env, [&] {
     server(handle).connect_service(
         *from_handle<odr::HtmlService>(service_handle), to_string(env, prefix));
-  });
-}
-
-extern "C" JNIEXPORT jlongArray JNICALL
-Java_app_opendocument_core_HttpServer_serveFileNative(JNIEnv *env, jobject,
-                                                      jlong handle,
-                                                      jlong file_handle,
-                                                      jstring prefix,
-                                                      jobject config) {
-  return guarded(env, [&] {
-    const odr::HtmlViews views = server(handle).serve_file(
-        *from_handle<odr::DecodedFile>(file_handle), to_string(env, prefix),
-        odr_jni::html_config_from_java(env, config));
-    std::vector<jlong> handles;
-    handles.reserve(views.size());
-    for (const odr::HtmlView &view : views) {
-      handles.push_back(make_handle(odr::HtmlView(view)));
-    }
-    jlongArray result = env->NewLongArray(static_cast<jsize>(handles.size()));
-    if (result == nullptr) {
-      return jlongArray{};
-    }
-    env->SetLongArrayRegion(result, 0, static_cast<jsize>(handles.size()),
-                            handles.data());
-    return result;
   });
 }
 
@@ -138,31 +101,18 @@ Java_app_opendocument_core_Odr_hasHttpServer(JNIEnv *, jclass) {
 }
 
 extern "C" JNIEXPORT jlong JNICALL
-Java_app_opendocument_core_HttpServer_create(JNIEnv *env, jclass, jstring) {
+Java_app_opendocument_core_HttpServer_create(JNIEnv *env, jclass) {
   return odr_jni::guarded(env, [&]() -> jlong { unsupported(); });
 }
 
 extern "C" JNIEXPORT void JNICALL
 Java_app_opendocument_core_HttpServer_destroy(JNIEnv *, jclass, jlong) {}
 
-extern "C" JNIEXPORT jstring JNICALL
-Java_app_opendocument_core_HttpServer_cachePathNative(JNIEnv *env, jobject,
-                                                      jlong) {
-  return odr_jni::guarded(env, [&]() -> jstring { unsupported(); });
-}
-
 extern "C" JNIEXPORT void JNICALL
 Java_app_opendocument_core_HttpServer_connectServiceNative(JNIEnv *env, jobject,
                                                            jlong, jlong,
                                                            jstring) {
   odr_jni::guarded(env, [&] { unsupported(); });
-}
-
-extern "C" JNIEXPORT jlongArray JNICALL
-Java_app_opendocument_core_HttpServer_serveFileNative(JNIEnv *env, jobject,
-                                                      jlong, jlong, jstring,
-                                                      jobject) {
-  return odr_jni::guarded(env, [&]() -> jlongArray { unsupported(); });
 }
 
 extern "C" JNIEXPORT jint JNICALL

--- a/jni/src/jni_http_server.cpp
+++ b/jni/src/jni_http_server.cpp
@@ -29,9 +29,7 @@ Java_app_opendocument_core_Odr_hasHttpServer(JNIEnv *, jclass) {
 
 extern "C" JNIEXPORT jlong JNICALL
 Java_app_opendocument_core_HttpServer_create(JNIEnv *env, jclass) {
-  return guarded(env, [&] {
-    return make_handle(odr::HttpServer(odr::HttpServer::Config{}));
-  });
+  return guarded(env, [&] { return make_handle(odr::HttpServer()); });
 }
 
 extern "C" JNIEXPORT void JNICALL

--- a/jni/tests/app/opendocument/core/HttpServerTest.java
+++ b/jni/tests/app/opendocument/core/HttpServerTest.java
@@ -2,15 +2,17 @@ package app.opendocument.core;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNotEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.junit.jupiter.api.Assumptions.assumeTrue;
 
 import java.io.IOException;
 import java.io.InputStream;
 import java.net.HttpURLConnection;
-import java.net.ServerSocket;
 import java.net.URI;
 import java.nio.charset.StandardCharsets;
+import java.nio.file.Files;
 import java.nio.file.Path;
 import java.time.Duration;
 import java.util.List;
@@ -20,12 +22,6 @@ import org.junit.jupiter.api.io.TempDir;
 
 class HttpServerTest {
   @TempDir Path tempDir;
-
-  private static int freePort() throws IOException {
-    try (ServerSocket socket = new ServerSocket(0)) {
-      return socket.getLocalPort();
-    }
-  }
 
   private record Response(int status, String body) {}
 
@@ -74,13 +70,13 @@ class HttpServerTest {
     List<HtmlView> views = server.serveFile(file, "doc", htmlConfig);
     assertEquals(1, views.size());
 
-    int port = freePort();
+    int port = server.bind("127.0.0.1", 0);
     AtomicReference<Throwable> listenError = new AtomicReference<>();
     Thread thread =
         new Thread(
             () -> {
               try {
-                server.listen("127.0.0.1", port);
+                server.listen();
               } catch (Throwable t) {
                 listenError.set(t);
               }
@@ -102,5 +98,36 @@ class HttpServerTest {
       thread.join(Duration.ofSeconds(5).toMillis());
     }
     assertFalse(thread.isAlive());
+  }
+
+  @Test
+  void bindReportsWhatItGot() throws IOException {
+    assumeTrue(Odr.hasHttpServer(), "built without the HTTP server");
+
+    HttpServer.Config config = new HttpServer.Config();
+    config.cachePath = Files.createDirectories(tempDir.resolve("server-cache")).toString();
+    HttpServer server = new HttpServer(config);
+
+    // a literal address on purpose: "localhost" resolves to both ::1 and 127.0.0.1,
+    // so a second bind would land on the other one instead of colliding
+    int port = server.bind("127.0.0.1", 0);
+    assertNotEquals(0, port);
+
+    // a second bind would leak the first socket, so it is refused
+    assertThrows(RuntimeException.class, () -> server.bind("127.0.0.1", 0));
+
+    server.stop();
+  }
+
+  @Test
+  void listenWithoutBindThrows() throws IOException {
+    assumeTrue(Odr.hasHttpServer(), "built without the HTTP server");
+
+    HttpServer.Config config = new HttpServer.Config();
+    config.cachePath = Files.createDirectories(tempDir.resolve("server-cache")).toString();
+    HttpServer server = new HttpServer(config);
+
+    // cpp-httplib reports success for this, hence the guard being tested
+    assertThrows(RuntimeException.class, server::listen);
   }
 }

--- a/jni/tests/app/opendocument/core/HttpServerTest.java
+++ b/jni/tests/app/opendocument/core/HttpServerTest.java
@@ -59,7 +59,7 @@ class HttpServerTest {
     assumeTrue(Odr.hasHttpServer(), "built without the HTTP server");
     assumeTrue(TestFiles.hasCoreData(), "odr core data path not available");
 
-    HttpServer server = new HttpServer(new HttpServer.Config());
+    HttpServer server = new HttpServer();
 
     // the server hosts what it is given; translating is the caller's business
     String cachePath = Files.createDirectories(tempDir.resolve("doc-cache")).toString();
@@ -106,7 +106,7 @@ class HttpServerTest {
   void bindReportsWhatItGot() {
     assumeTrue(Odr.hasHttpServer(), "built without the HTTP server");
 
-    HttpServer server = new HttpServer(new HttpServer.Config());
+    HttpServer server = new HttpServer();
 
     // a literal address on purpose: "localhost" resolves to both ::1 and 127.0.0.1,
     // so a second bind would land on the other one instead of colliding
@@ -123,7 +123,7 @@ class HttpServerTest {
   void listenWithoutBindThrows() {
     assumeTrue(Odr.hasHttpServer(), "built without the HTTP server");
 
-    HttpServer server = new HttpServer(new HttpServer.Config());
+    HttpServer server = new HttpServer();
 
     // cpp-httplib reports success for this, hence the guard being tested
     assertThrows(RuntimeException.class, server::listen);

--- a/jni/tests/app/opendocument/core/HttpServerTest.java
+++ b/jni/tests/app/opendocument/core/HttpServerTest.java
@@ -59,15 +59,17 @@ class HttpServerTest {
     assumeTrue(Odr.hasHttpServer(), "built without the HTTP server");
     assumeTrue(TestFiles.hasCoreData(), "odr core data path not available");
 
-    HttpServer.Config config = new HttpServer.Config();
-    config.cachePath = tempDir.resolve("server-cache").toString();
-    HttpServer server = new HttpServer(config);
+    HttpServer server = new HttpServer(new HttpServer.Config());
 
+    // the server hosts what it is given; translating is the caller's business
+    String cachePath = Files.createDirectories(tempDir.resolve("doc-cache")).toString();
     DecodedFile file = Odr.open(TestFiles.odtFile(tempDir).toString());
     HtmlConfig htmlConfig = new HtmlConfig();
     htmlConfig.embedImages = false;
     htmlConfig.relativeResourcePaths = false;
-    List<HtmlView> views = server.serveFile(file, "doc", htmlConfig);
+    HtmlService service = Html.translate(file, cachePath, htmlConfig);
+    server.connectService(service, "doc");
+    List<HtmlView> views = service.listViews();
     assertEquals(1, views.size());
 
     int port = server.bind("127.0.0.1", 0);
@@ -101,12 +103,10 @@ class HttpServerTest {
   }
 
   @Test
-  void bindReportsWhatItGot() throws IOException {
+  void bindReportsWhatItGot() {
     assumeTrue(Odr.hasHttpServer(), "built without the HTTP server");
 
-    HttpServer.Config config = new HttpServer.Config();
-    config.cachePath = Files.createDirectories(tempDir.resolve("server-cache")).toString();
-    HttpServer server = new HttpServer(config);
+    HttpServer server = new HttpServer(new HttpServer.Config());
 
     // a literal address on purpose: "localhost" resolves to both ::1 and 127.0.0.1,
     // so a second bind would land on the other one instead of colliding
@@ -120,12 +120,10 @@ class HttpServerTest {
   }
 
   @Test
-  void listenWithoutBindThrows() throws IOException {
+  void listenWithoutBindThrows() {
     assumeTrue(Odr.hasHttpServer(), "built without the HTTP server");
 
-    HttpServer.Config config = new HttpServer.Config();
-    config.cachePath = Files.createDirectories(tempDir.resolve("server-cache")).toString();
-    HttpServer server = new HttpServer(config);
+    HttpServer server = new HttpServer(new HttpServer.Config());
 
     // cpp-httplib reports success for this, hence the guard being tested
     assertThrows(RuntimeException.class, server::listen);

--- a/python/src/bind_http_server.cpp
+++ b/python/src/bind_http_server.cpp
@@ -14,9 +14,12 @@ void odr_python::bind_http_server(py::module_ &m) {
   py::class_<odr::HttpServer> server(m, "HttpServer",
                                      "Serves translated files over HTTP.");
 
-  py::class_<odr::HttpServer::Config>(server, "Config")
-      .def(py::init<>())
-      .def_readwrite("cache_path", &odr::HttpServer::Config::cache_path);
+  py::class_<odr::HttpServer::Config>(
+      server, "Config",
+      "Server-wide settings. Empty since the cache path went with "
+      "`serve_file`: "
+      "what a service was translated into belongs to whoever translated it.")
+      .def(py::init<>());
 
   py::class_<odr::HttpServer::Options>(server, "Options",
                                        "Socket options for `bind`.")
@@ -29,13 +32,8 @@ void odr_python::bind_http_server(py::module_ &m) {
              return odr::HttpServer(config);
            }),
            py::arg("config"))
-      .def("config", &odr::HttpServer::config)
       .def("connect_service", &odr::HttpServer::connect_service,
            py::arg("service"), py::arg("prefix"))
-      .def("serve_file", &odr::HttpServer::serve_file, py::arg("file"),
-           py::arg("prefix"), py::arg("config"),
-           "Translate a decoded file and host it under "
-           "`/file/<prefix>/<view path>`; returns the views.")
       .def(
           "bind",
           [](const odr::HttpServer &self, const std::string &host,

--- a/python/src/bind_http_server.cpp
+++ b/python/src/bind_http_server.cpp
@@ -31,7 +31,7 @@ void odr_python::bind_http_server(py::module_ &m) {
       .def(py::init([](const odr::HttpServer::Config &config) {
              return odr::HttpServer(config);
            }),
-           py::arg("config"))
+           py::arg("config") = odr::HttpServer::Config{})
       .def("connect_service", &odr::HttpServer::connect_service,
            py::arg("service"), py::arg("prefix"))
       .def(

--- a/python/src/bind_http_server.cpp
+++ b/python/src/bind_http_server.cpp
@@ -18,6 +18,12 @@ void odr_python::bind_http_server(py::module_ &m) {
       .def(py::init<>())
       .def_readwrite("cache_path", &odr::HttpServer::Config::cache_path);
 
+  py::class_<odr::HttpServer::Options>(server, "Options",
+                                       "Socket options for `bind`.")
+      .def(py::init<>())
+      .def_readwrite("reuse_address", &odr::HttpServer::Options::reuse_address)
+      .def_readwrite("reuse_port", &odr::HttpServer::Options::reuse_port);
+
   server
       .def(py::init([](const odr::HttpServer::Config &config) {
              return odr::HttpServer(config);
@@ -30,9 +36,20 @@ void odr_python::bind_http_server(py::module_ &m) {
            py::arg("prefix"), py::arg("config"),
            "Translate a decoded file and host it under "
            "`/file/<prefix>/<view path>`; returns the views.")
+      .def(
+          "bind",
+          [](const odr::HttpServer &self, const std::string &host,
+             const std::uint32_t port,
+             const odr::HttpServer::Options &options) {
+            return self.bind(host, port, options);
+          },
+          py::arg("host"), py::arg("port"),
+          py::arg("options") = odr::HttpServer::Options{},
+          "Bind the socket, `port` 0 for any free one; returns the port it "
+          "got. Connections are accepted from here on, before `listen` runs.")
       // Release the GIL: `listen` blocks and `stop` must remain callable from
       // other Python threads.
-      .def("listen", &odr::HttpServer::listen, py::arg("host"), py::arg("port"),
+      .def("listen", &odr::HttpServer::listen,
            py::call_guard<py::gil_scoped_release>())
       .def("clear", &odr::HttpServer::clear)
       .def("stop", &odr::HttpServer::stop,

--- a/python/tests/test_http_server.py
+++ b/python/tests/test_http_server.py
@@ -21,7 +21,7 @@ def fetch(url, timeout=5.0):
 
 @pytest.mark.skipif(not pyodr.has_http_server, reason="built without the HTTP server")
 def test_serve_file(core_data_path, odt_path, tmp_path):
-    server = pyodr.HttpServer(pyodr.HttpServer.Config())
+    server = pyodr.HttpServer()
 
     # the server hosts what it is given; translating is the caller's business
     cache_path = tmp_path / "doc-cache"
@@ -50,7 +50,7 @@ def test_serve_file(core_data_path, odt_path, tmp_path):
 
 @pytest.mark.skipif(not pyodr.has_http_server, reason="built without the HTTP server")
 def test_bind_reports_what_it_got():
-    server = pyodr.HttpServer(pyodr.HttpServer.Config())
+    server = pyodr.HttpServer()
 
     port = server.bind("127.0.0.1", 0)
     assert port != 0
@@ -64,23 +64,22 @@ def test_bind_reports_what_it_got():
 
 @pytest.mark.skipif(not pyodr.has_http_server, reason="built without the HTTP server")
 def test_bind_reports_a_port_in_use():
-    taken = pyodr.HttpServer(pyodr.HttpServer.Config())
+    taken = pyodr.HttpServer()
     # a literal address on purpose: "localhost" resolves to both ::1 and
     # 127.0.0.1, so a second bind lands on the other one instead of colliding
     port = taken.bind("127.0.0.1", 0)
 
-    other = pyodr.HttpServer(pyodr.HttpServer.Config())
-    options = pyodr.HttpServer.Options()
-    options.reuse_port = False  # or the two would share the port
+    other = pyodr.HttpServer()
+    # reuse_port defaults off, or the two would share the port
     with pytest.raises(RuntimeError):
-        other.bind("127.0.0.1", port, options)
+        other.bind("127.0.0.1", port)
 
     taken.stop()
 
 
 @pytest.mark.skipif(not pyodr.has_http_server, reason="built without the HTTP server")
 def test_listen_without_bind_raises():
-    server = pyodr.HttpServer(pyodr.HttpServer.Config())
+    server = pyodr.HttpServer()
 
     # cpp-httplib reports success for this, hence the guard being tested
     with pytest.raises(RuntimeError):

--- a/python/tests/test_http_server.py
+++ b/python/tests/test_http_server.py
@@ -21,15 +21,18 @@ def fetch(url, timeout=5.0):
 
 @pytest.mark.skipif(not pyodr.has_http_server, reason="built without the HTTP server")
 def test_serve_file(core_data_path, odt_path, tmp_path):
-    config = pyodr.HttpServer.Config()
-    config.cache_path = str(tmp_path / "server-cache")
-    server = pyodr.HttpServer(config)
+    server = pyodr.HttpServer(pyodr.HttpServer.Config())
 
+    # the server hosts what it is given; translating is the caller's business
+    cache_path = tmp_path / "doc-cache"
+    cache_path.mkdir()
     file = pyodr.open(str(odt_path))
     html_config = pyodr.HtmlConfig()
     html_config.embed_images = False
     html_config.relative_resource_paths = False
-    views = server.serve_file(file, "doc", html_config)
+    service = pyodr.html.translate(file, str(cache_path), html_config)
+    server.connect_service(service, "doc")
+    views = service.list_views()
     assert len(views) == 1
 
     port = server.bind("localhost", 0)
@@ -46,12 +49,8 @@ def test_serve_file(core_data_path, odt_path, tmp_path):
 
 
 @pytest.mark.skipif(not pyodr.has_http_server, reason="built without the HTTP server")
-def test_bind_reports_what_it_got(tmp_path):
-    config = pyodr.HttpServer.Config()
-    cache_path = tmp_path / "server-cache"
-    cache_path.mkdir()
-    config.cache_path = str(cache_path)
-    server = pyodr.HttpServer(config)
+def test_bind_reports_what_it_got():
+    server = pyodr.HttpServer(pyodr.HttpServer.Config())
 
     port = server.bind("127.0.0.1", 0)
     assert port != 0
@@ -64,17 +63,13 @@ def test_bind_reports_what_it_got(tmp_path):
 
 
 @pytest.mark.skipif(not pyodr.has_http_server, reason="built without the HTTP server")
-def test_bind_reports_a_port_in_use(tmp_path):
-    config = pyodr.HttpServer.Config()
-    cache_path = tmp_path / "server-cache"
-    cache_path.mkdir()
-    config.cache_path = str(cache_path)
-    taken = pyodr.HttpServer(config)
+def test_bind_reports_a_port_in_use():
+    taken = pyodr.HttpServer(pyodr.HttpServer.Config())
     # a literal address on purpose: "localhost" resolves to both ::1 and
     # 127.0.0.1, so a second bind lands on the other one instead of colliding
     port = taken.bind("127.0.0.1", 0)
 
-    other = pyodr.HttpServer(config)
+    other = pyodr.HttpServer(pyodr.HttpServer.Config())
     options = pyodr.HttpServer.Options()
     options.reuse_port = False  # or the two would share the port
     with pytest.raises(RuntimeError):
@@ -84,12 +79,8 @@ def test_bind_reports_a_port_in_use(tmp_path):
 
 
 @pytest.mark.skipif(not pyodr.has_http_server, reason="built without the HTTP server")
-def test_listen_without_bind_raises(tmp_path):
-    config = pyodr.HttpServer.Config()
-    cache_path = tmp_path / "server-cache"
-    cache_path.mkdir()
-    config.cache_path = str(cache_path)
-    server = pyodr.HttpServer(config)
+def test_listen_without_bind_raises():
+    server = pyodr.HttpServer(pyodr.HttpServer.Config())
 
     # cpp-httplib reports success for this, hence the guard being tested
     with pytest.raises(RuntimeError):

--- a/python/tests/test_http_server.py
+++ b/python/tests/test_http_server.py
@@ -1,4 +1,3 @@
-import socket
 import threading
 import time
 import urllib.request
@@ -6,12 +5,6 @@ import urllib.request
 import pytest
 
 import pyodr
-
-
-def free_port():
-    with socket.socket() as sock:
-        sock.bind(("localhost", 0))
-        return sock.getsockname()[1]
 
 
 def fetch(url, timeout=5.0):
@@ -39,10 +32,8 @@ def test_serve_file(core_data_path, odt_path, tmp_path):
     views = server.serve_file(file, "doc", html_config)
     assert len(views) == 1
 
-    port = free_port()
-    thread = threading.Thread(
-        target=server.listen, args=("localhost", port), daemon=True
-    )
+    port = server.bind("localhost", 0)
+    thread = threading.Thread(target=server.listen, daemon=True)
     thread.start()
     try:
         status, body = fetch(f"http://localhost:{port}/file/doc/{views[0].path()}")
@@ -52,3 +43,54 @@ def test_serve_file(core_data_path, odt_path, tmp_path):
         server.stop()
         thread.join(timeout=5.0)
     assert not thread.is_alive()
+
+
+@pytest.mark.skipif(not pyodr.has_http_server, reason="built without the HTTP server")
+def test_bind_reports_what_it_got(tmp_path):
+    config = pyodr.HttpServer.Config()
+    cache_path = tmp_path / "server-cache"
+    cache_path.mkdir()
+    config.cache_path = str(cache_path)
+    server = pyodr.HttpServer(config)
+
+    port = server.bind("127.0.0.1", 0)
+    assert port != 0
+
+    # a second bind would leak the first socket, so it is refused
+    with pytest.raises(RuntimeError):
+        server.bind("127.0.0.1", 0)
+
+    server.stop()
+
+
+@pytest.mark.skipif(not pyodr.has_http_server, reason="built without the HTTP server")
+def test_bind_reports_a_port_in_use(tmp_path):
+    config = pyodr.HttpServer.Config()
+    cache_path = tmp_path / "server-cache"
+    cache_path.mkdir()
+    config.cache_path = str(cache_path)
+    taken = pyodr.HttpServer(config)
+    # a literal address on purpose: "localhost" resolves to both ::1 and
+    # 127.0.0.1, so a second bind lands on the other one instead of colliding
+    port = taken.bind("127.0.0.1", 0)
+
+    other = pyodr.HttpServer(config)
+    options = pyodr.HttpServer.Options()
+    options.reuse_port = False  # or the two would share the port
+    with pytest.raises(RuntimeError):
+        other.bind("127.0.0.1", port, options)
+
+    taken.stop()
+
+
+@pytest.mark.skipif(not pyodr.has_http_server, reason="built without the HTTP server")
+def test_listen_without_bind_raises(tmp_path):
+    config = pyodr.HttpServer.Config()
+    cache_path = tmp_path / "server-cache"
+    cache_path.mkdir()
+    config.cache_path = str(cache_path)
+    server = pyodr.HttpServer(config)
+
+    # cpp-httplib reports success for this, hence the guard being tested
+    with pytest.raises(RuntimeError):
+        server.listen()

--- a/src/odr/exceptions.cpp
+++ b/src/odr/exceptions.cpp
@@ -113,6 +113,16 @@ PrefixInUse::PrefixInUse() : std::runtime_error("prefix in use") {}
 PrefixInUse::PrefixInUse(const std::string &prefix)
     : std::runtime_error("prefix in use: " + prefix) {}
 
+ServerBindFailed::ServerBindFailed(const std::string &host,
+                                   const std::uint32_t port)
+    : std::runtime_error("server bind failed: " + host + ":" +
+                         std::to_string(port)) {}
+
+ServerAlreadyBound::ServerAlreadyBound()
+    : std::runtime_error("server is bound already") {}
+
+ServerNotBound::ServerNotBound() : std::runtime_error("server is not bound") {}
+
 UnsupportedOption::UnsupportedOption(const std::string &message)
     : std::runtime_error("unsupported option: " + message) {}
 

--- a/src/odr/exceptions.hpp
+++ b/src/odr/exceptions.hpp
@@ -1,5 +1,6 @@
 #pragma once
 
+#include <cstdint>
 #include <stdexcept>
 
 namespace odr {
@@ -193,6 +194,21 @@ struct ResourceNotAccessible final : std::runtime_error {
 struct PrefixInUse final : std::runtime_error {
   PrefixInUse();
   explicit PrefixInUse(const std::string &prefix);
+};
+
+/// @brief HTTP server socket could not be bound
+struct ServerBindFailed final : std::runtime_error {
+  ServerBindFailed(const std::string &host, std::uint32_t port);
+};
+
+/// @brief HTTP server is bound already
+struct ServerAlreadyBound final : std::runtime_error {
+  ServerAlreadyBound();
+};
+
+/// @brief HTTP server has not been bound
+struct ServerNotBound final : std::runtime_error {
+  ServerNotBound();
 };
 
 /// @brief Unsupported option

--- a/src/odr/http_server.cpp
+++ b/src/odr/http_server.cpp
@@ -304,11 +304,6 @@ void HttpServer::connect_service(HtmlService service,
 }
 
 std::uint32_t HttpServer::bind(const std::string &host,
-                               const std::uint32_t port) const {
-  return bind(host, port, Options{});
-}
-
-std::uint32_t HttpServer::bind(const std::string &host,
                                const std::uint32_t port,
                                const Options &options) const {
   return m_impl->bind(host, port, options);

--- a/src/odr/http_server.cpp
+++ b/src/odr/http_server.cpp
@@ -7,15 +7,14 @@
 #include <httplib/httplib.h>
 
 #include <atomic>
-#include <filesystem>
 #include <sstream>
 
 namespace odr {
 
 class HttpServer::Impl {
 public:
-  Impl(Config config, std::shared_ptr<Logger> logger)
-      : m_config{std::move(config)}, m_logger{std::move(logger)},
+  explicit Impl(std::shared_ptr<Logger> logger)
+      : m_logger{std::move(logger)},
         m_server{std::make_unique<httplib::Server>()} {
     // Set up exception handler to catch any internal httplib exceptions.
     // This prevents crashes when exceptions occur during request processing.
@@ -81,10 +80,6 @@ public:
   // Prevent copying - the lambdas capture 'this' so copying would be unsafe
   Impl(const Impl &) = delete;
   Impl &operator=(const Impl &) = delete;
-
-  const Config &config() const { return m_config; }
-
-  const std::shared_ptr<Logger> &logger() const { return m_logger; }
 
   void serve_file(const httplib::Request &req, httplib::Response &res) {
     try {
@@ -169,6 +164,14 @@ public:
       throw ServerAlreadyBound();
     }
 
+#ifdef _WIN32
+    // Windows keeps cpp-httplib's defaults, which set SO_EXCLUSIVEADDRUSE
+    // alongside SO_REUSEADDR. The two flags mean the opposite of what they do
+    // below: there SO_REUSEADDR lets a second live socket take the endpoint
+    // over, and SO_EXCLUSIVEADDRUSE is what keeps it ours. Replacing that with
+    // the posix mapping would hand the port away, so Options does not apply.
+    static_cast<void>(options);
+#else
     // cpp-httplib's default sets SO_REUSEPORT where it exists and SO_REUSEADDR
     // only otherwise, which is the wrong way round for a server that gets
     // restarted: only SO_REUSEADDR lets a port held by TIME_WAIT sockets be
@@ -188,6 +191,7 @@ public:
       }
 #endif
     });
+#endif
 
     const int bound =
         port == 0 ? m_server->bind_to_any_port(host)
@@ -218,16 +222,11 @@ public:
   }
 
   void clear() {
-    ODR_VERBOSE(*m_logger, "Clearing HTTP server cache...");
+    ODR_VERBOSE(*m_logger, "Dropping connected services...");
 
     std::unique_lock lock{m_mutex};
 
     m_content.clear();
-
-    for (const auto &entry :
-         std::filesystem::directory_iterator(m_config.cache_path)) {
-      std::filesystem::remove_all(entry.path());
-    }
   }
 
   void stop() {
@@ -254,8 +253,6 @@ public:
   }
 
 private:
-  Config m_config;
-
   std::shared_ptr<Logger> m_logger;
 
   // Flag to indicate server is shutting down - checked by handlers
@@ -283,12 +280,9 @@ private:
   std::unique_ptr<httplib::Server> m_server;
 };
 
-HttpServer::HttpServer(const Config &config, std::shared_ptr<Logger> logger)
-    : m_impl{std::make_unique<Impl>(config, std::move(logger))} {}
-
-const HttpServer::Config &HttpServer::config() const {
-  return m_impl->config();
-}
+HttpServer::HttpServer(const Config & /*config*/,
+                       std::shared_ptr<Logger> logger)
+    : m_impl{std::make_unique<Impl>(std::move(logger))} {}
 
 void HttpServer::connect_service(HtmlService service,
                                  const std::string &prefix) const {
@@ -307,20 +301,6 @@ void HttpServer::connect_service(HtmlService service,
   }
 
   m_impl->connect_service(std::move(service), prefix);
-}
-
-HtmlViews HttpServer::serve_file(const DecodedFile &file,
-                                 const std::string &prefix,
-                                 const HtmlConfig &config) const {
-  const std::string cache_path = m_impl->config().cache_path + "/" + prefix;
-  std::filesystem::create_directories(cache_path);
-
-  const HtmlService service =
-      html::translate(file, cache_path, config, m_impl->logger());
-
-  connect_service(service, prefix);
-
-  return service.list_views();
 }
 
 std::uint32_t HttpServer::bind(const std::string &host,

--- a/src/odr/http_server.cpp
+++ b/src/odr/http_server.cpp
@@ -158,10 +158,63 @@ public:
     m_content.emplace(prefix, Content{prefix, std::move(service)});
   }
 
-  void listen(const std::string &host, const std::uint32_t port) const {
-    ODR_VERBOSE(*m_logger, "Listening on " << host << ":" << port);
+  std::uint32_t bind(const std::string &host, const std::uint32_t port,
+                     const Options &options) {
+    if (m_server == nullptr) {
+      throw ServerNotBound();
+    }
+    // binding twice would overwrite the socket cpp-httplib holds, leaking the
+    // first one and its port for good
+    if (m_bound.load(std::memory_order_acquire)) {
+      throw ServerAlreadyBound();
+    }
 
-    m_server->listen(host, static_cast<int>(port));
+    // cpp-httplib's default sets SO_REUSEPORT where it exists and SO_REUSEADDR
+    // only otherwise, which is the wrong way round for a server that gets
+    // restarted: only SO_REUSEADDR lets a port held by TIME_WAIT sockets be
+    // bound again, while SO_REUSEPORT hands a second server a share of the
+    // connections instead.
+    // socket_t is not in the httplib namespace in every version, hence auto
+    m_server->set_socket_options([options](const auto sock) {
+      constexpr int yes = 1;
+      const auto *const value = reinterpret_cast<const char *>(&yes);
+
+      if (options.reuse_address) {
+        setsockopt(sock, SOL_SOCKET, SO_REUSEADDR, value, sizeof(yes));
+      }
+#ifdef SO_REUSEPORT
+      if (options.reuse_port) {
+        setsockopt(sock, SOL_SOCKET, SO_REUSEPORT, value, sizeof(yes));
+      }
+#endif
+    });
+
+    const int bound =
+        port == 0 ? m_server->bind_to_any_port(host)
+                  : (m_server->bind_to_port(host, static_cast<int>(port))
+                         ? static_cast<int>(port)
+                         : -1);
+    if (bound < 0) {
+      throw ServerBindFailed(host, port);
+    }
+
+    m_bound.store(true, std::memory_order_release);
+
+    ODR_VERBOSE(*m_logger, "Bound to " << host << ":" << bound);
+
+    return static_cast<std::uint32_t>(bound);
+  }
+
+  void listen() const {
+    // cpp-httplib's listen_after_bind() reports success for a server that was
+    // never bound, so the state has to be checked here
+    if (m_server == nullptr || !m_bound.load(std::memory_order_acquire)) {
+      throw ServerNotBound();
+    }
+
+    ODR_VERBOSE(*m_logger, "Serving...");
+
+    m_server->listen_after_bind();
   }
 
   void clear() {
@@ -194,6 +247,8 @@ public:
       m_server.reset(); // Destroy server, join all thread pool threads
     }
 
+    m_bound.store(false, std::memory_order_release);
+
     // Clear content after server is fully destroyed to avoid use-after-free.
     clear();
   }
@@ -206,6 +261,10 @@ private:
   // Flag to indicate server is shutting down - checked by handlers
   // to reject new requests during shutdown.
   std::atomic<bool> m_stopping{false};
+
+  // Whether bind() has taken a socket. listen() needs it because cpp-httplib
+  // will happily "serve" a server that never bound one.
+  std::atomic<bool> m_bound{false};
 
   struct Content {
     std::string id;
@@ -264,10 +323,18 @@ HtmlViews HttpServer::serve_file(const DecodedFile &file,
   return service.list_views();
 }
 
-void HttpServer::listen(const std::string &host,
-                        const std::uint32_t port) const {
-  m_impl->listen(host, port);
+std::uint32_t HttpServer::bind(const std::string &host,
+                               const std::uint32_t port) const {
+  return bind(host, port, Options{});
 }
+
+std::uint32_t HttpServer::bind(const std::string &host,
+                               const std::uint32_t port,
+                               const Options &options) const {
+  return m_impl->bind(host, port, options);
+}
+
+void HttpServer::listen() const { m_impl->listen(); }
 
 void HttpServer::clear() const { m_impl->clear(); }
 

--- a/src/odr/http_server.hpp
+++ b/src/odr/http_server.hpp
@@ -17,9 +17,19 @@ class HttpServer {
 public:
   constexpr static auto prefix_pattern = R"(([a-zA-Z0-9_-]+))";
 
+  // TODO remove together with serve_file, which is all cache_path is for
   struct Config {
     // TODO remove
     std::string cache_path{"/tmp/odr"};
+  };
+
+  /// Socket options for bind().
+  struct Options {
+    bool reuse_address{true}; ///< SO_REUSEADDR, so a port held only by sockets
+                              ///< in TIME_WAIT can be bound again
+    bool reuse_port{false};   ///< SO_REUSEPORT where the platform has it. Two
+                              ///< live servers on one port share the incoming
+                              ///< connections between them, hence off
   };
 
   explicit HttpServer(const Config &config,
@@ -34,10 +44,21 @@ public:
                                      const std::string &prefix,
                                      const HtmlConfig &config) const;
 
-  void listen(const std::string &host, std::uint32_t port) const;
+  /// Binds the socket and returns the port it got - pass port 0 for any free
+  /// one. Connections are accepted into the backlog from here on, before
+  /// listen() runs. Throws ServerBindFailed / ServerAlreadyBound.
+  std::uint32_t bind(const std::string &host, std::uint32_t port) const;
+  std::uint32_t bind(const std::string &host, std::uint32_t port,
+                     const Options &options) const;
+
+  /// Serves what bind() opened until stop(). Throws ServerNotBound.
+  void listen() const;
 
   void clear() const;
 
+  /// Stops listen() and releases the socket. A server that was bound but never
+  /// listened keeps its port until the process ends - cpp-httplib only closes
+  /// the socket from its accept loop.
   void stop() const;
 
 private:

--- a/src/odr/http_server.hpp
+++ b/src/odr/http_server.hpp
@@ -17,13 +17,12 @@ class HttpServer {
 public:
   constexpr static auto prefix_pattern = R"(([a-zA-Z0-9_-]+))";
 
-  // TODO remove together with serve_file, which is all cache_path is for
-  struct Config {
-    // TODO remove
-    std::string cache_path{"/tmp/odr"};
-  };
+  /// Server-wide settings. Empty since cache_path went with serve_file: what a
+  /// service was translated into belongs to whoever translated it.
+  struct Config {};
 
-  /// Socket options for bind().
+  /// Socket options for bind(). POSIX only: Windows keeps cpp-httplib's
+  /// exclusive-address defaults, where these flags mean the opposite.
   struct Options {
     bool reuse_address{true}; ///< SO_REUSEADDR, so a port held only by sockets
                               ///< in TIME_WAIT can be bound again
@@ -35,14 +34,7 @@ public:
   explicit HttpServer(const Config &config,
                       std::shared_ptr<Logger> logger = Logger::create_null());
 
-  [[nodiscard]] const Config &config() const;
-
   void connect_service(HtmlService service, const std::string &prefix) const;
-
-  // TODO remove
-  [[nodiscard]] HtmlViews serve_file(const DecodedFile &file,
-                                     const std::string &prefix,
-                                     const HtmlConfig &config) const;
 
   /// Binds the socket and returns the port it got - pass port 0 for any free
   /// one. Connections are accepted into the backlog from here on, before
@@ -54,6 +46,8 @@ public:
   /// Serves what bind() opened until stop(). Throws ServerNotBound.
   void listen() const;
 
+  /// Drops the connected services. Files they were translated into are the
+  /// caller's, and are left alone.
   void clear() const;
 
   /// Stops listen() and releases the socket. A server that was bound but never

--- a/src/odr/http_server.hpp
+++ b/src/odr/http_server.hpp
@@ -13,25 +13,33 @@ class Filesystem;
 struct HtmlConfig;
 class HtmlService;
 
+/// Server-wide settings for HttpServer. Empty since cache_path went with
+/// serve_file: what a service was translated into belongs to whoever
+/// translated it.
+struct HttpServerConfig {};
+
+/// Socket options for HttpServer::bind(). POSIX only: Windows keeps
+/// cpp-httplib's exclusive-address defaults, where these flags mean the
+/// opposite.
+struct HttpServerOptions {
+  bool reuse_address{true}; ///< SO_REUSEADDR, so a port held only by sockets in
+                            ///< TIME_WAIT can be bound again
+  bool reuse_port{false};   ///< SO_REUSEPORT where the platform has it. Two
+                            ///< live servers on one port share the incoming
+                            ///< connections between them, hence off
+};
+
 class HttpServer {
 public:
   constexpr static auto prefix_pattern = R"(([a-zA-Z0-9_-]+))";
 
-  /// Server-wide settings. Empty since cache_path went with serve_file: what a
-  /// service was translated into belongs to whoever translated it.
-  struct Config {};
+  // at namespace scope, like HtmlConfig, so both can be defaulted with `= {}`
+  // below: a nested class's member initializers are not parsed until the
+  // enclosing class is complete, which a default argument here cannot wait for
+  using Config = HttpServerConfig;
+  using Options = HttpServerOptions;
 
-  /// Socket options for bind(). POSIX only: Windows keeps cpp-httplib's
-  /// exclusive-address defaults, where these flags mean the opposite.
-  struct Options {
-    bool reuse_address{true}; ///< SO_REUSEADDR, so a port held only by sockets
-                              ///< in TIME_WAIT can be bound again
-    bool reuse_port{false};   ///< SO_REUSEPORT where the platform has it. Two
-                              ///< live servers on one port share the incoming
-                              ///< connections between them, hence off
-  };
-
-  explicit HttpServer(const Config &config,
+  explicit HttpServer(const Config &config = {},
                       std::shared_ptr<Logger> logger = Logger::create_null());
 
   void connect_service(HtmlService service, const std::string &prefix) const;
@@ -39,9 +47,8 @@ public:
   /// Binds the socket and returns the port it got - pass port 0 for any free
   /// one. Connections are accepted into the backlog from here on, before
   /// listen() runs. Throws ServerBindFailed / ServerAlreadyBound.
-  std::uint32_t bind(const std::string &host, std::uint32_t port) const;
   std::uint32_t bind(const std::string &host, std::uint32_t port,
-                     const Options &options) const;
+                     const Options &options = {}) const;
 
   /// Serves what bind() opened until stop(). Throws ServerNotBound.
   void listen() const;

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -82,6 +82,12 @@ add_executable(odr_test
         "src/internal/zip/miniz_test.cpp"
         "src/internal/zip/zip_archive_test.cpp"
 )
+if (ODR_WITH_HTTP_SERVER)
+    target_sources(odr_test
+            PRIVATE
+            "src/http_server_test.cpp"
+    )
+endif ()
 target_include_directories(odr_test
         PRIVATE
         "src"

--- a/test/src/http_server_test.cpp
+++ b/test/src/http_server_test.cpp
@@ -8,7 +8,7 @@
 using namespace odr;
 
 TEST(HttpServer, bind_reports_the_port_it_got) {
-  const HttpServer server(HttpServer::Config{});
+  const HttpServer server;
 
   const std::uint32_t port = server.bind("127.0.0.1", 0);
   EXPECT_NE(port, 0);
@@ -17,7 +17,7 @@ TEST(HttpServer, bind_reports_the_port_it_got) {
 }
 
 TEST(HttpServer, bind_twice_is_refused) {
-  const HttpServer server(HttpServer::Config{});
+  const HttpServer server;
 
   server.bind("127.0.0.1", 0);
   // a second bind would replace the socket cpp-httplib holds, leaking the first
@@ -28,19 +28,18 @@ TEST(HttpServer, bind_twice_is_refused) {
 }
 
 TEST(HttpServer, bind_reports_a_port_in_use) {
-  const HttpServer taken(HttpServer::Config{});
+  const HttpServer taken;
   const std::uint32_t port = taken.bind("127.0.0.1", 0);
 
-  const HttpServer other(HttpServer::Config{});
-  HttpServer::Options options;
-  options.reuse_port = false; // or the two would share the port
-  EXPECT_THROW(other.bind("127.0.0.1", port, options), ServerBindFailed);
+  const HttpServer other;
+  // reuse_port defaults off, or the two would share the port
+  EXPECT_THROW(other.bind("127.0.0.1", port), ServerBindFailed);
 
   taken.stop();
 }
 
 TEST(HttpServer, listen_without_bind_is_refused) {
-  const HttpServer server(HttpServer::Config{});
+  const HttpServer server;
 
   // cpp-httplib's listen_after_bind() reports success for this
   EXPECT_THROW(server.listen(), ServerNotBound);

--- a/test/src/http_server_test.cpp
+++ b/test/src/http_server_test.cpp
@@ -4,23 +4,11 @@
 #include <gtest/gtest.h>
 
 #include <cstdint>
-#include <filesystem>
 
 using namespace odr;
 
-namespace {
-
-HttpServer::Config test_config(const std::string &name) {
-  HttpServer::Config config;
-  config.cache_path = (std::filesystem::temp_directory_path() / name).string();
-  std::filesystem::create_directories(config.cache_path);
-  return config;
-}
-
-} // namespace
-
 TEST(HttpServer, bind_reports_the_port_it_got) {
-  const HttpServer server(test_config("odr-http-server-test-any-port"));
+  const HttpServer server(HttpServer::Config{});
 
   const std::uint32_t port = server.bind("127.0.0.1", 0);
   EXPECT_NE(port, 0);
@@ -29,7 +17,7 @@ TEST(HttpServer, bind_reports_the_port_it_got) {
 }
 
 TEST(HttpServer, bind_twice_is_refused) {
-  const HttpServer server(test_config("odr-http-server-test-twice"));
+  const HttpServer server(HttpServer::Config{});
 
   server.bind("127.0.0.1", 0);
   // a second bind would replace the socket cpp-httplib holds, leaking the first
@@ -40,10 +28,10 @@ TEST(HttpServer, bind_twice_is_refused) {
 }
 
 TEST(HttpServer, bind_reports_a_port_in_use) {
-  const HttpServer taken(test_config("odr-http-server-test-taken"));
+  const HttpServer taken(HttpServer::Config{});
   const std::uint32_t port = taken.bind("127.0.0.1", 0);
 
-  const HttpServer other(test_config("odr-http-server-test-other"));
+  const HttpServer other(HttpServer::Config{});
   HttpServer::Options options;
   options.reuse_port = false; // or the two would share the port
   EXPECT_THROW(other.bind("127.0.0.1", port, options), ServerBindFailed);
@@ -52,7 +40,7 @@ TEST(HttpServer, bind_reports_a_port_in_use) {
 }
 
 TEST(HttpServer, listen_without_bind_is_refused) {
-  const HttpServer server(test_config("odr-http-server-test-unbound"));
+  const HttpServer server(HttpServer::Config{});
 
   // cpp-httplib's listen_after_bind() reports success for this
   EXPECT_THROW(server.listen(), ServerNotBound);

--- a/test/src/http_server_test.cpp
+++ b/test/src/http_server_test.cpp
@@ -1,0 +1,59 @@
+#include <odr/exceptions.hpp>
+#include <odr/http_server.hpp>
+
+#include <gtest/gtest.h>
+
+#include <cstdint>
+#include <filesystem>
+
+using namespace odr;
+
+namespace {
+
+HttpServer::Config test_config(const std::string &name) {
+  HttpServer::Config config;
+  config.cache_path = (std::filesystem::temp_directory_path() / name).string();
+  std::filesystem::create_directories(config.cache_path);
+  return config;
+}
+
+} // namespace
+
+TEST(HttpServer, bind_reports_the_port_it_got) {
+  const HttpServer server(test_config("odr-http-server-test-any-port"));
+
+  const std::uint32_t port = server.bind("127.0.0.1", 0);
+  EXPECT_NE(port, 0);
+
+  server.stop();
+}
+
+TEST(HttpServer, bind_twice_is_refused) {
+  const HttpServer server(test_config("odr-http-server-test-twice"));
+
+  server.bind("127.0.0.1", 0);
+  // a second bind would replace the socket cpp-httplib holds, leaking the first
+  // one and its port until the process ends
+  EXPECT_THROW(server.bind("127.0.0.1", 0), ServerAlreadyBound);
+
+  server.stop();
+}
+
+TEST(HttpServer, bind_reports_a_port_in_use) {
+  const HttpServer taken(test_config("odr-http-server-test-taken"));
+  const std::uint32_t port = taken.bind("127.0.0.1", 0);
+
+  const HttpServer other(test_config("odr-http-server-test-other"));
+  HttpServer::Options options;
+  options.reuse_port = false; // or the two would share the port
+  EXPECT_THROW(other.bind("127.0.0.1", port, options), ServerBindFailed);
+
+  taken.stop();
+}
+
+TEST(HttpServer, listen_without_bind_is_refused) {
+  const HttpServer server(test_config("odr-http-server-test-unbound"));
+
+  // cpp-httplib's listen_after_bind() reports success for this
+  EXPECT_THROW(server.listen(), ServerNotBound);
+}


### PR DESCRIPTION
🤖 Generated with [Claude Code](https://claude.com/claude-code)

`HttpServer::listen(host, port)` takes the address, blocks, and returns `void` — discarding the `bool` cpp-httplib hands it:

```cpp
void listen(const std::string &host, const std::uint32_t port) const {
  ODR_VERBOSE(*m_logger, "Listening on " << host << ":" << port);
  m_server->listen(host, static_cast<int>(port));   // returns bool, dropped
}
```

So a failed bind is known inside the library and thrown away twice, and the caller is left with a server that never listened and no way to find out.

That is not hypothetical. OpenDocument.droid hit it in opendocument-app/OpenDocument.droid#536: both flavors hardcode port 29665, `connectedCheck` runs them one after the other on one device, and the second app's bind failed against the first's TIME_WAIT sockets. No server, no complaint, and every document silently became chrome's error page — which read as "edit mode is broken" for three rounds of CI archaeology until a `WebViewClient.onReceivedError` finally said `net::ERR_CONNECTION_REFUSED`. The app now probes the port with a throwaway Java socket before starting the server, which is a guess about how the native bind behaves, and racy. This removes the need for it.

## What changed

`Config` is empty, `serve_file` and `config()` are gone, and `listen(host, port)` became `bind()` + `listen()`.

## The split

```cpp
/// Binds the socket and returns the port it got - pass port 0 for any free
/// one. Connections are accepted into the backlog from here on, before
/// listen() runs. Throws ServerBindFailed / ServerAlreadyBound.
std::uint32_t bind(const std::string &host, std::uint32_t port,
                   const Options &options = {}) const;

/// Serves what bind() opened until stop(). Throws ServerNotBound.
void listen() const;
```

`Config` and `Options` sit at namespace scope, next to `HtmlConfig` which is spelled that way already, and the class keeps them as aliases (`HttpServer::Config` still works). That is what lets both be defaulted with `= {}`: a nested class's member initializers are not parsed until the enclosing class is complete, so a default argument inside the class cannot reach them. Hence one `bind()` rather than two overloads, and `HttpServer server;` with no arguments at all.

Three things follow from it:

- **failure is reported** — `ServerBindFailed` carries the host and port
- **port 0 becomes usable** — `bind` returns what the OS gave, so no caller has to pick a free port and hope it stays free
- **no "is it up yet?" window** — cpp-httplib calls `::listen(sock, backlog)` inside the bind, so connections queue from the moment `bind()` returns, before the accept loop starts

## Two states cpp-httplib handles silently, now errors

- **binding twice** overwrote `svr_sock_` without closing it, leaking the first socket and holding its port until the process ended → `ServerAlreadyBound`
- **listen before bind**: `listen_internal()` sets `ret = true`, finds `svr_sock_ == INVALID_SOCKET` so the accept loop never runs, and returns **true**. A `bool` return would have reported success for the one case a caller most needs to hear about → `ServerNotBound`

The second is why `listen()` throws rather than returning `bool`.

## Config is empty, and the server no longer owns a cache

`Config` held nothing but `cache_path`, which existed only for the `serve_file` marked `// TODO remove` — and for a `clear()` that deleted the caller's translated files underneath them. Both are gone. The server hosts what it is given; what a service was translated into belongs to whoever translated it, and `clear()` now only drops the connected services.

Callers translate for themselves, which is what `serve_file` did internally anyway:

```cpp
const HtmlService service = html::translate(file, my_cache_path, html_config, logger);
server.connect_service(service, prefix);
```

`Config` stays as an empty struct, so server-wide settings have somewhere to land later.

## Socket options belong to the bind

`HttpServer::Options` is passed to `bind()`, not held on the server, and it corrects a default:

| | cpp-httplib | here |
|---|---|---|
| `SO_REUSEADDR` | only where `SO_REUSEPORT` is undefined | **on** |
| `SO_REUSEPORT` | on, wherever it exists | **off** |

Only `SO_REUSEADDR` lets a port still held by TIME_WAIT sockets be bound again — the failure above. `SO_REUSEPORT` does not help with that at all, and what it *does* do is let a second live server share the port and take a random share of the connections, which for a document server means requests answered by the wrong instance. It also only shares between sockets of the same uid, so it was never going to help two Android flavors either.

**Windows keeps cpp-httplib's defaults** (thanks to the review bot for catching this). The two flags mean the opposite there: `SO_REUSEADDR` lets a second live socket take the endpoint over, and `SO_EXCLUSIVEADDRUSE` — which the default sets and my first version dropped — is what keeps the port ours. Applying the POSIX mapping there would have handed the port away, which is precisely the hazard `reuse_port: false` exists to avoid. `Options` is documented as POSIX only.

## Known limitation, documented in the header

`stop()` releases the socket through cpp-httplib's `Server::stop()`, which only closes it `if (is_running_)`. `~Server()` is `= default` and never closes it. So a server that was bound but never listened keeps its port until the process ends. Enforcing the pairing here would mean either owning a thread inside the library or patching upstream; for now the header says so plainly.

## Follow-up this opens

OpenDocument.droid can delete its `choosePort`/`bindable` probe and simply ask for port 0.

## Callers and verification

CLI binds before printing its urls, prints the port it got, and owns its cache directory. The jni and python bindings gain `bind()` and `Options`, lose `serveFile`/`cachePath`, and both test suites drop the free-port dances they needed to work around the old API.

- `odr_test --gtest_filter='HttpServer.*'` — 4 new tests, all pass (new file; there was no C++ coverage of `HttpServer` before)
- jni JUnit `HttpServerTest` — 2 new tests pass locally, `serveFile` skipped for missing test data
- python `test_http_server.py` — 4 pass against a locally built `pyodr_core`, including the rewritten `serve_file` test that now translates and connects for itself
- `cli/server` serves a real odt end to end
- `scripts/format` and `black --check` clean

One detail worth knowing for the tests: `localhost` resolves to both `::1` and `127.0.0.1`, so a "bind a port already in use" test against `localhost` quietly succeeds on the *other* address. The tests use literal `127.0.0.1`.
