### PR TITLE
feat(maven): publish both artifacts to maven central

### DIFF
--- a/.github/workflows/android.yml
+++ b/.github/workflows/android.yml
@@ -204,6 +204,8 @@ jobs:
     if: github.event_name != 'push'
     needs: [aar, instrumented]
     runs-on: ubuntu-24.04
+    # holds the portal token and the signing key
+    environment: maven-central
     permissions:
       contents: read
       packages: write
@@ -237,8 +239,21 @@ jobs:
             echo "ODR_VERSION=${INPUT_VERSION}" >> $GITHUB_ENV
           fi
 
-      - name: publish
+      - name: publish to github packages
         working-directory: android
-        run: ./gradlew publishReleasePublicationToGitHubPackagesRepository -Podr.abis=
+        run: ./gradlew publishAllPublicationsToGitHubPackagesRepository -Podr.abis=
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+
+      # Uploads a deployment to the portal and leaves it there. Releasing it to
+      # Maven Central is a click in the portal UI, deliberately: Central never
+      # forgets a version, so this is the last point at which a bad artifact can
+      # still be dropped instead of lived with.
+      - name: publish to maven central
+        working-directory: android
+        run: ./gradlew publishToMavenCentral -Podr.abis=
+        env:
+          ORG_GRADLE_PROJECT_mavenCentralUsername: ${{ secrets.MAVEN_CENTRAL_USERNAME }}
+          ORG_GRADLE_PROJECT_mavenCentralPassword: ${{ secrets.MAVEN_CENTRAL_PASSWORD }}
+          ORG_GRADLE_PROJECT_signingInMemoryKey: ${{ secrets.SIGNING_KEY }}
+          ORG_GRADLE_PROJECT_signingInMemoryKeyPassword: ${{ secrets.SIGNING_PASS }}

--- a/.github/workflows/maven.yml
+++ b/.github/workflows/maven.yml
@@ -14,13 +14,34 @@ concurrency:
   group: ${{ github.workflow }}-${{ github.head_ref || github.run_id }}
   cancel-in-progress: true
 
-permissions:
-  contents: read
-  packages: write
-
 jobs:
   build:
     runs-on: ubuntu-24.04
+    permissions:
+      contents: read
+    steps:
+      - name: checkout
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
+
+      - name: setup java
+        uses: actions/setup-java@f4f1212c880fdec8162ea9a6493f4495191887b4 # v5
+        with:
+          distribution: temurin
+          java-version: 21
+          cache: maven
+
+      - name: build
+        run: mvn --batch-mode --no-transfer-progress --file jni/pom.xml verify
+
+  # Split out so the secrets sit behind an environment and are never in reach of
+  # a plain push build.
+  publish:
+    if: github.event_name != 'push'
+    runs-on: ubuntu-24.04
+    environment: maven-central
+    permissions:
+      contents: read
+      packages: write
     steps:
       - name: checkout
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
@@ -34,7 +55,6 @@ jobs:
           server-id: github
 
       - name: get version
-        if: github.event_name != 'push'
         env:
           INPUT_VERSION: ${{ inputs.version }}
         run: |
@@ -44,12 +64,31 @@ jobs:
             echo "REVISION=${INPUT_VERSION}" >> $GITHUB_ENV
           fi
 
-      - name: build
-        if: github.event_name == 'push'
-        run: mvn --batch-mode --no-transfer-progress --file jni/pom.xml verify
-
-      - name: publish
-        if: github.event_name != 'push'
+      - name: publish to github packages
         run: mvn --batch-mode --no-transfer-progress --file jni/pom.xml deploy -Drevision="${REVISION}"
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+
+      # A second setup-java: the central profile deploys to a different server
+      # id and needs the signing key in the runner's gpg keyring, and the step
+      # above has already had its turn with settings.xml.
+      - name: setup java for maven central
+        uses: actions/setup-java@f4f1212c880fdec8162ea9a6493f4495191887b4 # v5
+        with:
+          distribution: temurin
+          java-version: 21
+          cache: maven
+          server-id: central
+          server-username: MAVEN_CENTRAL_USERNAME
+          server-password: MAVEN_CENTRAL_PASSWORD
+          gpg-private-key: ${{ secrets.SIGNING_KEY }}
+          gpg-passphrase: MAVEN_GPG_PASSPHRASE
+
+      # Uploads and stops, the way the AAR does — released by hand from the
+      # portal, because Central never forgets a version.
+      - name: publish to maven central
+        run: mvn --batch-mode --no-transfer-progress --file jni/pom.xml deploy -Pcentral -Drevision="${REVISION}"
+        env:
+          MAVEN_CENTRAL_USERNAME: ${{ secrets.MAVEN_CENTRAL_USERNAME }}
+          MAVEN_CENTRAL_PASSWORD: ${{ secrets.MAVEN_CENTRAL_PASSWORD }}
+          MAVEN_GPG_PASSPHRASE: ${{ secrets.SIGNING_PASS }}

