### PR TITLE
feat(html): floor a text document's page box at one page height

### DIFF
--- a/src/odr/internal/html/document.cpp
+++ b/src/odr/internal/html/document.cpp
@@ -299,13 +299,13 @@ public:
     const TextRoot element = root.as_text_root();
 
     if (state.config().text_document_margin) {
-      auto page_layout = element.page_layout();
-      page_layout.height = {};
+      const PageLayout page_layout = element.page_layout();
 
       out.write_element_begin(
-          "div", HtmlElementOptions()
-                     .set_class("odr-page-outer")
-                     .set_style(translate_outer_page_style(page_layout)));
+          "div",
+          HtmlElementOptions()
+              .set_class("odr-page-outer")
+              .set_style(translate_outer_flowing_page_style(page_layout)));
       out.write_element_begin(
           "div", HtmlElementOptions()
                      .set_class("odr-page-inner")

--- a/src/odr/internal/html/document_style.cpp
+++ b/src/odr/internal/html/document_style.cpp
@@ -97,6 +97,19 @@ std::string html::translate_outer_page_style(const PageLayout &page_layout) {
   return result;
 }
 
+std::string
+html::translate_outer_flowing_page_style(const PageLayout &page_layout) {
+  PageLayout flowing_page_layout = page_layout;
+  flowing_page_layout.height = {};
+
+  std::string result = translate_outer_page_style(flowing_page_layout);
+  if (const std::optional<Measure> height = page_layout.height;
+      height.has_value()) {
+    result.append("min-height:").append(height->to_string()).append(";");
+  }
+  return result;
+}
+
 std::string html::translate_inner_page_style(const PageLayout &page_layout) {
   std::string result;
   if (const std::optional<Quantity<double>> margin_right =

--- a/src/odr/internal/html/document_style.hpp
+++ b/src/odr/internal/html/document_style.hpp
@@ -35,8 +35,6 @@ const char *translate_font_style(FontStyle font_style);
 const char *translate_font_position(FontPosition font_position);
 
 std::string translate_outer_page_style(const PageLayout &page_layout);
-/// Like `translate_outer_page_style`, but the page height only floors the box
-/// so that content may flow past it.
 std::string translate_outer_flowing_page_style(const PageLayout &page_layout);
 std::string translate_inner_page_style(const PageLayout &page_layout);
 std::string translate_text_style(const TextStyle &text_style);

--- a/src/odr/internal/html/document_style.hpp
+++ b/src/odr/internal/html/document_style.hpp
@@ -35,6 +35,9 @@ const char *translate_font_style(FontStyle font_style);
 const char *translate_font_position(FontPosition font_position);
 
 std::string translate_outer_page_style(const PageLayout &page_layout);
+/// Like `translate_outer_page_style`, but the page height only floors the box
+/// so that content may flow past it.
+std::string translate_outer_flowing_page_style(const PageLayout &page_layout);
 std::string translate_inner_page_style(const PageLayout &page_layout);
 std::string translate_text_style(const TextStyle &text_style);
 std::string translate_paragraph_style(const ParagraphStyle &paragraph_style);

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -37,6 +37,7 @@ add_executable(odr_test
         "src/table_position_test.cpp"
 
         "src/internal/html/common_test.cpp"
+        "src/internal/html/document_style_test.cpp"
         "src/internal/html/image_file_test.cpp"
         "src/internal/html/media_file_test.cpp"
 

--- a/test/src/internal/html/document_style_test.cpp
+++ b/test/src/internal/html/document_style_test.cpp
@@ -1,0 +1,37 @@
+#include <odr/quantity.hpp>
+#include <odr/style.hpp>
+
+#include <odr/internal/html/document_style.hpp>
+
+#include <gtest/gtest.h>
+
+using namespace odr;
+namespace ihtml = odr::internal::html;
+
+namespace {
+
+PageLayout a4_page_layout() {
+  PageLayout page_layout;
+  page_layout.width = Measure("21cm");
+  page_layout.height = Measure("29.7cm");
+  return page_layout;
+}
+
+} // namespace
+
+TEST(html_document_style, outer_page_style_fixes_both_dimensions) {
+  EXPECT_EQ(ihtml::translate_outer_page_style(a4_page_layout()),
+            "width:21cm;height:29.7cm;");
+}
+
+TEST(html_document_style, outer_flowing_page_style_floors_the_height) {
+  EXPECT_EQ(ihtml::translate_outer_flowing_page_style(a4_page_layout()),
+            "width:21cm;min-height:29.7cm;");
+}
+
+TEST(html_document_style, outer_flowing_page_style_without_height) {
+  PageLayout page_layout = a4_page_layout();
+  page_layout.height = {};
+  EXPECT_EQ(ihtml::translate_outer_flowing_page_style(page_layout),
+            "width:21cm;");
+}


### PR DESCRIPTION
🤖 Generated with [Claude Code](https://claude.com/claude-code)

A text document renders as a single `.odr-page-outer` that grows with its content, so `TextHtmlFragment` discarded the page height outright. A document shorter than one page therefore came out as a sliver of white rather than a page — visible now that the downstream apps paginate.

The height now *floors* the box instead of being dropped:

```
- width:8.2681in;
+ width:8.2681in;min-height:11.6929in;
```

Anything longer than a page is unaffected, since `min-height` can only ever be below the content height there. The other frontends are untouched — slides, drawing pages and PDF pages already emit both dimensions from their real page geometry.

New `translate_outer_flowing_page_style` keeps the "this box flows past its page" rule in `document_style.cpp` next to its fixed-size sibling, rather than as a `page_layout.height = {}` mutation at the call site.

## Verification

- New `html_document_style` unit tests cover the fixed/flowing/missing-height cases.
- End-to-end on `odr-public/odt/empty.odt` with `text_document_margin = true`: emits `width:8.2681in;min-height:11.6929in;`.
- `HtmlOutputTests` for odt/docx pass. **No reference-output regen needed** — `text_document_margin` defaults to `false`, and no committed reference for a text document contains a page box (only odg/odp/ppt/pptx do, and those paths are unchanged).