### PR TITLE
fix(apple): keep a view's service alive while the view is used

### DIFF
--- a/apple/AGENTS.md
+++ b/apple/AGENTS.md
@@ -76,12 +76,17 @@ consumer, and a SwiftPM binary target gives the consumer no way to pass
   `jni/src/odr_jni.cpp::throw_java` — keep the two in step.
 - **Elements carry their owner.** Most public C++ handles own a `shared_ptr`,
   so a wrapper holding one by value is self-sufficient and needs no keep-alive.
-  `odr::Element` is the exception: it holds a bare pointer into the document's
-  adapter. Every `ODRElement` therefore keeps a strong reference to its
-  `ODRDocument`, and navigation goes through `-derive:` so that reference is
-  carried along by construction rather than by remembering to pass it. This is
-  the JNI bindings' owner chain, and it is what lets a caller keep a subtree
-  after dropping the document.
+  `odr::Element` and `odr::HtmlView` are the exceptions: the first holds a bare
+  pointer into the document's adapter, the second one into its service. Every
+  `ODRElement` therefore keeps a strong reference to its `ODRDocument`, and
+  navigation goes through `-derive:` so that reference is carried along by
+  construction rather than by remembering to pass it; every `ODRHtmlView`
+  likewise keeps its `ODRHtmlService`. This is the JNI bindings' owner chain
+  (and python's `_service` attribute), and it is what lets a caller keep a
+  subtree after dropping the document, or render a view off a service it no
+  longer holds. **Check a new wrapper for a bare pointer before assuming the
+  `shared_ptr` makes it self-sufficient** — `HtmlView` looks like it owns
+  everything it needs, and does not.
 - **Strings**: `odr::apple::to_string` / `to_nsstring`, real UTF-8 ↔ UTF-16.
   Never hand a `-UTF8String` pointer to something that outlives the autorelease
   pool.

--- a/apple/src/ODRHtml.mm
+++ b/apple/src/ODRHtml.mm
@@ -306,11 +306,16 @@ NSArray<ODRHtmlResource *> *to_nsarray(const odr::HtmlResources &resources) {
 
 @implementation ODRHtmlView {
   std::optional<odr::HtmlView> _handle;
+  // The service the view belongs to. The view's impl holds a bare pointer to
+  // it, so without this a view handed out by `-views` could outlive what it
+  // points into — the same owner chain `ODRElement` keeps to its document.
+  id _owner;
 }
 
-+ (instancetype)viewWithHandle:(odr::HtmlView)handle {
++ (instancetype)viewWithHandle:(odr::HtmlView)handle owner:(id)owner {
   ODRHtmlView *const result = [[ODRHtmlView alloc] init];
   result->_handle = std::move(handle);
+  result->_owner = owner;
   return result;
 }
 
@@ -377,7 +382,7 @@ NSArray<ODRHtmlResource *> *to_nsarray(const odr::HtmlResources &resources) {
         NSMutableArray<ODRHtmlView *> *const result =
             [NSMutableArray arrayWithCapacity:views.size()];
         for (const odr::HtmlView &view : views) {
-          [result addObject:[ODRHtmlView viewWithHandle:view]];
+          [result addObject:[ODRHtmlView viewWithHandle:view owner:self]];
         }
         return result;
       },

--- a/apple/src/ODRPrivate.h
+++ b/apple/src/ODRPrivate.h
@@ -158,7 +158,7 @@ ODRMeasure *_Nullable box(const std::optional<odr::Measure> &measure);
 @end
 
 @interface ODRHtmlView (Private)
-+ (instancetype)viewWithHandle:(odr::HtmlView)handle;
++ (instancetype)viewWithHandle:(odr::HtmlView)handle owner:(id)owner;
 - (const odr::HtmlView &)handle;
 @end
 

--- a/apple/tests/OdrCoreTests.swift
+++ b/apple/tests/OdrCoreTests.swift
@@ -118,6 +118,20 @@ final class HtmlTests: XCTestCase {
     XCTAssertTrue(html.contains("<style"), "the html has no stylesheet")
   }
 
+  /// A view's impl points into its service without owning it, so the view has
+  /// to keep the service alive itself — the analogue of
+  /// `ElementTreeTests.testElementsKeepTheirDocumentAlive`. Rendering off a
+  /// service that only ever existed as a temporary used to segfault.
+  func testViewsKeepTheirServiceAlive() throws {
+    func viewOnly() throws -> HtmlView {
+      try XCTUnwrap(try service().views.first)
+    }
+    let view = try viewOnly()
+    XCTAssertFalse(view.path.isEmpty)
+    var resources: NSArray?
+    XCTAssertFalse(try view.writeHtml(resources: &resources).isEmpty)
+  }
+
   func testBringOfflineWritesFiles() throws {
     let output = try temporaryDirectory()
     let html = try service().bringOffline(to: output)


### PR DESCRIPTION
🤖 Generated with [Claude Code](https://claude.com/claude-code)

`odr::HtmlView` looks self-sufficient — it holds a `shared_ptr` — but the impl behind it, `internal::html::HtmlView`, keeps only a bare `abstract::HtmlService *` and forwards `config()` and `write_html()` through it. A view handed out by `-[ODRHtmlService views]` therefore dangles as soon as the service goes, and

```swift
let view = try XCTUnwrap(try service().views.first)   // service is a temporary
let html = try view.writeHtml(resources: &resources)  // 💥 SIGSEGV
```

segfaulted on both macOS and the simulator. That is ordinary Swift, not a contrived lifetime — the same call with the service in a local passes, which is why `testRendersHtml` was green next to it.

`ODRHtmlView` now carries its `ODRHtmlService` the way `ODRElement` already carries its `ODRDocument`. The other two bindings solved this when they bound views: JNI passes an `owner` into the `NativeResource` constructor, python pins the service onto the view as `_service` with the comment *"`translate(...).list_views()[0]` must not dangle"*. Apple was the one that missed it.

## Why this is urgent

`apple` is the only red workflow on main, and `release.yml` has `needs: [version, apple]` — a red test in the called workflow skips the release job, so **no release can be cut until this lands**.

`testRenderedHtmlCarriesItsOwnStyles` has been failing since it landed in #648: it was cancelled on that commit, first actually ran on #649, and failed. It has never been green on main. It is the crash, not a flake.

## Verification

Built both macOS slices locally, assembled the xcframework, ran the suite via `xcodebuild test`:

- with the fix — **all 19 tests pass**, including the previously-crashing `testRenderedHtmlCarriesItsOwnStyles`
- with `owner:nil` spliced back in — `testRenderedHtmlCarriesItsOwnStyles` **and** the new `testViewsKeepTheirServiceAlive` both segfault, while `testRendersHtml` / `testBringOfflineWritesFiles` (which hold the service in a local) still pass

So the new test is load-bearing rather than decorative.

## Also

`apple/AGENTS.md` said `odr::Element` was *the* exception to "a wrapper holding a `shared_ptr` is self-sufficient". It isn't any more, and that sentence is what makes this class of bug easy to reintroduce — updated, with the trap called out.