--- a/android/AGENTS.md
+++ b/android/AGENTS.md
@@ -50,6 +50,12 @@ calls it.
 - **Shared test inputs stay in `../jni/testfixtures`**, which both suites
   compile — so it is limited to what android API 26 offers (no `Path.of`, no
   `Files.writeString`, no `String.formatted`).
+- **Publishing goes to Maven Central and GitHub Packages**, via
+  `com.vanniktech.maven.publish` — sonatype ships no official gradle plugin for
+  the portal. Central's extra requirements (sources + javadoc jars, `developers`
+  in the POM, a PGP signature per file) drive what that block declares; do not
+  drop one thinking GitHub Packages is the only consumer. Signing is conditional
+  on a key being present so `publishToMavenLocal` works without one.
 - **`native/` is build output**, never committed; the artifacts CI downloads
   land in the same place. `-Podr.abis=` (empty) is what tells the build the
   libraries are already there.

--- a/android/README.md
+++ b/android/README.md
@@ -19,13 +19,7 @@ ABIs: `arm64-v8a`, `armeabi-v7a`, `x86`, `x86_64`. minSdk 26.
 
 ```gradle
 repositories {
-    maven {
-        url = uri("https://maven.pkg.github.com/opendocument-app/OpenDocument.core")
-        credentials {
-            username = providers.gradleProperty("gpr.user").orNull ?: System.getenv("GITHUB_ACTOR")
-            password = providers.gradleProperty("gpr.key").orNull ?: System.getenv("GITHUB_TOKEN")
-        }
-    }
+    mavenCentral()
 }
 
 dependencies {
@@ -33,8 +27,9 @@ dependencies {
 }
 ```
 
