### PR TITLE
fix(android): ship the AAR's native libraries with their debug info

### DIFF
--- a/android/README.md
+++ b/android/README.md
@@ -77,6 +77,15 @@ The odrcore build is a normal one — `ODR_JNI=ON`, static core linked into
 `libodr_jni.so` — driven by the `android-<arch>` conan profiles in
 `.github/config/conan/profiles`, which pin the NDK and API 26.
 
+The libraries ship unstripped — 60-72 MB per ABI, most of the AAR — so that a
+consuming app's `ndk.debugSymbolLevel` can hand play what it needs to symbolicate
+a crash inside the core. Devices never see it: play serves APKs built from the
+stripped copies, so the weight is on maven central and developer builds only.
+
+It takes both `build_native.py` not stripping and the
+`packaging.jniLibs.keepDebugSymbols` rule in `build.gradle.kts`. Without the
+second the first is invisible.
+
 ## Testing
 
 ```bash

--- a/android/build.gradle.kts
+++ b/android/build.gradle.kts
@@ -102,6 +102,15 @@ android {
         targetCompatibility = JavaVersion.VERSION_17
     }
 
+    packaging {
+        jniLibs {
+            // AGP strips the libraries on their way into the AAR unless told not
+            // to, silently — the published AAR comes out byte-identical to a
+            // fully stripped one however `build_native.py` built it.
+            keepDebugSymbols += "**/*.so"
+        }
+    }
+
     // pushing the instrumented apk onto a cold emulator outlasts ddmlib's
     // default timeout, which surfaces as a ShellCommandUnresponsiveException
     // rather than as a failing test

--- a/android/build_native.py
+++ b/android/build_native.py
@@ -14,6 +14,10 @@ its jniLibs source set:
 
 `libc++_shared.so` has to be shipped because the android profiles build against
 the shared c++ runtime and nothing else in a consuming app pulls it in.
+
+Neither is stripped: the NDK's unconditional `-g` is what a consumer's
+`ndk.debugSymbolLevel` turns into symbolicated play crash reports. Costs 60-72 MB
+per ABI, and needs the `keepDebugSymbols` rule in `build.gradle.kts` to survive.
 """
 
 import argparse
@@ -65,13 +69,8 @@ def libcxx_shared(ndk: Path, triple: str) -> Path:
     return matches[0]
 
 
-def strip(ndk: Path, library: Path) -> None:
-    """The NDK compiles with `-g` in every configuration, so a release build of
-    the bindings is ~70 MB until it is stripped."""
-    matches = sorted(ndk.glob("toolchains/llvm/prebuilt/*/bin/llvm-strip"))
-    if not matches:
-        raise SystemExit(f"no llvm-strip under {ndk}")
-    run([matches[0], "--strip-unneeded", library])
+def report(library: Path) -> None:
+    print(f"  {library.name}: {library.stat().st_size // 1024} KiB", flush=True)
 
 
 def build(architecture: str, conan: str, build_profile: str, output: Path) -> None:
@@ -106,7 +105,7 @@ def build(architecture: str, conan: str, build_profile: str, output: Path) -> No
     for source in (cmake_dir / "jni" / "libodr_jni.so", libcxx_shared(ndk, triple)):
         target = jni_libs / source.name
         shutil.copy2(source, target)
-        strip(ndk, target)
+        report(target)
 
 
 def main() -> int:


### PR DESCRIPTION
A consuming app's `ndk.debugSymbolLevel` has only the merged native libraries to extract from, and both halves of this repo were throwing that away. Play reported every frame of a crash inside the core as a bare address.

## Two strippers, not one

`build_native.py` stripped with `--strip-unneeded`. That was the obvious culprit, and fixing it alone does **nothing** — AGP's `StripDebugSymbolsTask` runs `--strip-unneeded` again on the way into the AAR.

The first push of this PR proved it: `build_native.py` produced a 7,326 KiB `libodr_jni.so`, and the AAR CI built from it contained **5,760,752 bytes** — byte-identical to the fully stripped one. Caught in review; the evidence is [that run's AAR artifact](https://github.com/opendocument-app/OpenDocument.core/actions/runs/30745544162).

So this needs both: the script leaves the libraries alone, and `packaging.jniLibs.keepDebugSymbols` holds AGP off them.

## Size, measured

`libodr_jni.so` per ABI — the NDK compiles with `-g` in every configuration:

| ABI | unstripped | `--strip-debug` | `--strip-unneeded` (before) |
|---|---|---|---|
| arm64-v8a | 72.1 MiB | 7.15 MiB | 5.49 MiB |
| armeabi-v7a | 60.8 MiB | 5.42 MiB | 3.89 MiB |
| x86 | 59.6 MiB | 6.40 MiB | 5.17 MiB |
| x86_64 | 69.1 MiB | 6.97 MiB | 5.64 MiB |

With `libc++_shared.so` that is 292 MiB uncompressed across four ABIs — but DWARF deflates about 4:1, so **the published AAR is 76.7 MiB** (80,459,111 bytes), against ~7 MiB before.

## Verified end to end

- The AAR CI now builds carries the debug info: `arm64-v8a/libodr_jni.so` is 75,638,648 bytes, up from 5,760,752
- Both emulator matrices (API 26 and 36) pass against the unstripped libraries
- Test-published as `6.1.1-test2` — the central portal accepted the ~77 MiB bundle and listed the AAR at exactly the 80,459,111 bytes CI produced. Deployment dropped afterwards.

## Why the size is the right trade

Debug symbols never reach a phone. AGP puts them in `BUNDLE-METADATA/com.android.tools.build.debugsymbols/` inside the `.aab`; play uses them to symbolicate and serves device APKs built from the stripped libraries. The cost is maven central storage and developer builds on a cold cache — not app size.

The alternative was `--strip-debug`, keeping `.symtab` only: ~32 MiB uncompressed, function names but no line numbers and inlined frames collapsed into their callers. Since end users pay nothing either way, the full DWARF is worth it — and it is what OpenDocument.droid already had via conan, before opendocument-app/OpenDocument.droid#558 moved it onto this AAR.

## Follow-up worth its own change

`publishToMavenCentral` uploads and exits without waiting for validation, so a release cannot tell a validated deployment from a failed one. The maven jar's path polls and reports `has been validated` explicitly; the android path should too.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Lqc6gWzBBnoqvdaQ9HPoEa