### PR TITLE
fix(maven): name the central deployment after its coordinates

### DIFF
--- a/jni/pom.xml
+++ b/jni/pom.xml
@@ -173,6 +173,10 @@
               <!-- Uploads and stops, the way the AAR does: a human releases it
                    from the portal, and Central is immutable once released. -->
               <autoPublish>false</autoPublish>
+              <!-- The plugin's default is the literal "Deployment", which tells
+                   nobody which of the two uploads they are looking at. Same
+                   shape the AAR's plugin builds for itself. -->
+              <deploymentName>${project.groupId}-${project.artifactId}-${project.version}</deploymentName>
             </configuration>
           </plugin>
         </plugins>


### PR DESCRIPTION
In the Central Portal, the `odr-core-java` upload showed up as **Deployment** while the AAR showed up as `app.opendocument-odr-core-android-6.2.0` — so of the two deployments awaiting a manual release, only one said what it was.

`central-publishing-maven-plugin` declares its default as the literal string:

```
<deploymentName implementation="java.lang.String" default-value="Deployment">
```

and `jni/pom.xml` never overrode it.

The AAR gets a real name because vanniktech's plugin builds one. Its `MavenCentralBuildService` concatenates group, artifactId and version with the recipe `\1-\1-\1` — **hyphens, not colons**, which is why this uses that separator rather than the more usual `group:artifact:version`.

## Verified

`mvn help:effective-pom -Pcentral -Drevision=6.2.0` resolves it, confirming `${project.version}` reaches through the CI-friendly `${revision}` indirection:

```
<deploymentName>app.opendocument-odr-core-java-6.2.0</deploymentName>
```

against the AAR's `app.opendocument-odr-core-android-6.2.0`.

Cosmetic — it changes the portal label only, not coordinates, artifacts or the published pom. Takes effect on the next release; v6.2.0 is already out.

🤖 Generated with [Claude Code](https://claude.com/claude-code)