-GitHub Packages needs a token with `read:packages` even for public packages —
-see [Publishing](#publishing) for what that rules out. Do not depend on
+The same artifact is also on GitHub Packages, but prefer Central: GitHub
+Packages needs a token with `read:packages` even for public packages — see
+[Publishing](#publishing) for what that rules out. Do not depend on
 `odr-core-java` as well: the AAR carries the same classes.
 
 ```kotlin
@@ -104,17 +99,31 @@ ships to — and on a current API level.
 
 ## Publishing
 
-Releases go to GitHub Packages, like the maven jar, and only once the
+Releases go to **Maven Central and GitHub Packages**, and only once the
 instrumented suite has passed on every API level — an AAR that assembles and
-lints is no evidence that it works on a device. That is enough for
-consumers who can hold a token, and **not** enough for the one this is
-ultimately built for: GitHub Packages demands `read:packages` even to read a
-public artifact, and f-droid builds from source with no credentials at all.
-Making the AAR the base of OpenDocument.droid therefore means publishing it to
-Maven Central first, which is a separate piece of work — the `app.opendocument`
-namespace has to be verified, and every artifact signed.
+lints is no evidence that it works on a device.
 
-Until then OpenDocument.droid keeps building odrcore from the conan package
+Maven Central is the one that matters. GitHub Packages demands `read:packages`
+even to read a public artifact, which rules out the consumer this is ultimately
+built for: f-droid builds from source with no credentials at all. It stays
+published there only because the maven jar is, and dropping it would break
+whoever already reads it.
+
+`app.opendocument` is an established namespace on Central — `pdf2htmlex-android`
+and `wvware-android` have been there since 2024 — so this is a new artifact under
+an old name, not a new namespace. Central asks for more than GitHub Packages
+does, and the module supplies it: sources and javadoc jars, a POM carrying
+`developers`, and a PGP signature over every file. Signing is conditional on a
+key being configured, so `publishToMavenLocal` and the GitHub Packages publish
+still work without one; an unsigned upload is rejected by the portal, so the
+release path stays guarded either way.
+
+Publishing **uploads a deployment to the portal and stops**. Releasing it is a
+deliberate click in the portal UI, because Central never forgets a version —
+that click is the last point at which a bad artifact can be dropped rather than
+lived with.
+
+For now OpenDocument.droid keeps building odrcore from the conan package
 (`with_jni=True`), deploying `libodr_jni.so`, `odr-core-java.jar` and the assets
 out of it. That path is unaffected by anything here, and it is the reason the
 two halves cannot drift: they come out of one build.

--- a/android/build.gradle.kts
+++ b/android/build.gradle.kts
@@ -1,7 +1,9 @@
+import com.vanniktech.maven.publish.AndroidSingleVariantLibrary
+
 plugins {
     alias(libs.plugins.android.library)
     alias(libs.plugins.spotless)
-    `maven-publish`
+    alias(libs.plugins.maven.publish)
 }
 
 // ktfmt in the kotlinlang flavor, the same formatter and version
@@ -143,13 +145,6 @@ android {
         // library outside java.library.path; android never takes that branch
         disable += "UnsafeDynamicallyLoadedCode"
     }
-
-    publishing {
-        singleVariant("release") {
-            withSourcesJar()
-            withJavadocJar()
-        }
-    }
 }
 
 dependencies {
@@ -159,37 +154,60 @@ dependencies {
     androidTestImplementation(libs.androidx.test.runner)
 }
 
-publishing {
-    publications {
-        register<MavenPublication>("release") {
-            groupId = "app.opendocument"
-            artifactId = "odr-core-android"
-            version = odrVersion
+// Two destinations, deliberately. Maven Central is the one that matters: it is
+// the only one f-droid and any other credential-less source builder can resolve
+// from, and `app.opendocument` is already a live namespace there
+// (`pdf2htmlex-android`, `wvware-android`). GitHub Packages stays because the
+// maven jar publishes there and dropping it would break whoever already reads
+// it. Central mandates what the publication below carries — sources and javadoc
+// jars, a pom with developers, and a PGP signature over every file — none of
+// which GitHub Packages asks for.
+mavenPublishing {
+    configure(AndroidSingleVariantLibrary(variant = "release"))
 
-            afterEvaluate { from(components["release"]) }
+    // Uploads to the portal and stops. A human releases it from there, so a bad
+    // artifact is still recallable — Central is immutable once released.
+    publishToMavenCentral()
 
-            pom {
-                name = "odr-core-android"
-                description =
-                    "Android bindings for OpenDocument.core — decode office documents " +
-                        "(ODF, OOXML, legacy MS binary, PDF, CSV, ...) and render them to HTML"
-                url = "https://github.com/opendocument-app/OpenDocument.core"
-                licenses {
-                    license {
-                        name = "MPL-2.0"
-                        url = "https://www.mozilla.org/en-US/MPL/2.0/"
-                    }
-                }
-                scm {
-                    connection = "scm:git:https://github.com/opendocument-app/OpenDocument.core.git"
-                    developerConnection =
-                        "scm:git:git@github.com:opendocument-app/OpenDocument.core.git"
-                    url = "https://github.com/opendocument-app/OpenDocument.core"
-                }
-            }
-        }
+    // Only Central demands a signature. Making it unconditional would mean no
+    // `publishToMavenLocal` and no GitHub Packages publish without a private
+    // key on hand, which is a steep price for a repository that never checks
+    // one. A Central upload missing its .asc files is rejected by the portal,
+    // so the release path is still guarded.
+    if (providers.gradleProperty("signingInMemoryKey").isPresent) {
+        signAllPublications()
     }
 
+    coordinates("app.opendocument", "odr-core-android", odrVersion)
+
+    pom {
+        name = "odr-core-android"
+        description =
+            "Android bindings for OpenDocument.core — decode office documents " +
+                "(ODF, OOXML, legacy MS binary, PDF, CSV, ...) and render them to HTML"
+        url = "https://github.com/opendocument-app/OpenDocument.core"
+        licenses {
+            license {
+                name = "MPL-2.0"
+                url = "https://www.mozilla.org/en-US/MPL/2.0/"
+            }
+        }
+        developers {
+            developer {
+                id = "opendocument-app"
+                name = "OpenDocument.app"
+                url = "https://github.com/opendocument-app"
+            }
+        }
+        scm {
+            connection = "scm:git:https://github.com/opendocument-app/OpenDocument.core.git"
+            developerConnection = "scm:git:git@github.com:opendocument-app/OpenDocument.core.git"
+            url = "https://github.com/opendocument-app/OpenDocument.core"
+        }
+    }
+}
+
+publishing {
     repositories {
         maven {
             name = "GitHubPackages"

--- a/android/gradle/libs.versions.toml
+++ b/android/gradle/libs.versions.toml
@@ -6,6 +6,10 @@ agp = "9.3.1"
 spotless = "8.8.0"
 ktfmt = "0.64"
 
+# sonatype ships no official gradle plugin for the central portal, so this is
+# the community one android libraries have settled on
+mavenPublish = "0.37.0"
+
 junit = "4.13.2"
 androidxTest = "1.7.0"
 androidxTestJunit = "1.3.0"
@@ -19,3 +23,4 @@ androidx-test-junit = { module = "androidx.test.ext:junit", version.ref = "andro
 [plugins]
 android-library = { id = "com.android.library", version.ref = "agp" }
 spotless = { id = "com.diffplug.spotless", version.ref = "spotless" }
+maven-publish = { id = "com.vanniktech.maven.publish", version.ref = "mavenPublish" }

--- a/jni/AGENTS.md
+++ b/jni/AGENTS.md
@@ -9,7 +9,7 @@ package `app.opendocument.core`. Mirrors the surface of the python bindings
 | Path | What |
 |------|------|
 | `CMakeLists.txt` | Builds `libodr_jni` + `odr-core-java.jar`; included from the root build via `ODR_JNI`, or standalone against an installed `odrcore`. |
-| `pom.xml` | Maven distribution of the Java classes only (`app.opendocument:odr-core-java`); published to GitHub Packages on release via `.github/workflows/maven.yml`. Keep `--release`/`-Xlint` in sync with `CMAKE_JAVA_COMPILE_FLAGS`. |
+| `pom.xml` | Maven distribution of the Java classes only (`app.opendocument:odr-core-java`); published to Maven Central (the `central` profile) and GitHub Packages on release via `.github/workflows/maven.yml`. Keep `--release`/`-Xlint` in sync with `CMAKE_JAVA_COMPILE_FLAGS`. |
 | `src/` | JNI sources, one `jni_*` unit per public-API area; `odr_jni.hpp` (strings, exceptions, handles) and `jni_convert.hpp` (struct/POJO marshalling) are the helpers. |
 | `java/app/opendocument/core/` | Java API: enums, POJOs (styles, metas, `HtmlConfig`), and handle-backed wrappers extending `NativeResource`. Also compiled as-is into the AAR (`../android`) — which is kotlin, but this stays java: `add_jar` below has no kotlin toolchain. |
 | `tests/` | JUnit 5 suite, run via ctest (`odr_jni_junit`); inputs are generated inline (tmp files, zip-built minimal ODT) — no fixture files. |

--- a/jni/README.md
+++ b/jni/README.md
@@ -24,7 +24,8 @@ The native library is loaded from `java.library.path` as `odr_jni`
 
 ## Maven distribution
 
-The Java classes are published as `app.opendocument:odr-core-java` to
+The Java classes are published as `app.opendocument:odr-core-java` to Maven
+Central and to
 [GitHub Packages](https://github.com/orgs/opendocument-app/packages?repo_name=OpenDocument.core)
 on release (`.github/workflows/maven.yml`, built from `pom.xml`). The artifact
 contains **only the Java API** — consumers build the native `odr_jni` library
@@ -36,13 +37,7 @@ native library for every ABI and the runtime assets. See [`../android`](../andro
 
 ```gradle
 repositories {
-    maven {
-        url = uri("https://maven.pkg.github.com/opendocument-app/OpenDocument.core")
-        credentials {
-            username = providers.gradleProperty("gpr.user").orNull ?: System.getenv("GITHUB_ACTOR")
-            password = providers.gradleProperty("gpr.key").orNull ?: System.getenv("GITHUB_TOKEN")
-        }
-    }
+    mavenCentral()
 }
 
 dependencies {
@@ -50,11 +45,14 @@ dependencies {
 }
 ```
 
-Note: GitHub Packages requires authentication (a token with `read:packages`)
-even for public packages.
+Prefer Central: GitHub Packages requires authentication (a token with
+`read:packages`) even for public packages.
 
 Local build: `mvn --file jni/pom.xml verify` (produces the jar plus sources
-and javadoc jars in `jni/target/`).
+and javadoc jars in `jni/target/`). Central additionally wants every file PGP
+signed and a POM carrying `developers`; both live in the `central` profile
+(`mvn deploy -Pcentral`), kept off the default build so neither a signing key
+nor a portal token is needed to build or to deploy to GitHub Packages.
 
 ## Building
 

--- a/jni/pom.xml
+++ b/jni/pom.xml
@@ -24,6 +24,15 @@
     </license>
   </licenses>
 
+  <!-- Required by Maven Central; GitHub Packages does not ask for it. -->
+  <developers>
+    <developer>
+      <id>opendocument-app</id>
+      <name>OpenDocument.app</name>
+      <url>https://github.com/opendocument-app</url>
+    </developer>
+  </developers>
+
   <scm>
     <connection>scm:git:https://github.com/opendocument-app/OpenDocument.core.git</connection>
     <developerConnection>scm:git:git@github.com:opendocument-app/OpenDocument.core.git</developerConnection>
@@ -111,6 +120,9 @@
     </plugins>
   </build>
 
+  <!-- `mvn deploy` goes here. Maven Central is the `central` profile below,
+       because its plugin takes over the deploy lifecycle wholesale and the two
+       destinations cannot be driven by one invocation. -->
   <distributionManagement>
     <repository>
       <id>github</id>
@@ -118,4 +130,53 @@
       <url>https://maven.pkg.github.com/opendocument-app/OpenDocument.core</url>
     </repository>
   </distributionManagement>
+
+  <profiles>
+    <!-- `mvn deploy -Pcentral`. Kept off the default build so that neither a
+         signing key nor a portal token is needed to `mvn verify` or to deploy
+         to GitHub Packages, which checks no signature. -->
+    <profile>
+      <id>central</id>
+
+      <build>
+        <plugins>
+          <plugin>
+            <groupId>org.apache.maven.plugins</groupId>
+            <artifactId>maven-gpg-plugin</artifactId>
+            <version>3.2.8</version>
+            <executions>
+              <execution>
+                <id>sign-artifacts</id>
+                <phase>verify</phase>
+                <goals>
+                  <goal>sign</goal>
+                </goals>
+              </execution>
+            </executions>
+            <configuration>
+              <!-- The passphrase comes from MAVEN_GPG_PASSPHRASE; loopback is
+                   what lets gpg take it without a tty to prompt on. -->
+              <gpgArguments>
+                <arg>--pinentry-mode</arg>
+                <arg>loopback</arg>
+              </gpgArguments>
+            </configuration>
+          </plugin>
+
+          <plugin>
+            <groupId>org.sonatype.central</groupId>
+            <artifactId>central-publishing-maven-plugin</artifactId>
+            <version>0.11.0</version>
+            <extensions>true</extensions>
+            <configuration>
+              <publishingServerId>central</publishingServerId>
+              <!-- Uploads and stops, the way the AAR does: a human releases it
+                   from the portal, and Central is immutable once released. -->
+              <autoPublish>false</autoPublish>
+            </configuration>
+          </plugin>
+        </plugins>
+      </build>
+    </profile>
+  </profiles>
 </project>


### PR DESCRIPTION
Stacked on #629.

GitHub Packages demands `read:packages` even to read a *public* artifact. f-droid builds from source with no credentials at all, so it cannot resolve either artifact from there — and being consumable by droid, which f-droid builds, is the whole reason the AAR exists. #629 says this needs Maven Central "first, which is a separate piece of work — the `app.opendocument` namespace has to be verified, and every artifact signed." Half of that turned out to be already done.

## `app.opendocument` is not a new namespace

The org has published android AARs to Maven Central before, under exactly this group:

| artifact | latest | published |
|---|---|---|
| `app.opendocument:pdf2htmlex-android` | 0.18.26 | 2024-08-25 |
| `app.opendocument:wvware-android` | 1.2.11 | 2024-08-26 |

Both are on `repo1.maven.org` today, and droid consumed them as ordinary `mavenCentral()` dependencies before they were archived. So this is a new artifact under an established name. What is genuinely outstanding is credentials, not verification — see below.

## What this changes

**The AAR** goes through `com.vanniktech.maven.publish`. Sonatype ships no official gradle plugin for the Central Portal, and OSSRH — which `pdf2htmlEX-Android` and `wvware-android` deployed to — is gone, so their `gradle-nexus/publish-plugin` + `s01.oss.sonatype.org` setup cannot simply be copied. vanniktech is what android libraries have settled on. It renames the publication `release` → `maven`, so the workflow now asks for the name-independent `publishAllPublicationsToGitHubPackagesRepository`.

**The jar** keeps its hand-written pom and gains a `central` profile. `central-publishing-maven-plugin` takes over the deploy lifecycle wholesale, so one `mvn deploy` cannot serve both destinations; the default stays GitHub Packages and `-Pcentral` is the Central path. `maven.yml` splits publishing into its own job so the secrets sit behind an environment, the shape `android.yml` already has.

**Both keep publishing to GitHub Packages.** Nothing that reads it today breaks.

Central asks for more than GitHub Packages does, and both artifacts now supply it:

* sources and javadoc jars — the jar already had them, the AAR now does;
* a POM carrying `developers` — **neither had one**, so neither would have been accepted as it stood;
* a PGP signature over every file.

Signing is **conditional on a key being configured**. Unconditional (`signAllPublications()` on its own) fails `publishToMavenLocal` with *"no configured signatory"*, which would mean nobody could publish locally or to GitHub Packages without a private key on hand — a steep price for two destinations that never check one. The portal rejects an unsigned upload, so the release path stays guarded.

Both publishes **upload a deployment and stop**. Releasing is a deliberate click in the portal UI: Central never forgets a version, and that click is the last point at which a bad artifact can be dropped rather than lived with.

## Verification

Locally, against a throwaway PGP key: the AAR publishes `.aar`, `.pom`, `.module`, sources and javadoc jars, each with a detached `.asc` that verifies against the key; the POM carries name, description, url, licenses, developers and scm; the AAR still contains its assets and prebuilt ABIs. With no key set it publishes the same artifacts unsigned. `mvn verify` and `mvn validate -Pcentral` both pass, and the flattened pom keeps `developers`.

Not verified: an actual upload to the portal, which needs credentials this repo does not have yet.

## Before this can release

The `maven-central` environment has to exist with four secrets:

| secret | what |
|---|---|
| `MAVEN_CENTRAL_USERNAME` / `MAVEN_CENTRAL_PASSWORD` | Central Portal **user token**, generated at central.sonatype.com — not portal login credentials |
| `SIGNING_KEY` | armored PGP private key |
| `SIGNING_PASS` | its passphrase |

The archived repos hold a working `SIGNING_KEY`/`SIGNING_PASS` pair in their own `OpenDocumentAppRelease` environment, so the signing key may just need copying. The Sonatype credentials do not carry over: those are OSSRH-era, and the Portal issues its own tokens. Worth confirming who holds the Portal account that owns the `app.opendocument` namespace, since these repos came from an outside author.

🤖 Generated with [Claude Code](https://claude.com/claude-code)