### PR TITLE
fix: attach the logger thread on android

### DIFF
--- a/jni/src/jni_logger.cpp
+++ b/jni/src/jni_logger.cpp
@@ -16,6 +16,18 @@ using odr_jni::make_handle;
 using odr_jni::to_jstring;
 using odr_jni::to_string;
 
+/// `JavaVM::AttachCurrentThread` takes a `JNIEnv **` on android and a `void **`
+/// on the jdk, and neither pointer converts to the other, so the argument has
+/// to be typed per platform. `GetEnv` is `void **` on both and needs none of
+/// this.
+jint attach_current_thread(JavaVM *const vm, JNIEnv **const env) {
+#ifdef __ANDROID__
+  return vm->AttachCurrentThread(env, nullptr);
+#else
+  return vm->AttachCurrentThread(reinterpret_cast<void **>(env), nullptr);
+#endif
+}
+
 /// A `JNIEnv` for the calling thread, attaching it if the JVM does not know it
 /// yet. Log calls arrive on whatever thread the library happens to be working
 /// on, which is not necessarily one the JVM started.
@@ -28,8 +40,7 @@ public:
     const jint status =
         m_vm->GetEnv(reinterpret_cast<void **>(&m_env), JNI_VERSION_1_6);
     if (status == JNI_EDETACHED) {
-      if (m_vm->AttachCurrentThread(reinterpret_cast<void **>(&m_env),
-                                    nullptr) == JNI_OK) {
+      if (attach_current_thread(m_vm, &m_env) == JNI_OK) {
         m_attached = true;
       } else {
         m_env = nullptr;


### PR DESCRIPTION
🤖 Generated with [Claude Code](https://claude.com/claude-code)

`JavaVM::AttachCurrentThread` takes a `JNIEnv **` on android and a `void **` on the jdk, and neither pointer converts to the other, so the `void **` cast in `ScopedEnv` breaks the android build outright:

```
jni/src/jni_logger.cpp:31:37: error: cannot initialize a parameter of type 'JNIEnv **' (aka '_JNIEnv **') with an rvalue of type 'void **'
```

`GetEnv` right above it is `void **` on both and stays as it was. Nothing else in the bindings attaches a thread.

Found building odrcore 6.0.0 for OpenDocument.droid, which is the only consumer that cross compiles the bindings for android — `.github/workflows/jni.yml` builds host side only, where the jdk declaration compiles and this stays invisible.

## Test

- `cmake --build cmake-build-relwithdebinfo --target odr_jni` (macOS/jdk) — passes, as before.
- odrcore built through conan for `armv8`, `armv7`, `x86` and `x86_64` with `with_jni=True`, NDK 28.2.13676358, api 26: `libodr_jni.so` links for all four. Before this it failed at `jni_logger.cpp` on every one of them.