### PR TITLE
fix: whole-codebase correctness and conciseness review

### DIFF
--- a/android/src/androidTest/java/app/opendocument/core/DocumentTest.kt
+++ b/android/src/androidTest/java/app/opendocument/core/DocumentTest.kt
@@ -94,8 +94,6 @@ class DocumentTest {
 
         val pages = html.pages()
         assertEquals(1, pages.size)
-        // the renderer reads the css/js the AAR ships, so this only passes with the
-        // extracted assets in place
         val content = read(Paths.get(pages[0].path))
         assertTrue(content.contains(TestFiles.ODT_WORD))
     }

--- a/apple/include/OdrCoreObjC/ODRTable.h
+++ b/apple/include/OdrCoreObjC/ODRTable.h
@@ -35,8 +35,11 @@ NS_INLINE ODRTablePosition ODRTablePositionMake(uint32_t column, uint32_t row) {
 NS_SWIFT_NAME(TableAddress)
 @interface ODRTableAddress : NSObject
 
+/// 0 for anything that is not a column, e.g. `"c"` or `""`; use
+/// `position:fromString:` to be told why instead.
 + (uint32_t)columnNumberFromString:(NSString *)string
     NS_SWIFT_NAME(columnNumber(from:));
+/// 0 for anything that is not a row number.
 + (uint32_t)rowNumberFromString:(NSString *)string
     NS_SWIFT_NAME(rowNumber(from:));
 + (NSString *)stringFromColumnNumber:(uint32_t)column

--- a/apple/src/ODRDocumentElement.mm
+++ b/apple/src/ODRDocumentElement.mm
@@ -60,13 +60,24 @@ ODRTableDimensions to_dimensions(const odr::TableDimensions &value) {
   return ODRTableDimensionsMake(value.rows, value.columns);
 }
 
+/// Wraps a range through `-derive:`, so `source`'s owner is carried along.
+NSArray<ODRElement *> *to_nsarray(ODRElement *const source,
+                                  const odr::ElementRange &range) {
+  NSMutableArray<ODRElement *> *const result = [NSMutableArray array];
+  for (const odr::Element element : range) {
+    if (ODRElement *const wrapped = [source derive:element]; wrapped != nil) {
+      [result addObject:wrapped];
+    }
+  }
+  return result;
+}
+
 } // namespace
 
 @implementation ODRElement {
   odr::Element _handle;
-  // The document the adapter behind `_handle` belongs to. `odr::Element` holds
-  // a bare pointer into it, so without this the tree could outlive what it
-  // points into — the analogue of the JNI bindings' owner chain.
+  // `odr::Element` holds a bare pointer into the document's adapter, so the
+  // tree has to keep the document alive itself.
   id _owner;
 }
 
@@ -212,15 +223,7 @@ ODRTableDimensions to_dimensions(const odr::TableDimensions &value) {
 - (NSArray<ODRElement *> *)children {
   return guarded_value(
       [&]() -> NSArray<ODRElement *> * {
-        NSMutableArray<ODRElement *> *const result = [NSMutableArray array];
-        for (odr::Element child = _handle.first_child(); child;
-             child = child.next_sibling()) {
-          ODRElement *const wrapped = [self derive:child];
-          if (wrapped != nil) {
-            [result addObject:wrapped];
-          }
-        }
-        return result;
+        return to_nsarray(self, _handle.children());
       },
       @[]);
 }
@@ -333,14 +336,7 @@ ODRTableDimensions to_dimensions(const odr::TableDimensions &value) {
 - (NSArray<ODRElement *> *)shapes {
   return guarded_value(
       [&]() -> NSArray<ODRElement *> * {
-        NSMutableArray<ODRElement *> *const result = [NSMutableArray array];
-        for (const odr::Element shape : self.handle.as_sheet().shapes()) {
-          ODRElement *const wrapped = [self derive:shape];
-          if (wrapped != nil) {
-            [result addObject:wrapped];
-          }
-        }
-        return result;
+        return to_nsarray(self, self.handle.as_sheet().shapes());
       },
       @[]);
 }
@@ -578,14 +574,7 @@ ODRTableDimensions to_dimensions(const odr::TableDimensions &value) {
 - (NSArray<ODRElement *> *)columns {
   return guarded_value(
       [&]() -> NSArray<ODRElement *> * {
-        NSMutableArray<ODRElement *> *const result = [NSMutableArray array];
-        for (const odr::Element column : self.handle.as_table().columns()) {
-          ODRElement *const wrapped = [self derive:column];
-          if (wrapped != nil) {
-            [result addObject:wrapped];
-          }
-        }
-        return result;
+        return to_nsarray(self, self.handle.as_table().columns());
       },
       @[]);
 }
@@ -593,14 +582,7 @@ ODRTableDimensions to_dimensions(const odr::TableDimensions &value) {
 - (NSArray<ODRElement *> *)rows {
   return guarded_value(
       [&]() -> NSArray<ODRElement *> * {
-        NSMutableArray<ODRElement *> *const result = [NSMutableArray array];
-        for (const odr::Element row : self.handle.as_table().rows()) {
-          ODRElement *const wrapped = [self derive:row];
-          if (wrapped != nil) {
-            [result addObject:wrapped];
-          }
-        }
-        return result;
+        return to_nsarray(self, self.handle.as_table().rows());
       },
       @[]);
 }

--- a/apple/src/ODRFile.mm
+++ b/apple/src/ODRFile.mm
@@ -271,8 +271,9 @@ NSString *_Nullable to_nsstring(const std::optional<std::string> &value) {
 
 + (instancetype)decodedFileWithHandle:(odr::DecodedFile)handle {
   // The most derived wrapper the file qualifies for, so a caller never has to
-  // downcast something it already knows the type of. PDFs are document files
-  // too, so they have to be tested first.
+  // downcast something it already knows the type of. The predicates are
+  // mutually exclusive — a PDF is not an `is_document_file`, despite reporting
+  // `FileCategory::document`.
   Class klass = [ODRDecodedFile class];
   if (handle.is_pdf_file()) {
     klass = [ODRPdfFile class];

--- a/apple/src/ODRHtml.mm
+++ b/apple/src/ODRHtml.mm
@@ -306,9 +306,8 @@ NSArray<ODRHtmlResource *> *to_nsarray(const odr::HtmlResources &resources) {
 
 @implementation ODRHtmlView {
   std::optional<odr::HtmlView> _handle;
-  // The service the view belongs to. The view's impl holds a bare pointer to
-  // it, so without this a view handed out by `-views` could outlive what it
-  // points into — the same owner chain `ODRElement` keeps to its document.
+  // The view's impl holds a bare pointer to its service, so the view has to
+  // keep the service alive itself — as `ODRElement` does its document.
   id _owner;
 }
 

--- a/apple/src/ODRInternal.h
+++ b/apple/src/ODRInternal.h
@@ -36,25 +36,13 @@ NSData *to_nsdata(std::istream &stream);
 /// inside a `catch`.
 void fill_error(NSError *_Nullable *_Nullable error);
 
-/// Fills `*error` with `ODRErrorUnsupportedOperation` for an API area that is
-/// declared but not bound yet, and returns nil. Every use is a placeholder to
-/// delete, never a permanent answer.
-id _Nullable not_yet_bound(NSError *_Nullable *_Nullable error,
-                           const char *what);
-
 /// Reports an exception that could not be handed to the caller. Call only from
 /// inside a `catch`.
 void report_swallowed(const char *what);
 
 /// Runs `body` where the caller has no way to receive an error — an ObjC
-/// property, or a `void` method — and returns `fallback` if it throws.
-///
-/// This is not politeness. An exception crossing into Objective-C++ unhandled
-/// calls `std::terminate`, so an unguarded getter turns a malformed argument
-/// into a crash of the *host app*; `odr::Filesystem::exists("")` throwing
-/// `std::invalid_argument` is exactly how this was found. Almost nothing in
-/// odrcore's public API is `noexcept`, so assume any call can throw and pick a
-/// fallback that keeps the caller sane — `YES` for a walker's `end`, so a
+/// property, or a `void` method — and returns `fallback` if it throws. Pick a
+/// fallback that keeps the caller sane: `YES` for a walker's `end`, so a
 /// `while (!end)` loop terminates rather than spins.
 template <typename Body>
 auto guarded_value(Body &&body, std::invoke_result_t<Body> fallback)
@@ -82,11 +70,8 @@ template <typename Body> void guarded_void(Body &&body) {
 }
 
 /// Runs `body`, mapping any C++ exception onto `*error`. A failed call returns
-/// a value-initialised `Result` — `nil` for an object, `NO` for a `BOOL`, `0`
-/// for a count — which is exactly the ObjC convention for "consult the error".
-///
-/// Every binding body goes through this: an exception crossing into ObjC++
-/// unhandled would terminate the process.
+/// a value-initialised `Result` — `nil`, `NO`, `0` — which is the ObjC
+/// convention for "consult the error".
 template <typename Body>
 auto guarded(NSError *_Nullable *_Nullable error,
              Body &&body) -> decltype(body()) {

--- a/apple/src/ODRLogger.mm
+++ b/apple/src/ODRLogger.mm
@@ -25,26 +25,33 @@ ODR_SAME_ENUM(ODRLogLevelFatal, odr::LogLevel::fatal);
 
 namespace {
 
+void report_sink_exception(NSException *const exception) {
+  // A logger must not derail the operation it is reporting on.
+  NSLog(@"odr: log sink threw %@: %@", exception.name, exception.reason);
+}
+
 /// Routes `odr::ILogger` into an ObjC sink, the analogue of `jni_logger.cpp`'s
-/// `JavaLogger`.
-///
-/// Holds the sink strongly: the C++ logger can outlive every ObjC reference the
-/// caller kept, and a sink collected out from under it would be a use after
-/// free on a background thread.
+/// `JavaLogger`. Holds the sink strongly: the C++ logger can outlive every ObjC
+/// reference the caller kept.
 class SinkLogger final : public odr::ILogger {
 public:
   explicit SinkLogger(id<ODRLogSink> sink) : m_sink{sink} {}
 
   [[nodiscard]] bool will_log(const odr::LogLevel level) const final {
     @autoreleasepool {
-      return [m_sink willLog:static_cast<ODRLogLevel>(level)] == YES;
+      @try {
+        return [m_sink willLog:static_cast<ODRLogLevel>(level)] == YES;
+      } @catch (NSException *const exception) {
+        report_sink_exception(exception);
+        return false;
+      }
     }
   }
 
   void log(const Time, const odr::LogLevel level, const std::string &message,
            const std::source_location &location) final {
-    // Log calls arrive on whatever thread the library works on, so each one
-    // gets its own pool rather than leaking into the caller's.
+    // Calls arrive on whatever thread the library works on, so each one gets
+    // its own pool rather than leaking into the caller's.
     @autoreleasepool {
       @try {
         [m_sink logLevel:static_cast<ODRLogLevel>(level)
@@ -53,8 +60,7 @@ public:
                              std::string_view(location.file_name()))
                     line:location.line()];
       } @catch (NSException *const exception) {
-        // A logger must not derail the operation it is reporting on.
-        NSLog(@"odr: log sink threw %@: %@", exception.name, exception.reason);
+        report_sink_exception(exception);
       }
     }
   }
@@ -64,7 +70,7 @@ public:
       @try {
         [m_sink flush];
       } @catch (NSException *const exception) {
-        NSLog(@"odr: log sink threw %@: %@", exception.name, exception.reason);
+        report_sink_exception(exception);
       }
     }
   }

--- a/apple/src/ODRPrivate.h
+++ b/apple/src/ODRPrivate.h
@@ -19,14 +19,10 @@
 
 /// Cross-translation-unit access to the C++ value each wrapper owns.
 ///
-/// The handle model is much lighter than the JNI one (`jni/AGENTS.md`): an
-/// ObjC++ `@implementation` can hold the C++ handle as an ivar directly, and
-/// ARC's `.cxx_construct`/`.cxx_destruct` run its constructor and destructor.
-/// No `long` handles, no `destroy` natives, no reaper thread.
-///
-/// Nor is there a keep-alive chain to maintain for these: the public C++
-/// handles hold a `shared_ptr` to the implementation, so a wrapper owning one
-/// by value already keeps it alive on its own.
+/// Each `@implementation` holds its handle as an ivar, destroyed by ARC's
+/// `.cxx_destruct` — no `long` handles as in `jni/`. Most handles own a
+/// `shared_ptr`, so a wrapper holding one needs no keep-alive; the exceptions
+/// are `ODRElement` and `ODRHtmlView` below.
 ///
 /// Categories cannot add ivars, so each class declares its own accessors here
 /// and implements them next to its `@implementation`.

--- a/apple/src/ODRStyle.mm
+++ b/apple/src/ODRStyle.mm
@@ -7,6 +7,7 @@
 
 #include <optional>
 
+using odr::apple::guarded_value;
 using odr::apple::to_nsstring;
 
 ODR_SAME_ENUM(ODRFontWeightNormal, odr::FontWeight::normal);
@@ -59,14 +60,11 @@ using odr::apple::box;
 
 namespace {
 
-/// The boxed forms of an absent `std::optional`. `nil` and not a sentinel: a
-/// style that does not set a property is different from one that sets it to a
-/// default, and only the caller knows what to fall back to.
-NSNumber *_Nullable box_bool(const std::optional<bool> &value) {
-  return value.has_value() ? @(*value) : nil;
-}
-
-NSNumber *_Nullable box_double(const std::optional<double> &value) {
+/// An absent `std::optional` boxes as `nil` and not as a sentinel: a style that
+/// does not set a property is different from one that sets it to a default, and
+/// only the caller knows what to fall back to.
+template <typename T>
+NSNumber *_Nullable box_number(const std::optional<T> &value) {
   return value.has_value() ? @(*value) : nil;
 }
 
@@ -75,15 +73,10 @@ NSNumber *_Nullable box_enum(const std::optional<Enum> &value) {
   return value.has_value() ? @(static_cast<NSInteger>(*value)) : nil;
 }
 
-NSString *_Nullable box_string(const std::optional<std::string> &value) {
-  return value.has_value() ? to_nsstring(*value) : nil;
-}
-
-/// `font_name` is a `string_view` borrowing from the document that produced the
-/// style, so it must be copied here — an `NSString` outliving that document is
-/// the whole point of handing it to a caller.
-NSString *_Nullable box_string_view(
-    const std::optional<std::string_view> &value) {
+/// Also takes the `string_view` of `font_name`, which borrows from the document
+/// that produced the style — copying it here is the point.
+template <typename T>
+NSString *_Nullable box_string(const std::optional<T> &value) {
   return value.has_value() ? to_nsstring(*value) : nil;
 }
 
@@ -102,15 +95,16 @@ NSString *_Nullable box_string_view(
 }
 
 - (double)magnitude {
-  return _handle->magnitude();
+  return guarded_value([&] { return _handle->magnitude(); }, 0.0);
 }
 
 - (NSString *)unit {
-  return to_nsstring(_handle->unit().name());
+  return guarded_value([&] { return to_nsstring(_handle->unit().name()); },
+                       @"");
 }
 
 - (NSString *)stringValue {
-  return to_nsstring(_handle->to_string());
+  return guarded_value([&] { return to_nsstring(_handle->to_string()); }, @"");
 }
 
 - (NSString *)description {
@@ -155,12 +149,12 @@ NSString *_Nullable box_string_view(
 
 + (instancetype)styleWithHandle:(const odr::TextStyle &)handle {
   ODRTextStyle *const result = [[ODRTextStyle alloc] init];
-  result->_fontName = box_string_view(handle.font_name);
+  result->_fontName = box_string(handle.font_name);
   result->_fontSize = box(handle.font_size);
   result->_fontWeight = box_enum(handle.font_weight);
   result->_fontStyle = box_enum(handle.font_style);
-  result->_fontUnderline = box_bool(handle.font_underline);
-  result->_fontLineThrough = box_bool(handle.font_line_through);
+  result->_fontUnderline = box_number(handle.font_underline);
+  result->_fontLineThrough = box_number(handle.font_line_through);
   result->_fontShadow = box_string(handle.font_shadow);
   result->_fontColor = box(handle.font_color);
   result->_backgroundColor = box(handle.background_color);
@@ -223,7 +217,7 @@ NSString *_Nullable box_string_view(
   result->_padding =
       [ODRDirectionalMeasure directionalWithHandle:handle.padding];
   result->_border = [ODRDirectionalString directionalWithHandle:handle.border];
-  result->_textRotation = box_double(handle.text_rotation);
+  result->_textRotation = box_number(handle.text_rotation);
   return result;
 }
 

--- a/apple/src/ODRTable.mm
+++ b/apple/src/ODRTable.mm
@@ -6,6 +6,7 @@
 #include <odr/table_position.hpp>
 
 using odr::apple::guarded;
+using odr::apple::guarded_value;
 using odr::apple::to_nsstring;
 using odr::apple::to_string;
 
@@ -16,25 +17,37 @@ static_assert(sizeof(ODRTablePosition) == sizeof(odr::TablePosition),
 
 @implementation ODRTableAddress
 
+// The parses throw on anything that is not a cell address — an empty string, a
+// lowercase column, a non-numeric row. These have no error out-parameter, so
+// they fall back to 0; `position:fromString:` is the one that reports why.
 + (uint32_t)columnNumberFromString:(NSString *)string {
-  return odr::TablePosition::to_column_num(to_string(string));
+  return guarded_value(
+      [&] { return odr::TablePosition::to_column_num(to_string(string)); }, 0u);
 }
 
 + (uint32_t)rowNumberFromString:(NSString *)string {
-  return odr::TablePosition::to_row_num(to_string(string));
+  return guarded_value(
+      [&] { return odr::TablePosition::to_row_num(to_string(string)); }, 0u);
 }
 
 + (NSString *)stringFromColumnNumber:(uint32_t)column {
-  return to_nsstring(odr::TablePosition::to_column_string(column));
+  return guarded_value(
+      [&] { return to_nsstring(odr::TablePosition::to_column_string(column)); },
+      @"");
 }
 
 + (NSString *)stringFromRowNumber:(uint32_t)row {
-  return to_nsstring(odr::TablePosition::to_row_string(row));
+  return guarded_value(
+      [&] { return to_nsstring(odr::TablePosition::to_row_string(row)); }, @"");
 }
 
 + (NSString *)stringFromPosition:(ODRTablePosition)position {
-  return to_nsstring(
-      odr::TablePosition(position.column, position.row).to_string());
+  return guarded_value(
+      [&] {
+        return to_nsstring(
+            odr::TablePosition(position.column, position.row).to_string());
+      },
+      @"");
 }
 
 + (BOOL)position:(ODRTablePosition *)position

--- a/apple/swift/Element+Tree.swift
+++ b/apple/swift/Element+Tree.swift
@@ -23,7 +23,7 @@ extension Element {
 
   /// The first descendant of the given type, or `nil`.
   public func firstDescendant<T: Element>(ofType type: T.Type) -> T? {
-    descendants.lazy.compactMap { $0 as? T }.first { _ in true }
+    descendants(ofType: type).first { _ in true }
   }
 
   /// The chain of ancestors, closest first.

--- a/apple/swift/HttpServer+Serve.swift
+++ b/apple/swift/HttpServer+Serve.swift
@@ -1,17 +1,14 @@
 import Foundation
 
 extension HttpServer {
-  /// Binds, serves, and stops when the returned handle is released or
-  /// cancelled.
+  /// Binds and serves, stopping when the returned handle is released.
   ///
-  /// `listen()` blocks its thread until `stop()`, which is a shape no Swift
-  /// caller wants to manage by hand — and getting it wrong deadlocks, because
-  /// `stop()` waits for `listen()` to return and so must never be called from
-  /// the thread that is inside it. This runs `listen()` on a detached thread of
-  /// its own and hands back the port. Returns only once the server is actually
-  /// serving, and throws rather than hand back a handle if it never gets there.
+  /// Runs the blocking `listen()` on a thread of its own — `stop()` waits for
+  /// `listen()` to return, so calling it from that thread deadlocks. Returns
+  /// only once the server is really serving, and throws instead of handing back
+  /// a handle if it never gets there.
   ///
-  /// Bind `127.0.0.1` on iOS. `0.0.0.0` trips the Local Network permission
+  /// Bind `127.0.0.1` on iOS: `0.0.0.0` trips the Local Network permission
   /// prompt, and nothing off the device needs to reach a server that exists to
   /// feed a web view.
   public func serve(
@@ -32,12 +29,8 @@ extension HttpServer {
     thread.name = "app.opendocument.OdrCore.HttpServer"
     thread.start()
 
-    // `listen()` runs on that thread, so `serve()` would otherwise return
-    // before the server is actually serving and `isRunning` would be false to
-    // the caller that just started it. Connections queue in the backlog from
-    // `bind()` onward, so this is about the observable state being honest
-    // rather than about correctness of the first request. Bounded, because a
-    // server that was already stopped never starts running at all.
+    // Otherwise `isRunning` would be false to the caller that just started the
+    // server. Bounded, because one that was already stopped never starts.
     let deadline = Date().addingTimeInterval(5)
     while !isRunning, failure.stored == nil, Date() < deadline {
       Thread.sleep(forTimeInterval: 0.005)

--- a/apple/swift/OdrCore.swift
+++ b/apple/swift/OdrCore.swift
@@ -1,11 +1,9 @@
 /// The Objective-C bindings are the API; this target re-exports them so a
 /// consumer writes one `import OdrCore`.
 ///
-/// What lives here is only what an ObjC annotation cannot express — sequences
-/// over the element tree, real Swift optionals over the boxed style values, and
-/// structured concurrency around the blocking HTTP server. Anything that *can*
-/// be said with `NS_SWIFT_NAME`, nullability or `NS_ERROR_ENUM` belongs in the
-/// headers instead, so there is one API to keep correct rather than two. This
-/// is the same rule `android/` follows in refusing to restate the java API in
-/// kotlin.
+/// Only what an ObjC annotation cannot express belongs here — element-tree
+/// sequences, real Swift optionals over the boxed style values, a thread around
+/// the blocking HTTP server. Anything `NS_SWIFT_NAME`, nullability or
+/// `NS_ERROR_ENUM` can say belongs in the headers, so there is one API to keep
+/// correct rather than two.
 @_exported import OdrCoreObjC

--- a/apple/tests/Fixture.swift
+++ b/apple/tests/Fixture.swift
@@ -1,19 +1,13 @@
 import Foundation
 import XCTest
 
-/// The document the suite runs on.
-///
-/// `Fixtures/mixed-layout.odt` is `odt/mixed-layout.odt` from
+/// The document the suite runs on: `odt/mixed-layout.odt` from
 /// [OpenDocument.test](https://github.com/opendocument-app/OpenDocument.test),
-/// copied in rather than referenced. `test/data/` is fetched by
-/// `cmake/test_data.cmake` and is not part of a package checkout, and pulling
-/// it in as a submodule is precisely what `Package.swift` must not do — SwiftPM
-/// initialises submodules on every consumer's checkout.
+/// copied in because `test/data/` is fetched and a package checkout has none of
+/// it — and a submodule is the one thing `Package.swift` must never grow.
 ///
-/// 9 KB of real LibreOffice output, four paragraphs across three master pages,
-/// each a text run plus a span. It replaced a document this suite wrote itself,
-/// which only ever proved that odrcore could read back what the test had
-/// written.
+/// 9 KB of real LibreOffice output: four paragraphs across three master pages,
+/// each a text run plus a span.
 enum Fixture {
   /// The text nodes of `odt`, in document order. Each paragraph is a run and a
   /// span, so the numbers are their own nodes.

--- a/cli/src/back_translate.cpp
+++ b/cli/src/back_translate.cpp
@@ -9,7 +9,12 @@
 
 using namespace odr;
 
-int main(int, char **argv) {
+int main(const int argc, char **argv) {
+  if (argc < 4) {
+    std::cerr << "usage: back_translate <input> <diff> <output>\n";
+    return 2;
+  }
+
   try {
     const Logger logger =
         Logger::create_stdio("odr-back-translate", LogLevel::verbose);

--- a/cli/src/meta.cpp
+++ b/cli/src/meta.cpp
@@ -10,6 +10,11 @@
 using namespace odr;
 
 int main(const int argc, char **argv) {
+  if (argc < 2) {
+    std::cerr << "usage: meta <input> [password]\n";
+    return 2;
+  }
+
   try {
     const Logger logger = Logger::create_stdio("odr-meta", LogLevel::verbose);
 

--- a/cli/src/server.cpp
+++ b/cli/src/server.cpp
@@ -13,6 +13,11 @@
 using namespace odr;
 
 int main(const int argc, char **argv) {
+  if (argc < 2) {
+    std::cerr << "usage: server <input> [password]\n";
+    return 2;
+  }
+
   try {
     const Logger logger = Logger::create_stdio("odr-server", LogLevel::verbose);
 

--- a/cli/src/translate.cpp
+++ b/cli/src/translate.cpp
@@ -9,6 +9,11 @@
 using namespace odr;
 
 int main(const int argc, char **argv) {
+  if (argc < 3) {
+    std::cerr << "usage: translate <input> <output> [password]\n";
+    return 2;
+  }
+
   try {
     const Logger logger =
         Logger::create_stdio("odr-translate", LogLevel::verbose);
@@ -40,11 +45,9 @@ int main(const int argc, char **argv) {
     config.editable = true;
     config.format_html = true;
 
-    const std::string output_tmp = output + "/tmp";
-    std::filesystem::create_directories(output_tmp);
+    std::filesystem::create_directories(output);
     const HtmlService service = html::translate(decoded_file, output, config);
-    Html html = service.bring_offline(output);
-    std::filesystem::remove_all(output_tmp);
+    const Html html = service.bring_offline(output);
 
     return 0;
   } catch (const std::exception &e) {

--- a/jni/java/app/opendocument/core/GuardedNativeResource.java
+++ b/jni/java/app/opendocument/core/GuardedNativeResource.java
@@ -6,14 +6,9 @@ import java.util.function.LongConsumer;
  * A {@link NativeResource} whose handle stays valid for the duration of a native
  * call, even when another thread closes it meanwhile.
  *
- * <p>{@link NativeResource#handle()} hands out a raw pointer and {@link #close()}
- * frees what it points at, so a call that has read the handle but not used it yet
- * is left holding a dangling one. For nearly every binding that is caller error -
- * you do not use an object while you close it - and plain {@link NativeResource}
- * is right, at no cost in fields or locks. It is not caller error where the API
- * asks for the call to be made on a thread of its own, which is
- * {@code HttpServer.listen()}: closing the server is exactly how that call is
- * meant to end.
+ * <p>Using an object while closing it is caller error everywhere except where the
+ * API asks for the call to run on a thread of its own - {@code HttpServer.listen()},
+ * which closing the server is meant to end.
  *
  * <p>{@link #guarded} counts such a call in and out. {@link #close()} stops new
  * ones from starting, calls {@link #unblock()} to make the ones in flight return,

--- a/jni/java/app/opendocument/core/Html.java
+++ b/jni/java/app/opendocument/core/Html.java
@@ -51,19 +51,35 @@ public final class Html {
     }
   }
 
+  // The handles below go into a static native as arguments, so no receiver holds
+  // the wrapper for the duration - keepAlive() does.
+
   /** Translates a decoded file to HTML. */
   public static HtmlService translate(DecodedFile file, String cachePath, HtmlConfig config) {
-    return new HtmlService(translateFile(file.handle(), cachePath, config), file);
+    try {
+      return new HtmlService(translateFile(file.handle(), cachePath, config), file);
+    } finally {
+      file.keepAlive();
+    }
   }
 
   /** Translates a document to HTML. */
   public static HtmlService translate(Document document, String cachePath, HtmlConfig config) {
-    return new HtmlService(translateDocument(document.handle(), cachePath, config), document);
+    try {
+      return new HtmlService(translateDocument(document.handle(), cachePath, config), document);
+    } finally {
+      document.keepAlive();
+    }
   }
 
   /** Translates a filesystem to HTML. */
   public static HtmlService translate(Filesystem filesystem, String cachePath, HtmlConfig config) {
-    return new HtmlService(translateFilesystem(filesystem.handle(), cachePath, config), filesystem);
+    try {
+      return new HtmlService(
+          translateFilesystem(filesystem.handle(), cachePath, config), filesystem);
+    } finally {
+      filesystem.keepAlive();
+    }
   }
 
   /** Applies a diff (produced by the browser-side editor) to a document. */

--- a/jni/java/app/opendocument/core/HtmlService.java
+++ b/jni/java/app/opendocument/core/HtmlService.java
@@ -59,7 +59,14 @@ public final class HtmlService extends NativeResource {
     for (int i = 0; i < handles.length; i++) {
       handles[i] = views.get(i).handle();
     }
-    return bringOfflineViewsNative(handle(), outputPath, handles);
+    try {
+      return bringOfflineViewsNative(handle(), outputPath, handles);
+    } finally {
+      // the handles went in as arguments, so nothing else keeps the views alive
+      for (HtmlView view : views) {
+        view.keepAlive();
+      }
+    }
   }
 
   private static native void destroy(long handle);

--- a/jni/java/app/opendocument/core/HttpServer.java
+++ b/jni/java/app/opendocument/core/HttpServer.java
@@ -65,9 +65,8 @@ public final class HttpServer extends GuardedNativeResource {
    * Blocks serving requests until {@link #stop()} is called from another thread.
    * Returns right away if the server has already been stopped or closed.
    *
-   * <p>Guarded: this is the one call in the bindings that is meant to be made on a
-   * thread of its own while another closes the object it runs on, so the handle it
-   * takes has to stay valid until it hands it back.
+   * <p>Guarded: the handle stays valid until this returns, even if another thread
+   * closes the server meanwhile.
    */
   public void listen() {
     guarded(this::listenNative);

--- a/jni/java/app/opendocument/core/NativeResource.java
+++ b/jni/java/app/opendocument/core/NativeResource.java
@@ -17,11 +17,8 @@ import java.util.function.LongConsumer;
  * collected while handles into it are alive.
  *
  * <p>The post-mortem free is a {@link PhantomReference} drained by a daemon
- * thread rather than a {@link java.lang.ref.Cleaner}, which is exactly what a
- * Cleaner does internally. Cleaner is a JDK 9 API that android only ships from
- * API level 33, and OpenDocument.droid targets API 26; referencing it made the
- * whole class fail to load there with a {@code NoClassDefFoundError}, and core
- * library desugaring does not cover {@code java.lang.ref}.
+ * thread, not a {@link java.lang.ref.Cleaner}: android ships Cleaner only from
+ * API 33 and desugaring does not cover {@code java.lang.ref}.
  */
 public abstract class NativeResource implements AutoCloseable {
   private static final ReferenceQueue<NativeResource> QUEUE = new ReferenceQueue<>();
@@ -82,24 +79,12 @@ public abstract class NativeResource implements AutoCloseable {
   }
 
   /**
-   * A use of this object that the optimiser cannot drop, so it stays reachable
-   * across whatever ran before it.
+   * A use the optimiser cannot drop, keeping this object reachable across the
+   * call before it. Needed for handles passed as arguments, where no receiver
+   * holds the wrapper and the reaper could free the handle mid-call.
    *
-   * <p>{@link #handle()} outlives the wrapper it came from: once nothing refers to
-   * the wrapper any more the collector may enqueue it and the reaper may free the
-   * handle, and the just-in-time compiler is free to decide that while a native
-   * call using it is still running. A native that takes the handle of the object it
-   * is called on is safe without this - the JNI frame holds the receiver - which is
-   * why every one of them is an instance method of its owner. This is for the
-   * handles that go in as arguments, where there is no receiver to hold them.
-   *
-   * <p>{@code java.lang.ref.Reference.reachabilityFence} is the API for it, and is
-   * unusable here: android has it from API level 28, {@code android/build.gradle.kts}
-   * sets {@code minSdk = 26}, and core library desugaring does not cover
-   * {@code java.lang.ref} - the same wall {@link java.lang.ref.Cleaner} hit above.
-   * Taking the monitor of an object the reference queue can also see is the fallback
-   * the JDK itself used before that method existed: lock elision needs the object to
-   * be provably confined, and this one is not.
+   * <p>The monitor stands in for {@code Reference.reachabilityFence}, which
+   * android only has from API 28 (see {@code jni/AGENTS.md}).
    */
   final void keepAlive() {
     synchronized (this) {

--- a/jni/src/jni_core.cpp
+++ b/jni/src/jni_core.cpp
@@ -254,17 +254,15 @@ Java_app_opendocument_core_Odr_openWithPreferenceNative(
     if (as_file_type >= 0) {
       preference.as_file_type = static_cast<odr::FileType>(as_file_type);
     }
-    const auto append_codes = [&](jintArray array, auto &target,
-                                  auto transform) {
-      const jsize length = env->GetArrayLength(array);
-      jint *codes = env->GetIntArrayElements(array, nullptr);
+    if (jint *codes = env->GetIntArrayElements(file_type_priority, nullptr);
+        codes != nullptr) {
+      const jsize length = env->GetArrayLength(file_type_priority);
       for (jsize i = 0; i < length; ++i) {
-        target.push_back(transform(codes[i]));
+        preference.file_type_priority.push_back(
+            static_cast<odr::FileType>(codes[i]));
       }
-      env->ReleaseIntArrayElements(array, codes, JNI_ABORT);
-    };
-    append_codes(file_type_priority, preference.file_type_priority,
-                 [](jint code) { return static_cast<odr::FileType>(code); });
+      env->ReleaseIntArrayElements(file_type_priority, codes, JNI_ABORT);
+    }
     return make_handle(odr::open(to_string(env, path), preference));
   });
 }

--- a/jni/src/jni_document.cpp
+++ b/jni/src/jni_document.cpp
@@ -50,13 +50,12 @@ jlongArray wrap_elements(JNIEnv *env, const odr::ElementRange &range) {
 // app.opendocument.core.Document
 
 extern "C" JNIEXPORT void JNICALL
-Java_app_opendocument_core_Document_destroy(JNIEnv *, jclass, jlong handle) {
-  destroy_handle<odr::Document>(handle);
+Java_app_opendocument_core_Document_destroy(JNIEnv *env, jclass, jlong handle) {
+  destroy_handle<odr::Document>(env, handle);
 }
 
-// odr::html::edit, but it belongs to Document: a native that takes a handle has
-// to be an instance method of whatever owns it, or the wrapper can be collected
-// - and the handle freed - while the call is still running
+// odr::html::edit, but it belongs to Document: a native taking a handle must be
+// an instance method of its owner, or the wrapper can be collected mid-call.
 extern "C" JNIEXPORT void JNICALL
 Java_app_opendocument_core_Document_editNative(JNIEnv *env, jobject,
                                                jlong handle, jstring diff) {
@@ -147,9 +146,9 @@ Java_app_opendocument_core_DocumentPath_create(JNIEnv *env, jclass,
 }
 
 extern "C" JNIEXPORT void JNICALL
-Java_app_opendocument_core_DocumentPath_destroy(JNIEnv *, jclass,
+Java_app_opendocument_core_DocumentPath_destroy(JNIEnv *env, jclass,
                                                 jlong handle) {
-  destroy_handle<odr::DocumentPath>(handle);
+  destroy_handle<odr::DocumentPath>(env, handle);
 }
 
 extern "C" JNIEXPORT jboolean JNICALL
@@ -190,8 +189,8 @@ Java_app_opendocument_core_DocumentPath_toStringNative(JNIEnv *env, jobject,
 // app.opendocument.core.Element
 
 extern "C" JNIEXPORT void JNICALL
-Java_app_opendocument_core_Element_destroy(JNIEnv *, jclass, jlong handle) {
-  destroy_handle<odr::Element>(handle);
+Java_app_opendocument_core_Element_destroy(JNIEnv *env, jclass, jlong handle) {
+  destroy_handle<odr::Element>(env, handle);
 }
 
 extern "C" JNIEXPORT jint JNICALL Java_app_opendocument_core_Element_typeNative(

--- a/jni/src/jni_file.cpp
+++ b/jni/src/jni_file.cpp
@@ -33,8 +33,8 @@ Java_app_opendocument_core_File_create(JNIEnv *env, jclass, jstring path) {
 }
 
 extern "C" JNIEXPORT void JNICALL
-Java_app_opendocument_core_File_destroy(JNIEnv *, jclass, jlong handle) {
-  destroy_handle<odr::File>(handle);
+Java_app_opendocument_core_File_destroy(JNIEnv *env, jclass, jlong handle) {
+  destroy_handle<odr::File>(env, handle);
 }
 
 extern "C" JNIEXPORT jint JNICALL
@@ -76,9 +76,8 @@ extern "C" JNIEXPORT void JNICALL Java_app_opendocument_core_File_copyNative(
           [&] { from_handle<odr::File>(handle)->copy(to_string(env, path)); });
 }
 
-// yields a DecodedFile but belongs to File: a native that takes a handle has to
-// be an instance method of whatever owns it, or the wrapper can be collected -
-// and the handle freed - while the call is still running
+// Yields a DecodedFile but belongs to File: a native taking a handle must be an
+// instance method of its owner, or the wrapper can be collected mid-call.
 extern "C" JNIEXPORT jlong JNICALL Java_app_opendocument_core_File_decodeNative(
     JNIEnv *env, jobject, jlong handle) {
   return guarded(env, [&] {
@@ -108,8 +107,9 @@ Java_app_opendocument_core_DecodedFile_createAs(JNIEnv *env, jclass,
 }
 
 extern "C" JNIEXPORT void JNICALL
-Java_app_opendocument_core_DecodedFile_destroy(JNIEnv *, jclass, jlong handle) {
-  destroy_handle<odr::DecodedFile>(handle);
+Java_app_opendocument_core_DecodedFile_destroy(JNIEnv *env, jclass,
+                                               jlong handle) {
+  destroy_handle<odr::DecodedFile>(env, handle);
 }
 
 extern "C" JNIEXPORT jlong JNICALL
@@ -403,9 +403,9 @@ Java_app_opendocument_core_FontFile_readNative(JNIEnv *env, jobject,
 
 // app.opendocument.core.FileWalker
 
-extern "C" JNIEXPORT void JNICALL
-Java_app_opendocument_core_FileWalker_destroy(JNIEnv *, jclass, jlong handle) {
-  destroy_handle<odr::FileWalker>(handle);
+extern "C" JNIEXPORT void JNICALL Java_app_opendocument_core_FileWalker_destroy(
+    JNIEnv *env, jclass, jlong handle) {
+  destroy_handle<odr::FileWalker>(env, handle);
 }
 
 extern "C" JNIEXPORT jboolean JNICALL
@@ -470,9 +470,9 @@ Java_app_opendocument_core_FileWalker_flatNextNative(JNIEnv *env, jobject,
 
 // app.opendocument.core.Filesystem
 
-extern "C" JNIEXPORT void JNICALL
-Java_app_opendocument_core_Filesystem_destroy(JNIEnv *, jclass, jlong handle) {
-  destroy_handle<odr::Filesystem>(handle);
+extern "C" JNIEXPORT void JNICALL Java_app_opendocument_core_Filesystem_destroy(
+    JNIEnv *env, jclass, jlong handle) {
+  destroy_handle<odr::Filesystem>(env, handle);
 }
 
 extern "C" JNIEXPORT jboolean JNICALL
@@ -526,8 +526,8 @@ Java_app_opendocument_core_Filesystem_openNative(JNIEnv *env, jobject,
 // app.opendocument.core.Archive
 
 extern "C" JNIEXPORT void JNICALL
-Java_app_opendocument_core_Archive_destroy(JNIEnv *, jclass, jlong handle) {
-  destroy_handle<odr::Archive>(handle);
+Java_app_opendocument_core_Archive_destroy(JNIEnv *env, jclass, jlong handle) {
+  destroy_handle<odr::Archive>(env, handle);
 }
 
 extern "C" JNIEXPORT jlong JNICALL

--- a/jni/src/jni_html.cpp
+++ b/jni/src/jni_html.cpp
@@ -53,11 +53,13 @@ jobject make_html(JNIEnv *env, odr::Html html) {
   jobjectArray page_array =
       env->NewObjectArray(static_cast<jsize>(pages.size()), page_cls, nullptr);
   for (jsize i = 0; i < static_cast<jsize>(pages.size()); ++i) {
-    jobject page =
-        env->NewObject(page_cls, page_ctor, to_jstring(env, pages[i].name),
-                       to_jstring(env, pages[i].path));
+    jstring name = to_jstring(env, pages[i].name);
+    jstring path = to_jstring(env, pages[i].path);
+    jobject page = env->NewObject(page_cls, page_ctor, name, path);
     env->SetObjectArrayElement(page_array, i, page);
     env->DeleteLocalRef(page);
+    env->DeleteLocalRef(path);
+    env->DeleteLocalRef(name);
   }
   env->DeleteLocalRef(page_cls);
 
@@ -94,11 +96,15 @@ jobject make_content(JNIEnv *env, const std::string &html,
     const auto &[resource, location] = resources[i];
     jobject resource_obj = env->NewObject(
         resource_cls, resource_ctor, make_handle(odr::HtmlResource(resource)));
-    jobject located = env->NewObject(
-        located_cls, located_ctor, resource_obj,
-        location.has_value() ? to_jstring(env, *location) : nullptr);
+    jstring location_str =
+        location.has_value() ? to_jstring(env, *location) : nullptr;
+    jobject located =
+        env->NewObject(located_cls, located_ctor, resource_obj, location_str);
     env->SetObjectArrayElement(located_array, i, located);
     env->DeleteLocalRef(located);
+    if (location_str != nullptr) {
+      env->DeleteLocalRef(location_str);
+    }
     env->DeleteLocalRef(resource_obj);
   }
   env->DeleteLocalRef(resource_cls);
@@ -174,8 +180,9 @@ Java_app_opendocument_core_Html_translateFilesystem(JNIEnv *env, jclass,
 // app.opendocument.core.HtmlService
 
 extern "C" JNIEXPORT void JNICALL
-Java_app_opendocument_core_HtmlService_destroy(JNIEnv *, jclass, jlong handle) {
-  destroy_handle<odr::HtmlService>(handle);
+Java_app_opendocument_core_HtmlService_destroy(JNIEnv *env, jclass,
+                                               jlong handle) {
+  destroy_handle<odr::HtmlService>(env, handle);
 }
 
 extern "C" JNIEXPORT jobject JNICALL
@@ -269,8 +276,8 @@ Java_app_opendocument_core_HtmlService_bringOfflineViewsNative(
 // app.opendocument.core.HtmlView
 
 extern "C" JNIEXPORT void JNICALL
-Java_app_opendocument_core_HtmlView_destroy(JNIEnv *, jclass, jlong handle) {
-  destroy_handle<odr::HtmlView>(handle);
+Java_app_opendocument_core_HtmlView_destroy(JNIEnv *env, jclass, jlong handle) {
+  destroy_handle<odr::HtmlView>(env, handle);
 }
 
 extern "C" JNIEXPORT jstring JNICALL
@@ -322,9 +329,9 @@ Java_app_opendocument_core_HtmlView_bringOfflineNative(JNIEnv *env, jobject,
 // app.opendocument.core.HtmlResource
 
 extern "C" JNIEXPORT void JNICALL
-Java_app_opendocument_core_HtmlResource_destroy(JNIEnv *, jclass,
+Java_app_opendocument_core_HtmlResource_destroy(JNIEnv *env, jclass,
                                                 jlong handle) {
-  destroy_handle<odr::HtmlResource>(handle);
+  destroy_handle<odr::HtmlResource>(env, handle);
 }
 
 extern "C" JNIEXPORT jint JNICALL

--- a/jni/src/jni_http_server.cpp
+++ b/jni/src/jni_http_server.cpp
@@ -32,9 +32,9 @@ Java_app_opendocument_core_HttpServer_create(JNIEnv *env, jclass) {
   return guarded(env, [&] { return make_handle(odr::HttpServer()); });
 }
 
-extern "C" JNIEXPORT void JNICALL
-Java_app_opendocument_core_HttpServer_destroy(JNIEnv *, jclass, jlong handle) {
-  destroy_handle<odr::HttpServer>(handle);
+extern "C" JNIEXPORT void JNICALL Java_app_opendocument_core_HttpServer_destroy(
+    JNIEnv *env, jclass, jlong handle) {
+  destroy_handle<odr::HttpServer>(env, handle);
 }
 
 extern "C" JNIEXPORT void JNICALL

--- a/jni/src/jni_logger.cpp
+++ b/jni/src/jni_logger.cpp
@@ -17,9 +17,7 @@ using odr_jni::to_jstring;
 using odr_jni::to_string;
 
 /// `JavaVM::AttachCurrentThread` takes a `JNIEnv **` on android and a `void **`
-/// on the jdk, and neither pointer converts to the other, so the argument has
-/// to be typed per platform. `GetEnv` is `void **` on both and needs none of
-/// this.
+/// on the jdk, and neither converts to the other. `GetEnv` needs none of this.
 jint attach_current_thread(JavaVM *const vm, JNIEnv **const env) {
 #ifdef __ANDROID__
   return vm->AttachCurrentThread(env, nullptr);
@@ -81,6 +79,7 @@ public:
       return;
     }
     m_bridge = static_cast<jclass>(env->NewGlobalRef(bridge));
+    env->DeleteLocalRef(bridge);
     m_will_log = env->GetStaticMethodID(m_bridge, "willLog",
                                         "(Lapp/opendocument/core/ILogger;I)Z");
     m_log = env->GetStaticMethodID(m_bridge, "log",
@@ -135,6 +134,11 @@ public:
         static_cast<jint>(level), text, file_name, function_name,
         static_cast<jint>(location.line()));
     clear_pending(env.get());
+    // an already-attached thread keeps one frame for the whole native call, so
+    // the strings of every message logged during it would pile up in it
+    env.get()->DeleteLocalRef(text);
+    env.get()->DeleteLocalRef(function_name);
+    env.get()->DeleteLocalRef(file_name);
   }
 
   void flush() override {
@@ -220,6 +224,6 @@ extern "C" JNIEXPORT void JNICALL Java_app_opendocument_core_Logger_flushNative(
 }
 
 extern "C" JNIEXPORT void JNICALL
-Java_app_opendocument_core_Logger_destroy(JNIEnv *, jclass, jlong handle) {
-  destroy_handle<odr::Logger>(handle);
+Java_app_opendocument_core_Logger_destroy(JNIEnv *env, jclass, jlong handle) {
+  destroy_handle<odr::Logger>(env, handle);
 }

--- a/jni/src/jni_style.cpp
+++ b/jni/src/jni_style.cpp
@@ -97,9 +97,16 @@ jobject enum_from_code(JNIEnv *env, const char *class_name, const jint code) {
   }
   auto array =
       static_cast<jobjectArray>(env->CallStaticObjectMethod(cls, values));
-  jobject result = env->GetObjectArrayElement(array, code);
-  env->DeleteLocalRef(array);
   env->DeleteLocalRef(cls);
+  if (array == nullptr) {
+    return nullptr;
+  }
+  // out of range means the java enum lags the C++ one; every JNI call after a
+  // pending ArrayIndexOutOfBoundsException would be undefined
+  jobject result = code < env->GetArrayLength(array)
+                       ? env->GetObjectArrayElement(array, code)
+                       : nullptr;
+  env->DeleteLocalRef(array);
   return result;
 }
 
@@ -142,12 +149,7 @@ jobject make_measure(JNIEnv *env, const odr::Measure &value) {
 }
 
 jobject make_measure(JNIEnv *env, const std::optional<odr::Measure> &value) {
-  if (!value.has_value()) {
-    return nullptr;
-  }
-  return new_object(env, "app/opendocument/core/Measure",
-                    "(DLjava/lang/String;)V", value->magnitude(),
-                    to_jstring(env, value->unit().to_string()));
+  return value.has_value() ? make_measure(env, *value) : nullptr;
 }
 
 jobject make_color(JNIEnv *env, const std::optional<odr::Color> &value) {
@@ -380,8 +382,9 @@ jobject html_config_to_java(JNIEnv *env, const odr::HtmlConfig &config) {
     for (jsize i = 0;
          i < static_cast<jsize>(config.pdf_dual_layer_fallback_fonts.size());
          ++i) {
-      env->SetObjectArrayElement(
-          fonts, i, to_jstring(env, config.pdf_dual_layer_fallback_fonts[i]));
+      jstring font = to_jstring(env, config.pdf_dual_layer_fallback_fonts[i]);
+      env->SetObjectArrayElement(fonts, i, font);
+      env->DeleteLocalRef(font);
     }
     set_object("pdfDualLayerFallbackFonts", "[Ljava/lang/String;", fonts);
     env->DeleteLocalRef(string_cls);

--- a/jni/src/odr_jni.hpp
+++ b/jni/src/odr_jni.hpp
@@ -44,8 +44,10 @@ template <typename T> jlong make_handle(T value) {
   return reinterpret_cast<jlong>(new T(std::move(value)));
 }
 
-template <typename T> void destroy_handle(jlong handle) {
-  delete from_handle<T>(handle);
+/// Frees a handle. Guarded like every other native body: a destructor that
+/// throws would otherwise unwind through the JNI boundary.
+template <typename T> void destroy_handle(JNIEnv *env, jlong handle) {
+  guarded(env, [&] { delete from_handle<T>(handle); });
 }
 
 } // namespace odr_jni

--- a/python/pyodr/cli.py
+++ b/python/pyodr/cli.py
@@ -60,17 +60,20 @@ def _serve(args, file) -> int:
         print("pyodr was built without the HTTP server", file=sys.stderr)
         return 1
 
-    server_config = pyodr.HttpServer.Config()
-    server_config.cache_path = tempfile.mkdtemp(prefix="pyodr-server-")
-    server = pyodr.HttpServer(server_config)
-
     html_config = pyodr.HtmlConfig()
     html_config.embed_images = False
+    cache = tempfile.mkdtemp(prefix="pyodr-server-")
+    service = pyodr.html.translate(file, cache, html_config)
 
     prefix = "file"
-    views = server.serve_file(file, prefix, html_config)
+    server = pyodr.HttpServer()
+    server.connect_service(service, prefix)
+    # bind before printing: the port is only known once the socket is, and it is
+    # not necessarily the one that was asked for
+    port = server.bind(args.host, args.port)
     urls = [
-        f"http://{args.host}:{args.port}/file/{prefix}/{view.path()}" for view in views
+        f"http://{args.host}:{port}/file/{prefix}/{view.path()}"
+        for view in service.list_views()
     ]
     for url in urls:
         print(url)
@@ -80,7 +83,7 @@ def _serve(args, file) -> int:
     # `listen` blocks in C++; restore the default SIGINT handler so Ctrl+C
     # terminates the server.
     signal.signal(signal.SIGINT, signal.SIG_DFL)
-    server.listen(args.host, args.port)
+    server.listen()
 
     return 0
 

--- a/python/src/bind_core.cpp
+++ b/python/src/bind_core.cpp
@@ -69,12 +69,8 @@ void odr_python::bind_core(py::module_ &m) {
 void odr_python::bind_functions(py::module_ &m) {
   m.def("all_file_types", &odr::all_file_types,
         "Every file type this library knows about.");
-  m.def(
-      "file_type_by_file_extension",
-      [](const std::string &extension) {
-        return odr::file_type_by_file_extension(extension);
-      },
-      py::arg("extension"));
+  m.def("file_type_by_file_extension", &odr::file_type_by_file_extension,
+        py::arg("extension"));
   m.def(
       "file_extensions_by_file_type",
       [](const odr::FileType type) {

--- a/python/src/bind_document.cpp
+++ b/python/src/bind_document.cpp
@@ -17,16 +17,27 @@ namespace py = pybind11;
 
 namespace {
 
-// Ties the returned object to `self` so navigation handles keep the
-// originating `Document` alive transitively.
+// Ties the returned object to `self`: navigation handles keep the originating
+// `Document` alive transitively, and so does a `TextStyle`, whose `font_name`
+// borrows from the document.
 constexpr auto keep_self_alive = py::keep_alive<0, 1>();
 
 py::object make_element_iterator(const odr::ElementRange &range) {
-  return py::make_iterator(range.begin(), range.end());
+  // The elements need the same tie: pybind11 hands them out by value, which
+  // drops the keep-alive `reference_internal` would otherwise imply.
+  return py::make_iterator(range.begin(), range.end(), keep_self_alive);
 }
 
 py::object make_children_iterator(const odr::Element &element) {
   return make_element_iterator(element.children());
+}
+
+/// `__bool__` has to come from the derived type: `Element::operator bool`
+/// ignores the typed adapter, so a failed `as_*` cast would look valid.
+template <typename T>
+py::class_<T, odr::Element> bind_element(py::module_ &m, const char *name) {
+  return py::class_<T, odr::Element>(m, name).def("__bool__",
+                                                  &T::operator bool);
 }
 
 } // namespace
@@ -162,17 +173,17 @@ void odr_python::bind_document(py::module_ &m) {
       .def("as_custom_shape", &odr::Element::as_custom_shape, keep_self_alive)
       .def("as_image", &odr::Element::as_image, keep_self_alive);
 
-  py::class_<odr::TextRoot, odr::Element>(m, "TextRoot")
+  bind_element<odr::TextRoot>(m, "TextRoot")
       .def("page_layout", &odr::TextRoot::page_layout)
       .def("first_master_page", &odr::TextRoot::first_master_page,
            keep_self_alive);
 
-  py::class_<odr::Slide, odr::Element>(m, "Slide")
+  bind_element<odr::Slide>(m, "Slide")
       .def("name", &odr::Slide::name)
       .def("page_layout", &odr::Slide::page_layout)
       .def("master_page", &odr::Slide::master_page, keep_self_alive);
 
-  py::class_<odr::Sheet, odr::Element>(m, "Sheet")
+  bind_element<odr::Sheet>(m, "Sheet")
       .def("name", &odr::Sheet::name)
       .def("dimensions", &odr::Sheet::dimensions)
       .def("content", &odr::Sheet::content, py::arg("range"))
@@ -190,44 +201,43 @@ void odr_python::bind_document(py::module_ &m) {
       .def("cell_style", &odr::Sheet::cell_style, py::arg("column"),
            py::arg("row"));
 
-  py::class_<odr::SheetCell, odr::Element>(m, "SheetCell")
+  bind_element<odr::SheetCell>(m, "SheetCell")
       .def("position", &odr::SheetCell::position)
       .def("is_covered", &odr::SheetCell::is_covered)
       .def("span", &odr::SheetCell::span)
       .def("value_type", &odr::SheetCell::value_type);
 
-  py::class_<odr::Page, odr::Element>(m, "Page")
+  bind_element<odr::Page>(m, "Page")
       .def("name", &odr::Page::name)
       .def("page_layout", &odr::Page::page_layout)
       .def("master_page", &odr::Page::master_page, keep_self_alive);
 
-  py::class_<odr::MasterPage, odr::Element>(m, "MasterPage")
+  bind_element<odr::MasterPage>(m, "MasterPage")
       .def("page_layout", &odr::MasterPage::page_layout);
 
-  py::class_<odr::LineBreak, odr::Element>(m, "LineBreak")
-      .def("style", &odr::LineBreak::style);
+  bind_element<odr::LineBreak>(m, "LineBreak")
+      .def("style", &odr::LineBreak::style, keep_self_alive);
 
-  py::class_<odr::Paragraph, odr::Element>(m, "Paragraph")
+  bind_element<odr::Paragraph>(m, "Paragraph")
       .def("style", &odr::Paragraph::style)
-      .def("text_style", &odr::Paragraph::text_style);
+      .def("text_style", &odr::Paragraph::text_style, keep_self_alive);
 
-  py::class_<odr::Span, odr::Element>(m, "Span").def("style",
-                                                     &odr::Span::style);
+  bind_element<odr::Span>(m, "Span").def("style", &odr::Span::style,
+                                         keep_self_alive);
 
-  py::class_<odr::Text, odr::Element>(m, "Text")
+  bind_element<odr::Text>(m, "Text")
       .def("content", &odr::Text::content)
       .def("set_content", &odr::Text::set_content, py::arg("text"))
-      .def("style", &odr::Text::style);
+      .def("style", &odr::Text::style, keep_self_alive);
 
-  py::class_<odr::Link, odr::Element>(m, "Link").def("href", &odr::Link::href);
+  bind_element<odr::Link>(m, "Link").def("href", &odr::Link::href);
 
-  py::class_<odr::Bookmark, odr::Element>(m, "Bookmark")
-      .def("name", &odr::Bookmark::name);
+  bind_element<odr::Bookmark>(m, "Bookmark").def("name", &odr::Bookmark::name);
 
-  py::class_<odr::ListItem, odr::Element>(m, "ListItem")
-      .def("style", &odr::ListItem::style);
+  bind_element<odr::ListItem>(m, "ListItem")
+      .def("style", &odr::ListItem::style, keep_self_alive);
 
-  py::class_<odr::Table, odr::Element>(m, "Table")
+  bind_element<odr::Table>(m, "Table")
       .def("first_row", &odr::Table::first_row, keep_self_alive)
       .def("first_column", &odr::Table::first_column, keep_self_alive)
       .def(
@@ -245,19 +255,19 @@ void odr_python::bind_document(py::module_ &m) {
       .def("dimensions", &odr::Table::dimensions)
       .def("style", &odr::Table::style);
 
-  py::class_<odr::TableColumn, odr::Element>(m, "TableColumn")
+  bind_element<odr::TableColumn>(m, "TableColumn")
       .def("style", &odr::TableColumn::style);
 
-  py::class_<odr::TableRow, odr::Element>(m, "TableRow")
+  bind_element<odr::TableRow>(m, "TableRow")
       .def("style", &odr::TableRow::style);
 
-  py::class_<odr::TableCell, odr::Element>(m, "TableCell")
+  bind_element<odr::TableCell>(m, "TableCell")
       .def("is_covered", &odr::TableCell::is_covered)
       .def("span", &odr::TableCell::span)
       .def("value_type", &odr::TableCell::value_type)
       .def("style", &odr::TableCell::style);
 
-  py::class_<odr::Frame, odr::Element>(m, "Frame")
+  bind_element<odr::Frame>(m, "Frame")
       .def("anchor_type", &odr::Frame::anchor_type)
       .def("x", &odr::Frame::x)
       .def("y", &odr::Frame::y)
@@ -266,35 +276,35 @@ void odr_python::bind_document(py::module_ &m) {
       .def("z_index", &odr::Frame::z_index)
       .def("style", &odr::Frame::style);
 
-  py::class_<odr::Rect, odr::Element>(m, "Rect")
+  bind_element<odr::Rect>(m, "Rect")
       .def("x", &odr::Rect::x)
       .def("y", &odr::Rect::y)
       .def("width", &odr::Rect::width)
       .def("height", &odr::Rect::height)
       .def("style", &odr::Rect::style);
 
-  py::class_<odr::Line, odr::Element>(m, "Line")
+  bind_element<odr::Line>(m, "Line")
       .def("x1", &odr::Line::x1)
       .def("y1", &odr::Line::y1)
       .def("x2", &odr::Line::x2)
       .def("y2", &odr::Line::y2)
       .def("style", &odr::Line::style);
 
-  py::class_<odr::Circle, odr::Element>(m, "Circle")
+  bind_element<odr::Circle>(m, "Circle")
       .def("x", &odr::Circle::x)
       .def("y", &odr::Circle::y)
       .def("width", &odr::Circle::width)
       .def("height", &odr::Circle::height)
       .def("style", &odr::Circle::style);
 
-  py::class_<odr::CustomShape, odr::Element>(m, "CustomShape")
+  bind_element<odr::CustomShape>(m, "CustomShape")
       .def("x", &odr::CustomShape::x)
       .def("y", &odr::CustomShape::y)
       .def("width", &odr::CustomShape::width)
       .def("height", &odr::CustomShape::height)
       .def("style", &odr::CustomShape::style);
 
-  py::class_<odr::Image, odr::Element>(m, "Image")
+  bind_element<odr::Image>(m, "Image")
       .def("is_internal", &odr::Image::is_internal)
       .def("file", &odr::Image::file)
       .def("href", &odr::Image::href);

--- a/python/src/bind_http_server.cpp
+++ b/python/src/bind_http_server.cpp
@@ -16,9 +16,8 @@ void odr_python::bind_http_server(py::module_ &m) {
 
   py::class_<odr::HttpServer::Config>(
       server, "Config",
-      "Server-wide settings. Empty since the cache path went with "
-      "`serve_file`: "
-      "what a service was translated into belongs to whoever translated it.")
+      "Server-wide settings, empty for now: what a service was translated "
+      "into belongs to whoever translated it.")
       .def(py::init<>());
 
   py::class_<odr::HttpServer::Options>(server, "Options",

--- a/python/tests/test_document.py
+++ b/python/tests/test_document.py
@@ -59,6 +59,28 @@ def test_element_navigation(odt_path):
     assert second.previous_sibling() == first
 
 
+def test_failed_cast_is_falsy(odt_path):
+    document = pyodr.open(str(odt_path)).as_document_file().document()
+    paragraph = next(
+        child
+        for child in document.root_element()
+        if child.type() == pyodr.ElementType.paragraph
+    )
+
+    assert paragraph.as_paragraph()
+    # the wrong cast has to come back falsy, not as a valid-looking handle
+    assert not paragraph.as_slide()
+
+
+def test_children_outlive_the_document(odt_path):
+    def collect():
+        document = pyodr.open(str(odt_path)).as_document_file().document()
+        return list(document.root_element())
+
+    # the document is only reachable through the elements by now
+    assert [child.type() for child in collect()]
+
+
 def test_text_root(odt_path):
     document = pyodr.open(str(odt_path)).as_document_file().document()
     root = document.root_element().as_text_root()

--- a/src/odr/document_element.cpp
+++ b/src/odr/document_element.cpp
@@ -74,105 +74,175 @@ Element Element::navigate_path(const DocumentPath &path) const {
 }
 
 TextRoot Element::as_text_root() const {
+  if (!exists_()) {
+    return {};
+  }
   return {m_adapter, m_identifier, m_adapter->text_root_adapter(m_identifier)};
 }
 
 Slide Element::as_slide() const {
+  if (!exists_()) {
+    return {};
+  }
   return {m_adapter, m_identifier, m_adapter->slide_adapter(m_identifier)};
 }
 
 Sheet Element::as_sheet() const {
+  if (!exists_()) {
+    return {};
+  }
   return {m_adapter, m_identifier, m_adapter->sheet_adapter(m_identifier)};
 }
 
 Page Element::as_page() const {
+  if (!exists_()) {
+    return {};
+  }
   return {m_adapter, m_identifier, m_adapter->page_adapter(m_identifier)};
 }
 
 SheetCell Element::as_sheet_cell() const {
+  if (!exists_()) {
+    return {};
+  }
   return {m_adapter, m_identifier, m_adapter->sheet_cell_adapter(m_identifier)};
 }
 
 MasterPage Element::as_master_page() const {
+  if (!exists_()) {
+    return {};
+  }
   return {m_adapter, m_identifier,
           m_adapter->master_page_adapter(m_identifier)};
 }
 
 LineBreak Element::as_line_break() const {
+  if (!exists_()) {
+    return {};
+  }
   return {m_adapter, m_identifier, m_adapter->line_break_adapter(m_identifier)};
 }
 
 Paragraph Element::as_paragraph() const {
+  if (!exists_()) {
+    return {};
+  }
   return {m_adapter, m_identifier, m_adapter->paragraph_adapter(m_identifier)};
 }
 
 Span Element::as_span() const {
+  if (!exists_()) {
+    return {};
+  }
   return {m_adapter, m_identifier, m_adapter->span_adapter(m_identifier)};
 }
 
 Text Element::as_text() const {
+  if (!exists_()) {
+    return {};
+  }
   return {m_adapter, m_identifier, m_adapter->text_adapter(m_identifier)};
 }
 
 Link Element::as_link() const {
+  if (!exists_()) {
+    return {};
+  }
   return {m_adapter, m_identifier, m_adapter->link_adapter(m_identifier)};
 }
 
 Bookmark Element::as_bookmark() const {
+  if (!exists_()) {
+    return {};
+  }
   return {m_adapter, m_identifier, m_adapter->bookmark_adapter(m_identifier)};
 }
 
 ListItem Element::as_list_item() const {
+  if (!exists_()) {
+    return {};
+  }
   return {m_adapter, m_identifier, m_adapter->list_item_adapter(m_identifier)};
 }
 
 Table Element::as_table() const {
+  if (!exists_()) {
+    return {};
+  }
   return {m_adapter, m_identifier, m_adapter->table_adapter(m_identifier)};
 }
 
 TableColumn Element::as_table_column() const {
+  if (!exists_()) {
+    return {};
+  }
   return {m_adapter, m_identifier,
           m_adapter->table_column_adapter(m_identifier)};
 }
 
 TableRow Element::as_table_row() const {
+  if (!exists_()) {
+    return {};
+  }
   return {m_adapter, m_identifier, m_adapter->table_row_adapter(m_identifier)};
 }
 
 TableCell Element::as_table_cell() const {
+  if (!exists_()) {
+    return {};
+  }
   return {m_adapter, m_identifier, m_adapter->table_cell_adapter(m_identifier)};
 }
 
 Frame Element::as_frame() const {
+  if (!exists_()) {
+    return {};
+  }
   return {m_adapter, m_identifier, m_adapter->frame_adapter(m_identifier)};
 }
 
 Rect Element::as_rect() const {
+  if (!exists_()) {
+    return {};
+  }
   return {m_adapter, m_identifier, m_adapter->rect_adapter(m_identifier)};
 }
 
 Line Element::as_line() const {
+  if (!exists_()) {
+    return {};
+  }
   return {m_adapter, m_identifier, m_adapter->line_adapter(m_identifier)};
 }
 
 Circle Element::as_circle() const {
+  if (!exists_()) {
+    return {};
+  }
   return {m_adapter, m_identifier, m_adapter->circle_adapter(m_identifier)};
 }
 
 CustomShape Element::as_custom_shape() const {
+  if (!exists_()) {
+    return {};
+  }
   return {m_adapter, m_identifier,
           m_adapter->custom_shape_adapter(m_identifier)};
 }
 
 Image Element::as_image() const {
+  if (!exists_()) {
+    return {};
+  }
   return {m_adapter, m_identifier, m_adapter->image_adapter(m_identifier)};
 }
 
 ElementRange Element::children() const {
-  return {exists_() ? ElementIterator(m_adapter, m_adapter->element_first_child(
-                                                     m_identifier))
-                    : ElementIterator(),
-          ElementIterator()};
+  if (!exists_()) {
+    return {};
+  }
+  return ElementRange(
+      ElementIterator(m_adapter, m_adapter->element_first_child(m_identifier)));
 }
 
 ElementIterator::ElementIterator() = default;

--- a/src/odr/exceptions.cpp
+++ b/src/odr/exceptions.cpp
@@ -19,7 +19,7 @@ FileNotFound::FileNotFound(const std::string &path)
 UnknownFileType::UnknownFileType() : Exception("unknown file type") {}
 
 UnsupportedFileType::UnsupportedFileType(const FileType file_type)
-    : Exception("unknown file type: " + file_type_to_string(file_type)),
+    : Exception("unsupported file type: " + file_type_to_string(file_type)),
       file_type{file_type} {}
 
 FileReadError::FileReadError() : Exception("file read error") {}

--- a/src/odr/exceptions.hpp
+++ b/src/odr/exceptions.hpp
@@ -6,11 +6,9 @@
 namespace odr {
 enum class FileType;
 
-/// @brief Base of every exception type this library declares.
-///
-/// Catching this catches every typed error below. Note that the decoders also
-/// throw plain `std::runtime_error` for malformed input that has no dedicated
-/// type, so `std::runtime_error` remains the widest net.
+/// @brief Base of every exception type this library declares. The decoders also
+/// throw plain `std::runtime_error` for malformed input with no dedicated type,
+/// so that remains the widest net.
 struct Exception : std::runtime_error {
   using std::runtime_error::runtime_error;
 };

--- a/src/odr/file.hpp
+++ b/src/odr/file.hpp
@@ -90,11 +90,9 @@ enum class FileType {
   // https://en.wikipedia.org/wiki/OpenType
   opentype_font,
 
-  // The media formats a viewer is regularly handed alongside documents.
-  // Nothing here is decoded - opening one wraps its bytes, and translating it
-  // puts those bytes in an `<img>` or in a player and lets the browser do the
-  // work. Naming them is what makes that possible; without a name the text
-  // fallback would call a video plain text.
+  // Media a viewer is handed alongside documents. Nothing here is decoded:
+  // opening one wraps its bytes and translating it hands them to an `<img>` or
+  // a player - but unnamed, a video would fall back to plain text.
   // New entries go at the end: the bindings mirror this enum by ordinal.
   // https://en.wikipedia.org/wiki/WebP
   webp,
@@ -144,9 +142,8 @@ enum class FileType {
   // https://en.wikipedia.org/wiki/Windows_Metafile#Enhanced_Metafile
   enhanced_metafile,
 
-  // Classification only for now - detection reports it under the formats built
-  // on it, e.g. an svg comes back as `[text_file, xml, scalable_vector_
-  // graphics]`, but there is no decoder of its own behind it yet.
+  // Classification only - reported under the formats built on it (an svg comes
+  // back as `[text_file, xml, scalable_vector_graphics]`), no decoder yet.
   // https://en.wikipedia.org/wiki/XML
   xml,
 };
@@ -174,9 +171,8 @@ enum class FileLocation {
 ///
 /// Declared, format-level support — an *upper bound*. A concrete file may still
 /// fail (corrupt, encrypted, an unsupported sub-variant); ask @ref DecodedFile
-/// or @ref Document for the precise answer. The point of the static query is
-/// the decisions a caller has to make *before* it holds a file, e.g. which
-/// MIME types to advertise to the platform's file picker.
+/// or @ref Document for that. This answers what a caller has to decide before
+/// it holds a file, e.g. which MIME types to hand the platform's file picker.
 struct FileTypeCapabilities final {
   bool detect_by_content{}; ///< recognised from its bytes alone
   bool open{};              ///< a decoder exists; @ref odr::open can decode it
@@ -293,10 +289,9 @@ public:
 
   /// @brief What can be done with this file.
   ///
-  /// Refines @ref capabilities_by_file_type with what is known about this
-  /// file. `edit`/`save`/`encrypt` are passed through from the format-level
-  /// declaration — resolving them exactly would mean decoding the document;
-  /// ask @ref Document::is_editable / @ref Document::is_savable for that.
+  /// Refines @ref capabilities_by_file_type with what is known about this file.
+  /// `edit`/`save`/`encrypt` stay as declared — ask @ref Document::is_editable
+  /// / @ref Document::is_savable for those.
   [[nodiscard]] FileTypeCapabilities capabilities() const;
 
   [[nodiscard]] bool is_text_file() const;

--- a/src/odr/html.cpp
+++ b/src/odr/html.cpp
@@ -242,11 +242,9 @@ HtmlService html::translate(const DecodedFile &file,
 HtmlResourceLocator html::standard_resource_locator() {
   return [](const HtmlResource &resource,
             const HtmlConfig &config) -> HtmlResourceLocation {
-    if (!resource.is_accessible()) {
-      return resource.path();
-    }
-
-    if (config.embed_images && resource.type() == HtmlResourceType::image) {
+    // only an accessible image can be embedded; everything else is linked
+    if (resource.is_accessible() && config.embed_images &&
+        resource.type() == HtmlResourceType::image) {
       return std::nullopt;
     }
 

--- a/src/odr/html.hpp
+++ b/src/odr/html.hpp
@@ -72,37 +72,24 @@ enum class HtmlTableGridlines {
 };
 
 /// @brief Initial zoom of the emitted HTML on mobile (viewport meta tag).
-///
-/// Desktop browsers ignore the viewport meta tag entirely.
-///
-/// - `automatic`: per-content default — fixed-size paged content (PDF pages,
-///   slides, drawings, images, text documents with page margins) uses
-///   `fit_width`; reflowing content (spreadsheets, plain text) uses
-///   `actual_size`.
-/// - `fit_width`: the browser picks the initial zoom so the content's full
-///   width fits the screen.
-/// - `actual_size`: initial zoom locked to 100% (`initial-scale=1.0`).
-/// - `none`: no viewport meta tag is written.
+/// Desktop browsers ignore the tag entirely.
 enum class HtmlViewportMode {
-  automatic,
-  fit_width,
-  actual_size,
-  none,
+  automatic,   ///< `fit_width` for fixed-size paged content (PDF pages, slides,
+               ///< drawings, images, text documents with page margins),
+               ///< `actual_size` for reflowing content (spreadsheets, text)
+  fit_width,   ///< initial zoom fits the content's full width on screen
+  actual_size, ///< initial zoom locked to 100% (`initial-scale=1.0`)
+  none,        ///< no viewport meta tag at all
 };
 
-/// @brief PDF text rendering mode.
-///
-/// Selects how text is emitted in PDF→HTML output.
-///
-/// - `dual_layer`: A visual layer (paint order, embedded PUA glyphs) and a
-///   separate transparent selection/search layer (reading order, real Unicode).
-///   Similar to pdf.js. No JavaScript required.
-/// - `single_layer`: A single combined layer where every glyph is mapped to
-///   Unicode via frequency analysis. Similar to pdf2htmlEX. No JavaScript
-///   required.
+/// @brief How text is emitted in PDF→HTML output. Neither mode needs
+/// JavaScript.
 enum class PdfTextMode {
-  dual_layer,
-  single_layer,
+  dual_layer,   ///< a visual layer (paint order, embedded PUA glyphs) plus a
+                ///< transparent selection layer (reading order, real Unicode),
+                ///< like pdf.js
+  single_layer, ///< one layer, every glyph mapped to Unicode by frequency
+                ///< analysis, like pdf2htmlEX
 };
 
 /// @brief HTML configuration.
@@ -165,17 +152,12 @@ struct HtmlConfig {
 
   // PDF text mode
   PdfTextMode pdf_text_mode{PdfTextMode::dual_layer};
-  // `dual_layer`'s invisible selection-layer text is rendered in a local
-  // system font (tried in order; the first that resolves wins) rather than
-  // the embedded PDF font, so its natural width rarely matches the
-  // PDF-derived box width CSS `text-justify` is asked to fill (justify can
-  // only add spacing, never compress).
-  // `pdf_dual_layer_fallback_font_size_adjust` is applied as that @font-face's
-  // `size-adjust` (0-1, written out as a percent) to shrink the fallback font's
-  // metrics toward the PDF's, leaving less — ideally no — gap for justify to
-  // compress instead of stretch into. Safe to underestimate (justify then just
-  // spreads characters further; harmless on an invisible layer) but not to
-  // overestimate (the excess is clipped, not shrunk).
+  // `dual_layer` renders its invisible selection layer in a local system font
+  // (first of these that resolves), whose natural width rarely matches the
+  // PDF-derived box CSS justify has to fill — and justify can only add spacing.
+  // The size-adjust (0-1, written as the @font-face percent) shrinks the
+  // fallback's metrics toward the PDF's to close that gap. Safe to
+  // underestimate, not to overestimate: the excess is clipped, not shrunk.
   std::vector<std::string> pdf_dual_layer_fallback_fonts{
       "Arial", "Helvetica", "Liberation Sans", "DejaVu Sans", "Nimbus Sans"};
   double pdf_dual_layer_fallback_font_size_adjust{0.5};
@@ -275,117 +257,53 @@ namespace html {
 
 HtmlResourceLocator standard_resource_locator();
 
-/// @brief Translates a decoded file to HTML.
-///
-/// @param file Decoded file to translate.
-/// @param cache_path Directory path for temporary output.
-/// @param config Configuration for the HTML output.
-/// @param logger Logger to use for logging.
-/// @return HTML output.
+/// @brief Translates a decoded file to HTML. `cache_path` is the directory
+/// temporary output goes into.
 HtmlService translate(const DecodedFile &file, const std::string &cache_path,
                       const HtmlConfig &config,
                       const Logger &logger = Logger::null());
 
 /// @brief Translates a text file to HTML.
-///
-/// @param text_file Text file to translate.
-/// @param cache_path Directory path for temporary output.
-/// @param config Configuration for the HTML output.
-/// @param logger Logger to use for logging.
-/// @return HTML output.
 HtmlService translate(const TextFile &text_file, const std::string &cache_path,
                       const HtmlConfig &config,
                       const Logger &logger = Logger::null());
 /// @brief Translates an image file to HTML.
-///
-/// @param image_file Image file to translate.
-/// @param cache_path Directory path for temporary output.
-/// @param config Configuration for the HTML output.
-/// @param logger Logger to use for logging.
-/// @return HTML output.
 HtmlService translate(const ImageFile &image_file,
                       const std::string &cache_path, const HtmlConfig &config,
                       const Logger &logger = Logger::null());
-/// @brief Translates an archive to HTML.
-///
-/// @param archive_file Archive file to translate.
-/// @param cache_path Directory path for temporary output.
-/// @param config Configuration for the HTML output.
-/// @param logger Logger to use for logging.
-/// @return HTML output.
+/// @brief Translates an archive file to HTML.
 HtmlService translate(const ArchiveFile &archive_file,
                       const std::string &cache_path, const HtmlConfig &config,
                       const Logger &logger = Logger::null());
-/// @brief Translates a document to HTML.
-///
-/// @param document_file Document file to translate.
-/// @param cache_path Directory path for temporary output.
-/// @param config Configuration for the HTML output.
-/// @param logger Logger to use for logging.
-/// @return HTML output.
+/// @brief Translates a document file to HTML.
 HtmlService translate(const DocumentFile &document_file,
                       const std::string &cache_path, const HtmlConfig &config,
                       const Logger &logger = Logger::null());
 /// @brief Translates a PDF file to HTML.
-///
-/// @param pdf_file PDF file to translate.
-/// @param cache_path Directory path for temporary output.
-/// @param config Configuration for the HTML output.
-/// @param logger Logger to use for logging.
-/// @return HTML output.
 HtmlService translate(const PdfFile &pdf_file, const std::string &cache_path,
                       const HtmlConfig &config,
                       const Logger &logger = Logger::null());
 
 /// @brief Translates a font file to HTML (a specimen page).
-///
-/// @param font_file Font file to translate.
-/// @param cache_path Directory path for temporary output.
-/// @param config Configuration for the HTML output.
-/// @param logger Logger to use for logging.
-/// @return HTML output.
 HtmlService translate(const FontFile &font_file, const std::string &cache_path,
                       const HtmlConfig &config,
                       const Logger &logger = Logger::null());
 
 /// @brief Translates a filesystem to HTML.
-///
-/// @param filesystem Filesystem to translate.
-/// @param cache_path Directory path for temporary output.
-/// @param config Configuration for the HTML output.
-/// @param logger Logger to use for logging.
-/// @return HTML output.
 HtmlService translate(const Filesystem &filesystem,
                       const std::string &cache_path, const HtmlConfig &config,
                       const Logger &logger = Logger::null());
 /// @brief Translates an archive to HTML.
-///
-/// @param archive Archive to translate.
-/// @param cache_path Directory path for temporary output.
-/// @param config Configuration for the HTML output.
-/// @param logger Logger to use for logging.
-/// @return HTML output.
 HtmlService translate(const Archive &archive, const std::string &cache_path,
                       const HtmlConfig &config,
                       const Logger &logger = Logger::null());
 /// @brief Translates a document to HTML.
-///
-/// @param document Document to translate.
-/// @param cache_path Directory path for temporary output.
-/// @param config Configuration for the HTML output.
-/// @param logger Logger to use for logging.
-/// @return HTML output.
 HtmlService translate(const Document &document, const std::string &cache_path,
                       const HtmlConfig &config,
                       const Logger &logger = Logger::null());
 
-/// @brief Edits a document with a diff.
-///
-/// @note The diff is generated by our JavaScript code in the browser.
-///
-/// @param document Document to edit.
-/// @param diff Diff to apply.
-/// @param logger Logger to use for logging.
+/// @brief Applies a diff to a document. The diff is what our JavaScript
+/// produces in the browser.
 void edit(const Document &document, std::string_view diff,
           const Logger &logger = Logger::null());
 

--- a/src/odr/http_server.cpp
+++ b/src/odr/http_server.cpp
@@ -18,19 +18,15 @@ namespace odr {
 
 class HttpServer::Impl : public std::enable_shared_from_this<Impl> {
 public:
-  /// What a HttpServer holds: a second reference to the impl whose deleter
-  /// stops the server rather than destroying it. Running out of handles is what
-  /// has to stop a listen() in flight, and ~Impl cannot be that signal -
-  /// listen() keeps a reference of its own, so the impl outlives the handles
-  /// for as long as it serves. Destroying it is left to the reference captured
-  /// below.
+  /// What a HttpServer holds: a second reference whose deleter stops the server
+  /// rather than destroying it. ~Impl cannot be that signal - listen() keeps a
+  /// reference of its own, so the impl outlives the handles while it serves.
   static std::shared_ptr<Impl> create(const Logger &logger) {
     std::shared_ptr<Impl> owner = std::make_shared<Impl>(logger);
     Impl *const impl = owner.get();
 
     // shared_from_this() stays bound to the control block make_shared put
-    // there: a second one only takes weak_this over when it has expired. So
-    // listen() holds that reference, not one of these, which is the whole point
+    // there, so listen() holds `owner`'s reference, not one of these
     return std::shared_ptr<Impl>{
         impl, [owner = std::move(owner)](Impl * /*owner already has it*/) {
           owner->stop();
@@ -39,8 +35,7 @@ public:
 
   explicit Impl(const Logger &logger)
       : m_logger{logger}, m_server{std::make_shared<httplib::Server>()} {
-    // Set up exception handler to catch any internal httplib exceptions.
-    // This prevents crashes when exceptions occur during request processing.
+    // an exception escaping a handler tears down the process otherwise
     m_server->set_exception_handler([this](const httplib::Request & /*req*/,
                                            httplib::Response &res,
                                            const std::exception_ptr &ep) {
@@ -62,52 +57,46 @@ public:
                     res.set_content("Hello World!", "text/plain");
                   });
 
-    m_server->Get("/file/" + std::string(prefix_pattern),
-                  [this](const httplib::Request &req, httplib::Response &res) {
-                    if (m_stopping.load(std::memory_order_acquire)) {
-                      res.status = 503;
-                      res.set_content("Service Unavailable", "text/plain");
-                      return;
-                    }
-                    serve_file(req, res);
-                  });
+    const auto file_handler = [this](const httplib::Request &req,
+                                     httplib::Response &res) {
+      if (m_stopping.load(std::memory_order_acquire)) {
+        res.status = 503;
+        res.set_content("Service Unavailable", "text/plain");
+        return;
+      }
+      serve_file(req, res);
+    };
+    m_server->Get("/file/" + std::string(prefix_pattern), file_handler);
     m_server->Get("/file/" + std::string(prefix_pattern) + "/(.*)",
-                  [this](const httplib::Request &req, httplib::Response &res) {
-                    if (m_stopping.load(std::memory_order_acquire)) {
-                      res.status = 503;
-                      res.set_content("Service Unavailable", "text/plain");
-                      return;
-                    }
-                    serve_file(req, res);
-                  });
+                  file_handler);
   }
 
   ~Impl() {
-    // listen() holds a reference to the impl of its own, so this cannot run
-    // underneath an accept loop. stop() is still what tears the server down: it
-    // closes the socket, waits for any listen() to return and only then drops
-    // the httplib server, whose destructor joins the thread pool. m_content is
-    // destroyed after this body, i.e. after all of that.
+    // cannot run underneath an accept loop - listen() holds a reference of its
+    // own - but stop() is still what closes the socket and joins the pool,
+    // before m_content is destroyed after this body
     stop();
   }
 
-  // Prevent copying - the lambdas capture 'this' so copying would be unsafe
+  // the handler lambdas capture `this`
   Impl(const Impl &) = delete;
   Impl &operator=(const Impl &) = delete;
 
   void serve_file(const httplib::Request &req, httplib::Response &res) {
     try {
-      std::string id = req.matches[1].str();
-      std::string path = req.matches.size() > 1 ? req.matches[2].str() : "";
+      const std::string id = req.matches[1].str();
+      // the route without a trailing path has the one group
+      const std::string path =
+          req.matches.size() > 2 ? req.matches[2].str() : "";
 
       std::unique_lock lock{m_mutex};
-      auto it = m_content.find(id);
+      const auto it = m_content.find(id);
       if (it == m_content.end()) {
         ODR_ERROR(m_logger, "Content not found for ID: " << id);
         res.status = 404;
         return;
       }
-      auto [_, service] = it->second;
+      const HtmlService service = it->second.service;
       lock.unlock();
 
       serve_file(res, service, path);
@@ -132,14 +121,9 @@ public:
 
     ODR_VERBOSE(m_logger, "Serving file: " << path);
 
-    // Buffer content to avoid streaming issues on Android.
-    // Using ContentProviderWithoutLength (chunked transfer encoding) can cause
-    // SIGSEGV crashes in httplib::Server::write_response_core when:
-    // 1. The client disconnects during transfer
-    // 2. Exceptions are thrown during content generation
-    // 3. The server is stopped while requests are in-flight
-    // By buffering content first, we can handle errors gracefully and use
-    // Content-Length based responses which are more reliable.
+    // buffered rather than streamed: a chunked ContentProviderWithoutLength
+    // crashes httplib::Server::write_response_core when the client disconnects,
+    // the content generation throws, or the server stops mid-request
     try {
       std::ostringstream buffer;
       service.write(path, buffer);
@@ -164,7 +148,7 @@ public:
       throw PrefixInUse(prefix);
     }
 
-    m_content.emplace(prefix, Content{prefix, std::move(service)});
+    m_content.emplace(prefix, Content{std::move(service)});
   }
 
   std::uint32_t bind(const std::string &host, const std::uint32_t port,
@@ -181,18 +165,16 @@ public:
     }
 
 #ifdef _WIN32
-    // Windows keeps cpp-httplib's defaults, which set SO_EXCLUSIVEADDRUSE
-    // alongside SO_REUSEADDR. The two flags mean the opposite of what they do
-    // below: there SO_REUSEADDR lets a second live socket take the endpoint
-    // over, and SO_EXCLUSIVEADDRUSE is what keeps it ours. Replacing that with
-    // the posix mapping would hand the port away, so Options does not apply.
+    // Options does not apply: Windows keeps cpp-httplib's
+    // SO_EXCLUSIVEADDRUSE defaults, where SO_REUSEADDR lets another live socket
+    // take the endpoint over and the posix mapping below would hand the port
+    // away
     static_cast<void>(options);
 #else
-    // cpp-httplib's default sets SO_REUSEPORT where it exists and SO_REUSEADDR
-    // only otherwise, which is the wrong way round for a server that gets
-    // restarted: only SO_REUSEADDR lets a port held by TIME_WAIT sockets be
-    // bound again, while SO_REUSEPORT hands a second server a share of the
-    // connections instead.
+    // cpp-httplib defaults to SO_REUSEPORT where it exists, the wrong way round
+    // for a server that gets restarted: only SO_REUSEADDR rebinds a port held
+    // by TIME_WAIT sockets, SO_REUSEPORT shares connections with a second
+    // server instead.
     // socket_t is not in the httplib namespace in every version, hence auto
     m_server->set_socket_options([options](const auto sock) {
       constexpr int yes = 1;
@@ -229,10 +211,9 @@ public:
   }
 
   void listen() {
-    // listen() blocks, so it runs on a thread of the caller's. A reference of
-    // its own keeps the impl - and with it the httplib server, the mutex and
-    // the condition variable below - alive for as long as the accept loop is on
-    // it, whatever the thread that owns the HttpServer does meanwhile.
+    // this blocks on a thread of the caller's; a reference of its own keeps the
+    // impl - server, mutex, condition variable - alive under the accept loop,
+    // whatever the thread owning the HttpServer does meanwhile
     const std::shared_ptr<Impl> self = shared_from_this();
 
     std::shared_ptr<httplib::Server> server;
@@ -300,11 +281,10 @@ public:
       server = std::move(m_server);
 
       if (server != nullptr && m_listening > 0) {
-        // httplib::Server::stop() closes the listening socket, but only once
-        // listen_internal() has the accept loop up - and it asserts, then
-        // closes an already closed descriptor, if it runs a second time after
-        // that. A listen() that is still on its way there therefore has to be
-        // waited for, and httplib's own flag is the only thing to wait on.
+        // httplib::Server::stop() only closes the listening socket once the
+        // accept loop is up, and double-closes the descriptor if it runs again
+        // after that, so a listen() on its way there has to be waited for -
+        // httplib's own flag being the only thing to wait on
         while (m_listening > 0 && !server->is_running()) {
           m_listen_done.wait_for(lock, std::chrono::milliseconds{1});
         }
@@ -315,10 +295,8 @@ public:
         }
       }
 
-      // the accept loop stands on the server object and on everything the
-      // handlers capture, so neither may go before listen() has returned:
-      // dropping the server underneath it was the use after free, and the two
-      // then raced over the listening socket as well
+      // the accept loop stands on the server and on what the handlers capture,
+      // so neither may go before listen() has returned
       m_listen_done.wait(lock, [this] { return m_listening == 0; });
     }
 
@@ -351,17 +329,14 @@ private:
   // listen() calls in flight - 0 or 1 in any sane use
   std::size_t m_listening{0};
 
-  // Flag to indicate server is shutting down - checked by handlers
-  // to reject new requests during shutdown. Atomic because they read it
-  // without the lock.
+  // rejects new requests; atomic because the handlers read it without the lock
   std::atomic<bool> m_stopping{false};
 
-  // Whether bind() has taken a socket. listen() needs it because cpp-httplib
-  // will happily "serve" a server that never bound one.
+  // whether bind() has taken a socket - cpp-httplib will happily "serve" a
+  // server that never bound one
   bool m_bound{false};
 
   struct Content {
-    std::string id;
     HtmlService service;
   };
 

--- a/src/odr/internal/abstract/archive.hpp
+++ b/src/odr/internal/abstract/archive.hpp
@@ -1,5 +1,6 @@
 #pragma once
 
+#include <iosfwd>
 #include <memory>
 
 namespace odr::internal::abstract {

--- a/src/odr/internal/abstract/document.hpp
+++ b/src/odr/internal/abstract/document.hpp
@@ -6,6 +6,7 @@
 #include <cstdint>
 #include <memory>
 #include <optional>
+#include <string>
 
 namespace odr {
 class File;
@@ -33,16 +34,11 @@ class Path;
 
 namespace odr::internal::abstract {
 class ReadableFilesystem;
-}
-
-namespace odr::internal::abstract {
 class ElementAdapter;
 class TextRootAdapter;
 class SlideAdapter;
 class PageAdapter;
 class SheetAdapter;
-class SheetColumnAdapter;
-class SheetRowAdapter;
 class SheetCellAdapter;
 class MasterPageAdapter;
 class LineBreakAdapter;
@@ -67,34 +63,22 @@ class Document {
 public:
   virtual ~Document() = default;
 
-  /// \return `true` if the document is editable in any way.
+  /// Editable in any way.
   [[nodiscard]] virtual bool is_editable() const noexcept = 0;
 
-  /// \param encrypted to ask for encrypted saves.
-  /// \return `true` if the document is is_savable.
+  /// Savable, @p encrypted to ask for an encrypted save.
   [[nodiscard]] virtual bool is_savable(bool encrypted) const noexcept = 0;
 
-  /// \param path the destination path.
   virtual void save(const Path &path) const = 0;
-
-  /// \param path the destination path.
-  /// \param password the encryption password.
   virtual void save(const Path &path, const char *password) const = 0;
 
-  /// \return the type of the document.
   [[nodiscard]] virtual FileType file_type() const noexcept = 0;
-
-  /// \return the type of the document.
   [[nodiscard]] virtual DocumentType document_type() const noexcept = 0;
 
-  /// \return the underlying filesystem of the document.
   [[nodiscard]] virtual std::shared_ptr<ReadableFilesystem>
   as_filesystem() const noexcept = 0;
 
-  /// \return cursor to the root element of the document.
   [[nodiscard]] virtual ElementIdentifier root_element() const = 0;
-
-  /// \return the element adapter for this document.
   [[nodiscard]] virtual const ElementAdapter *element_adapter() const = 0;
 };
 

--- a/src/odr/internal/abstract/font.hpp
+++ b/src/odr/internal/abstract/font.hpp
@@ -8,14 +8,8 @@
 
 namespace odr::internal::abstract {
 
-/// @brief Read-only view over a font program, exposing the *facts* every
-/// consumer needs while the raw glyph bytes pass through untouched.
-///
-/// Per the "IR for facts, pass-through for glyphs" architecture this never
-/// decompiles outlines: it reports counts / metrics / names and hands back the
-/// original bytes. The embedded-font reverse map reads Unicode from it, the OTF
-/// wrap synthesizes the SFNT skeleton from it, and the PUA re-encoder assigns
-/// code points from its glyph count.
+/// Read-only view over a font program: counts, metrics, names and character
+/// maps. Outlines are never decompiled, the glyph bytes pass through untouched.
 class Font {
 public:
   virtual ~Font() = default;
@@ -41,15 +35,13 @@ public:
   [[nodiscard]] virtual std::uint16_t
   advance_width(std::uint16_t glyph) const = 0;
 
-  /// The font's own forward map: Unicode code point -> glyph id, 0 (`.notdef`)
-  /// when unmapped. Seeds the specimen page and the PUA re-encode.
+  /// The font's own character map: code point -> glyph id, 0 (`.notdef`) when
+  /// unmapped.
   [[nodiscard]] virtual std::uint16_t
   glyph_for_code_point(char32_t code_point) const = 0;
 
-  /// The reverse map: glyph id -> Unicode code point, when the font's character
-  /// map reaches the glyph. This is the embedded-font reverse map used to
-  /// recover Unicode for a font with no usable `/ToUnicode` or `/Encoding`;
-  /// `nullopt` when no code point maps.
+  /// The reverse of that map, `nullopt` when no code point reaches @p glyph.
+  /// Recovers Unicode for a font without usable `/ToUnicode` or `/Encoding`.
   [[nodiscard]] virtual std::optional<char32_t>
   code_point_for_glyph(std::uint16_t glyph) const = 0;
 };

--- a/src/odr/internal/cfb/cfb_impl.cpp
+++ b/src/odr/internal/cfb/cfb_impl.cpp
@@ -39,6 +39,14 @@ impl::CompoundFileEntry impl::parse_entry(std::istream &in) {
 namespace odr::internal::cfb::impl {
 
 std::string CompoundFileEntry::get_name() const {
+  // [MS-CFB] 2.6.1: `name_len` counts bytes including the terminating NUL and
+  // never exceeds the 64-byte name field.
+  if (name_len > sizeof(name)) {
+    throw CfbFileCorrupted();
+  }
+  if (name_len < 2) {
+    return {};
+  }
   return internal::util::string::c16str_to_string(name, name_len - 2);
 }
 
@@ -106,47 +114,6 @@ void CompoundFileReader::read_file(std::istream &in,
     read_mini_stream(in, {entry.start_sector_location, offset}, buffer, len);
   } else {
     read_stream(in, {entry.start_sector_location, offset}, buffer, len);
-  }
-}
-
-void CompoundFileReader::visit_descendants(
-    std::istream &in, const CompoundFileEntry &entry,
-    const std::int32_t max_level, const EnumFilesCallback &callback) const {
-  const CompoundFileEntry child_entry = parse_entry(in, entry.child_id);
-  visit_descendants(in, child_entry, 0, max_level, std::u16string(), callback);
-}
-
-void CompoundFileReader::visit_descendants(
-    std::istream &in, const CompoundFileEntry &entry,
-    const std::int32_t current_level, const std::int32_t max_level,
-    const std::u16string &dir, const EnumFilesCallback &callback) const {
-  if (max_level > 0 && current_level >= max_level) {
-    return;
-  }
-
-  callback(entry, dir, current_level + 1);
-
-  if (entry.child_id != NullId) {
-    const CompoundFileEntry child = parse_entry(in, entry.child_id);
-
-    std::u16string new_dir = dir;
-    new_dir.append(entry.name, entry.name_len / 2);
-    visit_descendants(in, child, current_level + 1, max_level, new_dir,
-                      callback);
-  }
-
-  if (entry.left_sibling_id != NullId) {
-    const CompoundFileEntry left_sibling =
-        parse_entry(in, entry.left_sibling_id);
-    visit_descendants(in, left_sibling, current_level, max_level, dir,
-                      callback);
-  }
-
-  if (entry.right_sibling_id != NullId) {
-    const CompoundFileEntry right_sibling =
-        parse_entry(in, entry.right_sibling_id);
-    visit_descendants(in, right_sibling, current_level, max_level, dir,
-                      callback);
   }
 }
 

--- a/src/odr/internal/cfb/cfb_impl.hpp
+++ b/src/odr/internal/cfb/cfb_impl.hpp
@@ -3,7 +3,6 @@
 #include <odr/internal/abstract/file.hpp>
 
 #include <cstdint>
-#include <functional>
 #include <string>
 
 namespace odr::internal::cfb::impl {
@@ -68,10 +67,6 @@ CompoundFileEntry parse_entry(std::istream &in);
 
 class CompoundFileReader final {
 public:
-  using EnumFilesCallback =
-      std::function<void(const CompoundFileEntry &entry,
-                         const std::u16string &dir, std::uint32_t level)>;
-
   static constexpr auto MAGIC = "\xD0\xCF\x11\xE0\xA1\xB1\x1A\xE1";
 
   explicit CompoundFileReader(std::istream &in, std::uint64_t file_size);
@@ -100,10 +95,6 @@ public:
   void read_file(std::istream &in, const CompoundFileEntry &entry,
                  std::uint64_t offset, char *buffer, std::uint64_t len) const;
 
-  void visit_descendants(std::istream &in, const CompoundFileEntry &entry,
-                         int max_level,
-                         const EnumFilesCallback &callback) const;
-
 private:
   struct SectorOffset final {
     Sector sector;
@@ -111,12 +102,6 @@ private:
   };
 
   static constexpr Sector MaxSector = 0xFFFFFFFA;
-
-  // Enum entries with same level, including 'entry' itself
-  void visit_descendants(std::istream &in, const CompoundFileEntry &entry,
-                         std::int32_t current_level, std::int32_t max_level,
-                         const std::u16string &dir,
-                         const EnumFilesCallback &callback) const;
 
   void read_stream(std::istream &in, const SectorOffset &sector_offset,
                    char *buffer, std::uint64_t length) const;

--- a/src/odr/internal/cfb/cfb_util.cpp
+++ b/src/odr/internal/cfb/cfb_util.cpp
@@ -1,5 +1,7 @@
 #include <odr/internal/cfb/cfb_util.hpp>
 
+#include <odr/exceptions.hpp>
+
 #include <odr/internal/common/file.hpp>
 #include <odr/internal/util/string_util.hpp>
 
@@ -172,6 +174,13 @@ std::optional<Archive::Entry> Archive::Entry::child() const {
                m_path.join(RelPath(child.get_name())));
 }
 
+void Archive::Iterator::enter_(Entry entry) {
+  if (!m_visited.insert(entry.m_entry_id).second) {
+    throw CfbFileCorrupted();
+  }
+  m_entry = std::move(entry);
+}
+
 void Archive::Iterator::dig_left_() {
   if (!m_entry.has_value()) {
     return;
@@ -183,7 +192,7 @@ void Archive::Iterator::dig_left_() {
       break;
     }
     m_ancestors.push_back(*m_entry);
-    m_entry = left;
+    enter_(*left);
   }
 }
 
@@ -194,7 +203,7 @@ void Archive::Iterator::next_() {
 
   if (const std::optional<Entry> child = m_entry->child(); child.has_value()) {
     m_directories.push_back(*m_entry);
-    m_entry = child;
+    enter_(*child);
     dig_left_();
     return;
   }
@@ -208,7 +217,7 @@ void Archive::Iterator::next_flat_() {
   }
 
   if (const std::optional<Entry> right = m_entry->right(); right.has_value()) {
-    m_entry = right;
+    enter_(*right);
     dig_left_();
     return;
   }

--- a/src/odr/internal/cfb/cfb_util.hpp
+++ b/src/odr/internal/cfb/cfb_util.hpp
@@ -6,9 +6,13 @@
 #include <odr/internal/cfb/cfb_impl.hpp>
 #include <odr/internal/common/path.hpp>
 
+#include <cstdint>
 #include <istream>
 #include <memory>
+#include <optional>
+#include <set>
 #include <string>
+#include <vector>
 
 namespace odr::internal::cfb::impl {
 class CompoundFileReader;
@@ -102,12 +106,17 @@ public:
     std::optional<Entry> m_entry;
     std::vector<Entry> m_ancestors;
     std::vector<Entry> m_directories;
+    std::set<std::uint32_t> m_visited;
 
     Iterator() = default;
-    explicit Iterator(const Entry &root_entry) : m_entry{root_entry} {
+    explicit Iterator(const Entry &root_entry) {
+      enter_(root_entry);
       dig_left_();
     }
 
+    /// Move onto a not-yet-visited entry; a repeat means a cyclic
+    /// child/sibling link ([MS-CFB] 2.6.4) that would never terminate.
+    void enter_(Entry entry);
     void dig_left_();
     void next_();
     void next_flat_();

--- a/src/odr/internal/common/filesystem.cpp
+++ b/src/odr/internal/common/filesystem.cpp
@@ -119,18 +119,19 @@ bool SystemFilesystem::copy(const AbsPath &from, const AbsPath &to) {
 
 std::shared_ptr<abstract::File>
 SystemFilesystem::copy(const abstract::File &from, const AbsPath &to) {
+  // `create_file` and `open` translate `to` themselves
   const auto istream = from.stream();
-  const auto ostream = create_file(to_system_path_(to));
+  const auto ostream = create_file(to);
 
   util::stream::pipe(*istream, *ostream);
 
-  return open(to_system_path_(to));
+  return open(to);
 }
 
 std::shared_ptr<abstract::File>
 SystemFilesystem::copy(const std::shared_ptr<abstract::File> from,
                        const AbsPath &to) {
-  return copy(*from, to_system_path_(to));
+  return copy(*from, to);
 }
 
 bool SystemFilesystem::move(const AbsPath &from, const AbsPath &to) {
@@ -150,12 +151,19 @@ public:
 
   VirtualFileWalker(const AbsPath &root, const Files &files) {
     for (const auto &[path, file] : files) {
-      if (path.ancestor_of(root)) {
+      if (path.descendant_of(root)) {
         m_files[path] = file;
       }
     }
 
     m_iterator = std::begin(m_files);
+  }
+
+  /// The iterator has to be re-seated into the copied map.
+  VirtualFileWalker(const VirtualFileWalker &other) : m_files{other.m_files} {
+    m_iterator = other.m_iterator == std::end(other.m_files)
+                     ? std::end(m_files)
+                     : m_files.find(other.m_iterator->first);
   }
 
   [[nodiscard]] std::unique_ptr<FileWalker> clone() const override {

--- a/src/odr/internal/common/path.cpp
+++ b/src/odr/internal/common/path.cpp
@@ -4,6 +4,20 @@
 
 namespace odr::internal {
 
+namespace {
+
+/// Whether @p path continues @p prefix at a component boundary, so that "/ab"
+/// is not taken for a descendant of "/a".
+bool has_path_prefix(const std::string &path, const std::string &prefix) {
+  if (!path.starts_with(prefix)) {
+    return false;
+  }
+  return prefix.empty() || prefix.back() == '/' ||
+         path.size() == prefix.size() || path[prefix.size()] == '/';
+}
+
+} // namespace
+
 Path::Path() noexcept : Path("") {}
 
 Path::Path(const char *c_string) : Path(std::string(c_string)) {}
@@ -32,15 +46,10 @@ Path::Path(const std::filesystem::path &path) : Path(path.string()) {}
 void Path::parent_() {
   if (m_downwards > 0) {
     --m_downwards;
-    if (m_downwards == 0) {
-      if (m_absolute) {
-        m_path = "/";
-      } else {
-        m_path = "";
-      }
+    if (m_upwards + m_downwards == 0) {
+      m_path = m_absolute ? "/" : "";
     } else {
-      const auto pos = m_path.rfind('/');
-      m_path = m_path.substr(0, pos);
+      m_path = m_path.substr(0, m_path.rfind('/'));
     }
   } else if (!m_absolute) {
     if (m_upwards + m_downwards == 0) {
@@ -129,7 +138,8 @@ bool Path::parent_of(const Path &b) const {
     throw std::invalid_argument("cannot compare absolute and relative path");
   }
   // TODO we need to check upwards as well
-  return (m_downwards + 1 == b.m_downwards) && (b.m_path.rfind(m_path, 0) == 0);
+  return (m_downwards + 1 == b.m_downwards) &&
+         has_path_prefix(b.m_path, m_path);
 }
 
 bool Path::ancestor_of(const Path &b) const { return b.descendant_of(*this); }
@@ -139,7 +149,7 @@ bool Path::descendant_of(const Path &b) const {
     throw std::invalid_argument("cannot compare absolute and relative path");
   }
   // TODO we need to check upwards as well
-  return (m_downwards < b.m_downwards) && (b.m_path.rfind(m_path, 0) == 0);
+  return (b.m_downwards < m_downwards) && has_path_prefix(m_path, b.m_path);
 }
 
 AbsPath Path::as_absolute() const & { return AbsPath(*this); }
@@ -176,10 +186,8 @@ std::string Path::basename() const {
 }
 
 std::string Path::extension() const {
-  // The extension is the last dot-separated segment of the file name, without
-  // the leading dot (e.g. "a.b.ppt" -> "ppt"). Delegate to std::filesystem so
-  // edge cases (no extension, dot-files like ".bashrc") match the platform's
-  // definition; it returns ".ppt", so strip the leading dot.
+  // `std::filesystem` defines the edge cases (none, dot-files); it yields
+  // ".ppt", we want "ppt"
   std::string extension = path().extension().string();
   if (!extension.empty() && extension.front() == '.') {
     extension.erase(extension.begin());

--- a/src/odr/internal/common/table_cursor.cpp
+++ b/src/odr/internal/common/table_cursor.cpp
@@ -7,7 +7,7 @@ namespace odr::internal {
 
 TableCursor::TableCursor() { m_sparse.emplace_back(); }
 
-void TableCursor::add_column(const uint32_t repeat) noexcept {
+void TableCursor::add_column(const std::uint32_t repeat) noexcept {
   m_column += repeat;
 }
 

--- a/src/odr/internal/crypto/crypto_util.cpp
+++ b/src/odr/internal/crypto/crypto_util.cpp
@@ -188,14 +188,20 @@ std::string util::decrypt_aes_gcm(const std::string &key, const std::string &iv,
                                   const std::string &input) {
   // follows https://www.w3.org/TR/xmlenc-core1/#sec-AES-GCM
 
-  if (std::strncmp(iv.data(), input.data(), iv.size()) != 0) {
+  const std::size_t iv_size = iv.size();
+  constexpr std::size_t mac_size = 16;
+
+  // The input is IV || ciphertext || tag; anything shorter would wrap
+  // `cipher_size`. `memcmp`, not `strncmp` — both operands are binary.
+  if (input.size() < iv_size + mac_size) {
+    throw std::runtime_error("GCM input too short");
+  }
+  if (std::memcmp(iv.data(), input.data(), iv_size) != 0) {
     throw std::runtime_error("IV mismatch");
   }
 
   std::string result(input.size(), '\0');
 
-  const std::size_t iv_size = iv.size();
-  constexpr std::size_t mac_size = 16;
   const std::size_t cipher_size = input.size() - iv_size - mac_size;
   auto *message = reinterpret_cast<byte *>(result.data());
   const auto *mac =

--- a/src/odr/internal/crypto/crypto_util.hpp
+++ b/src/odr/internal/crypto/crypto_util.hpp
@@ -38,6 +38,9 @@ std::string decrypt_aes_cbc(const std::string &key, const std::string &iv,
 /// size). Needed by the PDF R 6 hardened-hash algorithm (ISO 32000-2 2.B).
 std::string encrypt_aes_cbc(const std::string &key, const std::string &iv,
                             const std::string &input);
+/// AES-GCM per XML Encryption 1.1 §5.2.4: @p input is `iv || ciphertext ||
+/// 16-byte tag` and must repeat @p iv. Throws if it does not, if @p input is
+/// too short to hold both, or if the tag fails to verify.
 std::string decrypt_aes_gcm(const std::string &key, const std::string &iv,
                             const std::string &input);
 std::string decrypt_triple_des(const std::string &key, const std::string &iv,

--- a/src/odr/internal/file_type_table.cpp
+++ b/src/odr/internal/file_type_table.cpp
@@ -11,10 +11,9 @@ using file_type_table::Row;
 
 using namespace std::string_view_literals;
 
-// File extensions and MIME types accepted for each file type. The first entry
-// of a list is the canonical one. Aliases have to stay unique across file
-// types — the lookups take the first match and `odr_test` asserts that no
-// extension or MIME type appears twice.
+// Extensions and MIME types per file type, canonical one first. Aliases are
+// unique across types — the lookups take the first match, `odr_test` asserts
+// no alias appears twice.
 
 constexpr std::array odt_extensions{"odt"sv, "fodt"sv, "ott"sv, "odm"sv,
                                     "otm"sv};
@@ -79,9 +78,8 @@ constexpr std::array xlsx_mimetypes{
     "application/vnd.ms-excel.template.macroEnabled.12"sv,
 };
 
-// `.xlsb` ships in an OOXML package but stores the workbook in binary parts
-// instead of spreadsheetml, so it gets its own type rather than riding along
-// with `xlsx` — the capability row is what tells a caller we cannot open it.
+// `.xlsb` ships in an OOXML package but stores the workbook in binary parts,
+// not spreadsheetml, so it is its own type with no capabilities.
 constexpr std::array xlsb_extensions{"xlsb"sv};
 constexpr std::array xlsb_mimetypes{
     "application/vnd.ms-excel.sheet.binary.macroEnabled.12"sv};
@@ -246,13 +244,12 @@ constexpr std::array avi_extensions{"avi"sv};
 constexpr std::array avi_mimetypes{"video/x-msvideo"sv, "video/avi"sv,
                                    "video/msvideo"sv};
 
-// The single source of truth behind every public format lookup. `odr_test`
-// asserts that it covers each `FileType` exactly once and that the capability
-// bits agree with what the engines actually do.
+// The single source of truth behind every public format lookup; `odr_test`
+// asserts one row per `FileType` and capabilities that match the engines.
 //
-// `decrypt` on the OOXML document types refers to a password-protected
-// package, which is detected as `office_open_xml_encrypted` and decrypts into
-// the type named here. ODF files decrypt in place and keep their type.
+// `decrypt` on an OOXML document type means a password-protected package,
+// detected as `office_open_xml_encrypted` and decrypting into the type named
+// here. ODF files decrypt in place and keep their type.
 constexpr std::array table{
     Row{FileType::unknown,
         "unknown"sv,
@@ -505,11 +502,9 @@ constexpr std::array table{
         DocumentType::unknown,
         {.detect_by_content = true, .open = true, .translate_html = true}},
 
-    // Named but not decoded: `open` wraps the bytes without looking at them
-    // and `translate_html` hands them straight to the browser, in an `<img>`
-    // for the images below and in a player for the audio and video after them.
-    // Nothing here reads a pixel or a sample - see the comment on these in
-    // `FileType`.
+    // Named but not decoded: `open` wraps the bytes and `translate_html` hands
+    // them to the browser in an `<img>` or a player. Nothing reads a pixel or
+    // a sample.
     Row{FileType::webp,
         "webp"sv,
         webp_extensions,
@@ -611,9 +606,9 @@ constexpr std::array table{
         DocumentType::unknown,
         {.detect_by_content = true, .open = true, .translate_html = true}},
 
-    // Named but not decoded, like the images above. `translate_html` says the
-    // image page is written and the data url is labelled with the type below,
-    // not that every browser paints it - that is already true of tiff and heif.
+    // Named but not decoded, like the images above. `translate_html` means the
+    // image page is written and the data url labelled, not that every browser
+    // paints it.
     Row{FileType::scalable_vector_graphics,
         "svg"sv,
         svg_extensions,
@@ -680,7 +675,8 @@ template <typename Projection>
 const Row *find_by_alias(const std::string_view needle,
                          Projection list) noexcept {
   const auto it = std::ranges::find_if(table, [&](const Row &row) {
-    return std::ranges::find(list(row), needle) != std::ranges::end(list(row));
+    const auto aliases = list(row);
+    return std::ranges::find(aliases, needle) != std::ranges::end(aliases);
   });
   return it == std::ranges::end(table) ? nullptr : &*it;
 }

--- a/src/odr/internal/font/cff_builder.hpp
+++ b/src/odr/internal/font/cff_builder.hpp
@@ -21,17 +21,12 @@ struct BuilderGlyph {
 /// browser) needs: Header, Name INDEX, Top DICT (FontBBox +
 /// charset/CharStrings/Private offsets), String INDEX (every glyph name, SID
 /// 391+), an empty Global Subr INDEX, the CharStrings INDEX, a format-0 charset
-/// and a Private DICT
-/// (`defaultWidthX`/`nominalWidthX`). Glyph 0 is the implicit `.notdef`; the
-/// caller orders @p glyphs so glyph 0 is `.notdef`.
+/// and a Private DICT (`defaultWidthX`/`nominalWidthX`). The caller orders
+/// @p glyphs so glyph 0 is the implicit `.notdef`.
 ///
-/// This is the assembly target for the Type1 -> CFF path: the translated Type2
-/// charstrings go in here, the result feeds `CffFont` + `wrap_to_otf`. No
-/// `FontMatrix` is emitted, so the font is 1000
-/// units/em (the Type1 default); a non-default matrix is a follow-up.
-///
-/// Offsets in the Top DICT use the fixed-width 5-byte integer form so the
-/// layout resolves in a single pass.
+/// No `FontMatrix` is emitted, so the font is 1000 units/em (the Type1
+/// default); a non-default matrix is a follow-up. Top DICT offsets use the
+/// fixed-width 5-byte integer form so the layout resolves in a single pass.
 [[nodiscard]] std::string build_cff(std::string_view name,
                                     const std::vector<BuilderGlyph> &glyphs,
                                     double default_width, double nominal_width,

--- a/src/odr/internal/font/cff_font.cpp
+++ b/src/odr/internal/font/cff_font.cpp
@@ -4,10 +4,12 @@
 #include <odr/internal/pdf/pdf_encoding.hpp>
 #include <odr/internal/util/byte_string.hpp>
 
+#include <algorithm>
+#include <array>
 #include <cmath>
 #include <cstdint>
-#include <iterator>
 #include <map>
+#include <span>
 #include <stdexcept>
 #include <utility>
 #include <vector>
@@ -33,6 +35,8 @@ enum Operator : std::uint16_t {
   op_font_bbox = 5,
   op_ros = 1230,
   op_charstring_type = 1206,
+  op_fd_array = 1236,
+  op_fd_select = 1237,
 };
 
 /// Number-operand byte markers shared by DICT data and Type2 charstrings
@@ -95,6 +99,12 @@ namespace bs = util::byte_string;
 /// A parsed DICT: operator -> operands. Reals are decoded to double; integers
 /// stay exact within double range (CFF integers fit).
 using Dict = std::map<std::uint16_t, std::vector<double>>;
+
+/// A DICT operand as an FWord. Clamping keeps an out-of-range operand out of
+/// the undefined double -> int16 conversion.
+[[nodiscard]] std::int16_t to_fword(const double value) {
+  return static_cast<std::int16_t>(std::clamp(value, -32768.0, 32767.0));
+}
 
 /// Parse a CFF DICT occupying the byte range [begin, end) of @p d.
 [[nodiscard]] Dict parse_dict(const std::string_view d,
@@ -181,28 +191,28 @@ enum PredefinedCharset : std::uint32_t {
 
 /// Predefined Expert charset: glyph -> SID (Adobe TN #5176 Appendix C). The
 /// ISOAdobe charset is the identity (SID == GID) so it needs no table.
-constexpr std::uint16_t expert_charset[] = {
-    0,   1,   229, 230, 231, 232, 233, 234, 235, 236, 237, 238, 13,  14,
-    15,  99,  239, 240, 241, 242, 243, 244, 245, 246, 247, 248, 27,  28,
-    249, 250, 251, 252, 253, 254, 255, 256, 257, 258, 259, 260, 261, 262,
-    263, 264, 265, 266, 109, 110, 267, 268, 269, 270, 271, 272, 273, 274,
-    275, 276, 277, 278, 279, 280, 281, 282, 283, 284, 285, 286, 287, 288,
-    289, 290, 291, 292, 293, 294, 295, 296, 297, 298, 299, 300, 301, 302,
-    303, 304, 305, 306, 307, 308, 309, 310, 311, 312, 313, 314, 315, 316,
-    317, 318, 158, 155, 163, 319, 320, 321, 322, 323, 324, 325, 326, 150,
-    164, 169, 327, 328, 329, 330, 331, 332, 333, 334, 335, 336, 337, 338,
-    339, 340, 341, 342, 343, 344, 345, 346, 347, 348, 349, 350, 351, 352,
-    353, 354, 355, 356, 357, 358, 359, 360, 361, 362, 363, 364, 365, 366,
-    367, 368, 369, 370, 371, 372, 373, 374, 375, 376, 377, 378};
+constexpr auto expert_charset = std::to_array<std::uint16_t>(
+    {0,   1,   229, 230, 231, 232, 233, 234, 235, 236, 237, 238, 13,  14,
+     15,  99,  239, 240, 241, 242, 243, 244, 245, 246, 247, 248, 27,  28,
+     249, 250, 251, 252, 253, 254, 255, 256, 257, 258, 259, 260, 261, 262,
+     263, 264, 265, 266, 109, 110, 267, 268, 269, 270, 271, 272, 273, 274,
+     275, 276, 277, 278, 279, 280, 281, 282, 283, 284, 285, 286, 287, 288,
+     289, 290, 291, 292, 293, 294, 295, 296, 297, 298, 299, 300, 301, 302,
+     303, 304, 305, 306, 307, 308, 309, 310, 311, 312, 313, 314, 315, 316,
+     317, 318, 158, 155, 163, 319, 320, 321, 322, 323, 324, 325, 326, 150,
+     164, 169, 327, 328, 329, 330, 331, 332, 333, 334, 335, 336, 337, 338,
+     339, 340, 341, 342, 343, 344, 345, 346, 347, 348, 349, 350, 351, 352,
+     353, 354, 355, 356, 357, 358, 359, 360, 361, 362, 363, 364, 365, 366,
+     367, 368, 369, 370, 371, 372, 373, 374, 375, 376, 377, 378});
 
 /// Predefined ExpertSubset charset: glyph -> SID (Adobe TN #5176 Appendix C).
-constexpr std::uint16_t expert_subset_charset[] = {
-    0,   1,   231, 232, 235, 236, 237, 238, 13,  14,  15,  99,  239, 240, 241,
-    242, 243, 244, 245, 246, 247, 248, 27,  28,  249, 250, 251, 253, 254, 255,
-    256, 257, 258, 259, 260, 261, 262, 263, 264, 265, 266, 109, 110, 267, 268,
-    269, 270, 272, 300, 301, 302, 305, 314, 315, 158, 155, 163, 320, 321, 322,
-    323, 324, 325, 326, 150, 164, 169, 327, 328, 329, 330, 331, 332, 333, 334,
-    335, 336, 337, 338, 339, 340, 341, 342, 343, 344, 345, 346};
+constexpr auto expert_subset_charset = std::to_array<std::uint16_t>(
+    {0,   1,   231, 232, 235, 236, 237, 238, 13,  14,  15,  99,  239, 240, 241,
+     242, 243, 244, 245, 246, 247, 248, 27,  28,  249, 250, 251, 253, 254, 255,
+     256, 257, 258, 259, 260, 261, 262, 263, 264, 265, 266, 109, 110, 267, 268,
+     269, 270, 272, 300, 301, 302, 305, 314, 315, 158, 155, 163, 320, 321, 322,
+     323, 324, 325, 326, 150, 164, 169, 327, 328, 329, 330, 331, 332, 333, 334,
+     335, 336, 337, 338, 339, 340, 341, 342, 343, 344, 345, 346});
 
 } // namespace
 
@@ -237,6 +247,11 @@ std::vector<CffFont::Range> CffFont::read_index(const std::uint32_t offset,
   for (std::uint16_t i = 1; i <= count; ++i) {
     const std::uint32_t next =
         read_be(d, offset_array + i * off_size, off_size);
+    // The offset array is non-decreasing (Adobe TN #5176 §5); otherwise the
+    // member length would wrap.
+    if (next < prev) {
+      throw std::runtime_error("cff: non-monotonic INDEX offsets");
+    }
     members.push_back({data_base + prev, next - prev});
     prev = next;
   }
@@ -295,10 +310,8 @@ void CffFont::parse_top_dict(const Range top_dict) {
 
   if (const auto it = dict.find(op_font_bbox);
       it != dict.end() && it->second.size() == 4) {
-    m_bbox = {static_cast<std::int16_t>(it->second[0]),
-              static_cast<std::int16_t>(it->second[1]),
-              static_cast<std::int16_t>(it->second[2]),
-              static_cast<std::int16_t>(it->second[3])};
+    m_bbox = {to_fword(it->second[0]), to_fword(it->second[1]),
+              to_fword(it->second[2]), to_fword(it->second[3])};
   }
 
   if (const auto it = dict.find(op_char_strings); it != dict.end()) {
@@ -311,7 +324,15 @@ void CffFont::parse_top_dict(const Range top_dict) {
       it != dict.end() && it->second.size() == 2) {
     const auto size = static_cast<std::uint32_t>(it->second[0]);
     const auto offset = static_cast<std::uint32_t>(it->second[1]);
-    parse_private_dict({offset, size});
+    m_widths = parse_private_dict({offset, size});
+  }
+
+  // A CID-keyed font keeps its Private DICTs per FD, not in the Top DICT.
+  if (const auto it = dict.find(op_fd_array); it != dict.end()) {
+    parse_fd_array(static_cast<std::uint32_t>(it->second.at(0)));
+  }
+  if (const auto it = dict.find(op_fd_select); it != dict.end()) {
+    parse_fd_select(static_cast<std::uint32_t>(it->second.at(0)));
   }
 
   // charset: an offset past the predefined ids (0/1/2) is a custom charset;
@@ -339,33 +360,87 @@ void CffFont::load_predefined_charset(const std::uint32_t id) {
     }
     return;
   }
-  const std::uint16_t *table = nullptr;
-  std::size_t size = 0;
-  if (id == predefined_charset_expert) {
-    table = expert_charset;
-    size = std::size(expert_charset);
-  } else { // predefined_charset_expert_subset
-    table = expert_subset_charset;
-    size = std::size(expert_subset_charset);
-  }
-  for (std::uint16_t gid = 1; gid < glyphs && gid < size; ++gid) {
+  const std::span<const std::uint16_t> table =
+      id == predefined_charset_expert
+          ? std::span<const std::uint16_t>(expert_charset)
+          : std::span<const std::uint16_t>(expert_subset_charset);
+  for (std::uint16_t gid = 1; gid < glyphs && gid < table.size(); ++gid) {
     m_charset[gid] = table[gid];
   }
 }
 
-void CffFont::parse_private_dict(const Range private_dict) {
+CffFont::Widths CffFont::parse_private_dict(const Range private_dict) const {
+  Widths widths;
   if (private_dict.length == 0) {
-    return;
+    return widths;
   }
   const std::string_view d{m_data};
   const Dict dict = parse_dict(d, private_dict.offset,
                                private_dict.offset + private_dict.length);
   if (const auto it = dict.find(op_default_width_x); it != dict.end()) {
-    m_default_width = it->second.at(0);
+    widths.default_width = it->second.at(0);
   }
   if (const auto it = dict.find(op_nominal_width_x); it != dict.end()) {
-    m_nominal_width = it->second.at(0);
+    widths.nominal_width = it->second.at(0);
   }
+  return widths;
+}
+
+void CffFont::parse_fd_array(const std::uint32_t offset) {
+  const std::string_view d{m_data};
+  std::uint32_t end = 0;
+  for (const Range font_dict : read_index(offset, end)) {
+    const Dict dict =
+        parse_dict(d, font_dict.offset, font_dict.offset + font_dict.length);
+    Widths widths;
+    if (const auto it = dict.find(op_private);
+        it != dict.end() && it->second.size() == 2) {
+      widths = parse_private_dict({static_cast<std::uint32_t>(it->second[1]),
+                                   static_cast<std::uint32_t>(it->second[0])});
+    }
+    m_fd_widths.push_back(widths);
+  }
+}
+
+void CffFont::parse_fd_select(const std::uint32_t offset) {
+  const std::string_view d{m_data};
+  const std::uint16_t glyphs = glyph_count();
+  const std::uint8_t format = u8(d, offset);
+
+  if (format == 0) {
+    m_fd_select.reserve(glyphs);
+    for (std::uint16_t gid = 0; gid < glyphs; ++gid) {
+      m_fd_select.push_back(u8(d, offset + 1 + gid));
+    }
+    return;
+  }
+  if (format != 3) {
+    throw std::runtime_error("cff: unknown FDSelect format");
+  }
+
+  // format 3: ranges of [first, next first) sharing one FD, then a sentinel
+  const auto ranges = static_cast<std::uint16_t>(read_be(d, offset + 1, 2));
+  m_fd_select.assign(glyphs, 0);
+  for (std::uint16_t i = 0; i < ranges; ++i) {
+    const std::uint32_t entry = offset + 3 + 3 * i;
+    const auto first = static_cast<std::uint16_t>(read_be(d, entry, 2));
+    const std::uint8_t fd = u8(d, entry + 2);
+    const auto next = static_cast<std::uint16_t>(read_be(d, entry + 3, 2));
+    for (std::uint32_t gid = first; gid < next && gid < glyphs; ++gid) {
+      m_fd_select[gid] = fd;
+    }
+  }
+}
+
+const CffFont::Widths &
+CffFont::widths_for_glyph(const std::uint16_t glyph) const {
+  if (!m_fd_widths.empty()) {
+    const std::size_t fd = glyph < m_fd_select.size() ? m_fd_select[glyph] : 0;
+    if (fd < m_fd_widths.size()) {
+      return m_fd_widths[fd];
+    }
+  }
+  return m_widths;
 }
 
 void CffFont::parse_charset(const std::uint32_t offset) {
@@ -510,11 +585,13 @@ bool CffFont::symbolic() const noexcept {
 FontBBox CffFont::bounding_box() const noexcept { return m_bbox; }
 
 std::uint16_t CffFont::advance_width(const std::uint16_t glyph) const {
-  if (const std::optional<std::int32_t> width = charstring_width(glyph);
-      width.has_value()) {
-    return static_cast<std::uint16_t>(m_nominal_width + *width);
-  }
-  return static_cast<std::uint16_t>(m_default_width);
+  const Widths &widths = widths_for_glyph(glyph);
+  const std::optional<std::int32_t> width = charstring_width(glyph);
+  const double advance =
+      width.has_value() ? widths.nominal_width + *width : widths.default_width;
+  // An advance is a uFWord; clamping keeps a hostile Private DICT out of the
+  // undefined double -> uint16 conversion.
+  return static_cast<std::uint16_t>(std::clamp(advance, 0.0, 65535.0));
 }
 
 std::uint16_t CffFont::glyph_for_code_point(const char32_t code_point) const {

--- a/src/odr/internal/font/cff_font.hpp
+++ b/src/odr/internal/font/cff_font.hpp
@@ -49,8 +49,7 @@ public:
   [[nodiscard]] bool is_cid_keyed() const noexcept;
 
   /// The glyph's PostScript name (non-CID fonts), empty when unresolved (a
-  /// CID-keyed font, an out-of-range glyph, or a standard-string SID until the
-  /// standard-strings table lands — see the .cpp TODO).
+  /// CID-keyed font, an out-of-range glyph, or an unknown SID).
   [[nodiscard]] std::string glyph_name(std::uint16_t glyph) const;
 
   /// charset glyph -> CID (CID-keyed fonts), `0` when out of range or not
@@ -69,9 +68,24 @@ private:
     std::uint32_t length{};
   };
 
+  /// The two Private DICT entries a charstring's width is resolved against
+  /// (Adobe TN #5177 "width").
+  struct Widths {
+    double default_width{};
+    double nominal_width{};
+  };
+
   void parse();
   void parse_top_dict(Range top_dict);
-  void parse_private_dict(Range private_dict);
+  [[nodiscard]] Widths parse_private_dict(Range private_dict) const;
+  /// Parse `/FDArray`'s per-FD Private DICTs and `/FDSelect` (CID-keyed fonts;
+  /// Adobe TN #5176 §19). Without these a CID font resolves every width against
+  /// a `nominalWidthX` of 0.
+  void parse_fd_array(std::uint32_t offset);
+  void parse_fd_select(std::uint32_t offset);
+  /// The Private DICT widths governing @p glyph — its FD's for a CID-keyed
+  /// font, the Top DICT's otherwise.
+  [[nodiscard]] const Widths &widths_for_glyph(std::uint16_t glyph) const;
   void parse_charset(std::uint32_t offset);
   /// Materialize a predefined charset (id 0 ISOAdobe / 1 Expert / 2
   /// ExpertSubset) into `m_charset`, used when `/charset` is a predefined id or
@@ -100,8 +114,9 @@ private:
   std::vector<Range> m_strings;         // String INDEX members (SID 391+)
   std::vector<std::uint16_t> m_charset; // glyph -> SID (or CID, CID-keyed)
 
-  double m_default_width{};
-  double m_nominal_width{};
+  Widths m_widths;                       // Top DICT Private DICT
+  std::vector<Widths> m_fd_widths;       // per FDArray entry, CID-keyed only
+  std::vector<std::uint8_t> m_fd_select; // glyph -> FDArray index
 };
 
 } // namespace odr::internal::font::cff

--- a/src/odr/internal/font/cff_transform.cpp
+++ b/src/odr/internal/font/cff_transform.cpp
@@ -99,24 +99,9 @@ std::string cff::wrap_to_otf(const CffFont &font,
                              const std::map<char32_t, std::uint16_t> &extra) {
   const std::uint16_t glyphs = font.glyph_count();
 
-  // The uniform PUA re-encode: pua_code_point(glyph) -> glyph over every glyph.
-  // Glyphs past the 6400-slot BMP PUA overflow into Supplementary PUA-A, and
-  // serialize_cmap emits a format-12 subtable to cover them.
-  std::map<char32_t, std::uint16_t> pua;
-  for (std::uint16_t glyph = 0; glyph < glyphs; ++glyph) {
-    pua[pua_code_point(glyph)] = glyph;
-  }
-  // Real-Unicode entries: caller guarantees BMP, non-PUA keys, so these never
-  // collide with the PUA range filled above. A glyph id the font does not have
-  // is dropped: `glyph_for_code` can fall back to "code as GID" (ISO 32000-1
-  // 9.6.6.4) and yield an out-of-range index, and a single cmap reference past
-  // `numGlyphs` makes the OTS sanitizer reject the *entire* font (so every
-  // glyph would render as a tofu box, not just the unmappable code).
-  for (const auto &[code, glyph] : extra) {
-    if (glyph < glyphs) {
-      pua[code] = glyph;
-    }
-  }
+  // Glyphs past the 6400-slot BMP PUA overflow into Supplementary PUA-A, which
+  // serialize_cmap covers with a format-12 subtable.
+  const std::map<char32_t, std::uint16_t> pua = pua_cmap(glyphs, extra);
 
   std::uint16_t advance_width_max = 0;
   for (std::uint16_t glyph = 0; glyph < glyphs; ++glyph) {

--- a/src/odr/internal/font/cff_transform.hpp
+++ b/src/odr/internal/font/cff_transform.hpp
@@ -14,21 +14,11 @@ class CffFont;
 /// sanitizer) require, so this synthesizes the skeleton — `head` / `hhea` /
 /// `maxp` (v0.5) / `hmtx` / `name` / `post` / `OS/2` — from the
 /// `abstract::Font` facts and embeds the original CFF verbatim as the `CFF `
-/// table (pass-through, no outline interpretation). The `cmap` is the **uniform
-/// PUA re-encode**: `pua_code_point(glyph) -> glyph` over every
-/// glyph, so the font renders every glyph — including charset-unreachable ones
-/// — when loaded via `@font-face`, matching the PUA code points the PDF HTML
-/// layer emits.
+/// table (pass-through, no outline interpretation).
 ///
-/// @p extra adds real-Unicode -> glyph entries alongside the PUA range, so a
-/// run whose codes map 1:1 to those scalars can render the *real* Unicode
-/// directly (the HTML layer then collapses its dual selectable/visible spans
-/// into one). Keys must be in the BMP and outside the PUA (`U+E000..U+F8FF`);
-/// the caller guarantees this. The PUA range is always kept as a fallback.
-///
-/// Reuses the `sfnt_transform` serializers (`build_sfnt`, `serialize_cmap`,
-/// `serialize_post`, `serialize_os2`). Throws `std::runtime_error` if the glyph
-/// count exceeds the BMP PUA capacity (6400).
+/// The `cmap` is `pua_cmap(glyph_count, extra)`, so the font renders every
+/// glyph — including charset-unreachable ones — at the PUA code points the PDF
+/// HTML layer emits.
 [[nodiscard]] std::string
 wrap_to_otf(const CffFont &font,
             const std::map<char32_t, std::uint16_t> &extra = {});

--- a/src/odr/internal/font/sfnt_font.cpp
+++ b/src/odr/internal/font/sfnt_font.cpp
@@ -18,9 +18,7 @@ namespace bs = util::byte_string;
 
 namespace {
 
-// SFNT enumerations (OpenType spec). Values are the on-disk codes; casting a
-// raw `u16` to one and switching/comparing keeps the magic numbers in one
-// place.
+// The enumerators below are the on-disk codes (OpenType spec).
 
 /// `cmap`/`name` platform IDs.
 enum class PlatformId : std::uint16_t {
@@ -203,8 +201,7 @@ void SfntFont::read_directory(const std::string_view sfnt) {
                                          : FontFormat::truetype;
   const std::uint16_t num_tables = bs::read_u16_be(sfnt.substr(4));
 
-  // The offset table is 12 bytes (sfntVersion, numTables, then the three search
-  // hints); each of the `num_tables` directory entries is 16 bytes: tag(4),
+  // Past the 12 byte offset table, each directory entry is 16 bytes: tag(4),
   // checkSum(4), offset(4), length(4).
   for (std::uint16_t i = 0; i < num_tables; ++i) {
     const std::size_t entry = 12 + static_cast<std::size_t>(i) * 16;
@@ -309,9 +306,6 @@ void SfntFont::read_cmap_subtable(const std::string_view s) {
     m_cmap[code] = glyph;
   };
 
-  // Every subtable format has a fixed-layout header, so each field is read at
-  // its known offset (matching the rest of this file). Format 4's arrays are
-  // variable-length, but each one's offset is a fixed function of segCount.
   const auto read_u16_vector = [](const std::string_view v,
                                   const std::size_t count) {
     std::vector<std::uint16_t> out;
@@ -330,11 +324,10 @@ void SfntFont::read_cmap_subtable(const std::string_view s) {
     }
     break;
   }
-  case CmapFormat::segment_mapping: { // segment mapping to delta values
-    // format(0), length(2), language(4), segCountX2(6), then searchRange(8),
-    // entrySelector(10), rangeShift(12). The four parallel segs-sized arrays
-    // follow: endCode(14), reservedPad, startCode, idDelta, idRangeOffset, each
-    // starting at a fixed offset once segCount is known.
+  case CmapFormat::segment_mapping: {
+    // format(0), length(2), language(4), segCountX2(6), 3 search hints(8..12),
+    // then the parallel segs-sized arrays endCode(14), reservedPad, startCode,
+    // idDelta, idRangeOffset.
     const std::uint16_t length = bs::read_u16_be(s.substr(2));
     const std::size_t segs = bs::read_u16_be(s.substr(6)) / 2U;
     const std::vector<std::uint16_t> end_codes =
@@ -345,9 +338,8 @@ void SfntFont::read_cmap_subtable(const std::string_view s) {
         read_u16_vector(s.substr(16 + 4 * segs), segs);
     const std::vector<std::uint16_t> id_range_offsets =
         read_u16_vector(s.substr(16 + 6 * segs), segs);
-    // Whatever remains of the subtable is the glyphIdArray that non-zero
-    // idRangeOffsets index into; preload it so the inner loop is a plain
-    // lookup. The header up to this point is 16 + 8*segs bytes.
+    // What remains past the 16 + 8*segs byte header is the glyphIdArray that
+    // non-zero idRangeOffsets index into.
     const std::size_t header = 16 + 8 * segs;
     if (length < header) {
       throw std::runtime_error("sfnt: cmap format 4 subtable too short");
@@ -505,22 +497,16 @@ std::string SfntFont::write() const {
   }
   tables.emplace_back("cmap", serialize_cmap(m_cmap));
 
-  // A `post` table is required by OTS; PDF-embedded TrueType fonts often omit
-  // it. Synthesize a minimal one so the browser accepts the `@font-face`.
+  // OTS rejects a font missing `post` / `name` / `OS/2`, and PDF-embedded
+  // TrueType routinely omits all three; synthesize the missing ones so the
+  // browser accepts the `@font-face`. build_sfnt sorts the directory, so the
+  // insertion order here does not matter.
   if (!m_tables.contains("post")) {
     tables.emplace_back("post", serialize_post());
   }
-
-  // `name` is likewise required by OTS and likewise often omitted from
-  // TrueType subsets. Synthesize a minimal one (falls back to "ODR Font" when
-  // the font carries no name at all).
   if (!m_tables.contains("name")) {
     tables.emplace_back("name", serialize_name(m_name));
   }
-
-  // `OS/2` is likewise required by OTS and likewise often omitted. Synthesize
-  // it from the cmap bounds and bounding box (build_sfnt sorts the directory,
-  // so the insertion order here does not matter).
   if (!m_tables.contains("OS/2")) {
     std::uint16_t first_char = 0;
     std::uint16_t last_char = 0;

--- a/src/odr/internal/font/sfnt_transform.cpp
+++ b/src/odr/internal/font/sfnt_transform.cpp
@@ -150,12 +150,11 @@ font::build_sfnt(const std::uint32_t sfnt_version,
   return out;
 }
 
-/// Format-12 `cmap` subtable (segmented coverage): sequential map groups over
-/// the full Unicode range, each `[startCharCode, endCharCode]` mapping to
-/// `startGlyphID + (code - startCharCode)`. Used when the map reaches beyond
-/// the BMP (glyphs overflowing into Supplementary PUA-A), which format 4 cannot
-/// express. Wrapped in a (Windows, Unicode full repertoire) encoding record.
-static std::string
+namespace {
+
+/// Format-12 `cmap` subtable (segmented coverage), in a (Windows, Unicode full
+/// repertoire) encoding record — what format 4 cannot express.
+std::string
 serialize_cmap_format12(const std::map<char32_t, std::uint16_t> &map) {
   struct Group {
     std::uint32_t start_code;
@@ -195,6 +194,8 @@ serialize_cmap_format12(const std::map<char32_t, std::uint16_t> &map) {
   cmap += sub;
   return cmap;
 }
+
+} // namespace
 
 std::string font::serialize_cmap(const std::map<char32_t, std::uint16_t> &map) {
   // Format 4 tops out at the BMP; a map that overflows into the Supplementary
@@ -375,29 +376,32 @@ std::string font::serialize_os2(const std::uint16_t units_per_em,
   return os2;
 }
 
-void font::reencode_to_pua(sfnt::SfntFont &font,
-                           const std::map<char32_t, std::uint16_t> &extra) {
+std::map<char32_t, std::uint16_t>
+font::pua_cmap(const std::uint16_t glyph_count,
+               const std::map<char32_t, std::uint16_t> &extra) {
   // A uint16 glyph id always fits: `pua_code_point` maps the BMP PUA first
   // (6400 slots) then overflows into Supplementary PUA-A, whose combined
   // `pua_capacity` (71934) exceeds any 16-bit glyph count.
   static_assert(std::numeric_limits<std::uint16_t>::max() < pua_capacity);
 
   std::map<char32_t, std::uint16_t> map;
-  for (std::uint16_t glyph = 0; glyph < font.glyph_count(); ++glyph) {
+  for (std::uint16_t glyph = 0; glyph < glyph_count; ++glyph) {
     map[pua_code_point(glyph)] = glyph;
   }
-  // Real-Unicode entries: caller guarantees BMP, non-PUA keys, so these never
-  // collide with the PUA range filled above. A glyph id the font does not have
-  // is dropped: `glyph_for_code` can fall back to "code as GID" (ISO 32000-1
-  // 9.6.6.4) and yield an out-of-range index, and a single cmap reference past
-  // `numGlyphs` makes the OTS sanitizer reject the *entire* font (so every
-  // glyph would render as a tofu box, not just the unmappable code).
+  // The caller guarantees BMP, non-PUA keys, so these never collide with the
+  // range filled above. An out-of-range glyph is dropped: `glyph_for_code` can
+  // fall back to "code as GID" (ISO 32000-1 9.6.6.4).
   for (const auto &[code, glyph] : extra) {
-    if (glyph < font.glyph_count()) {
+    if (glyph < glyph_count) {
       map[code] = glyph;
     }
   }
-  font.set_cmap(std::move(map));
+  return map;
+}
+
+void font::reencode_to_pua(sfnt::SfntFont &font,
+                           const std::map<char32_t, std::uint16_t> &extra) {
+  font.set_cmap(pua_cmap(font.glyph_count(), extra));
 }
 
 } // namespace odr::internal

--- a/src/odr/internal/font/sfnt_transform.hpp
+++ b/src/odr/internal/font/sfnt_transform.hpp
@@ -12,68 +12,52 @@ namespace sfnt {
 class SfntFont;
 }
 
-/// The deterministic Private Use Area code point that the uniform
-/// re-encode assigns to glyph @p glyph:
-/// `U+E000 + glyph` in the BMP PUA. Every consumer (the specimen page, the PDF
-/// `@font-face` emission) derives the displayed code point from this — no
-/// per-font table needed.
+/// The deterministic Private Use Area code point the uniform re-encode assigns
+/// to glyph @p glyph: `U+E000 + glyph` while the BMP PUA lasts (6400 slots),
+/// then Supplementary PUA-A from `U+F0000`. Every consumer derives the
+/// displayed code point from this — no per-font table needed.
 [[nodiscard]] char32_t pua_code_point(std::uint16_t glyph) noexcept;
 
+/// The uniform PUA re-encode as a `cmap` model: `pua_code_point(glyph) ->
+/// glyph` for every glyph below @p glyph_count, plus @p extra's real-Unicode
+/// entries alongside it (keys must be in the BMP and outside `U+E000..U+F8FF`
+/// so they never shadow a glyph's own PUA code point; the caller guarantees
+/// this). An @p extra entry naming a glyph the font does not have is dropped —
+/// a single `cmap` reference past `numGlyphs` makes the OTS sanitizer reject
+/// the *entire* font, so every glyph would render as tofu.
+[[nodiscard]] std::map<char32_t, std::uint16_t>
+pua_cmap(std::uint16_t glyph_count,
+         const std::map<char32_t, std::uint16_t> &extra = {});
+
 /// Serialize an SFNT from its tables, computing the table directory, per-table
-/// checksums and `head.checkSumAdjustment`, and return the assembled bytes.
-/// @p tables need not be sorted; a `head` table is patched in place with the
-/// final adjustment.
-///
-/// The whole-file checksum is additive over the 4-byte-aligned table layout, so
-/// it equals `checksum(header+directory) + Σ checksum(table)` — computed
-/// analytically and the adjustment patched into `head` before the bytes are
-/// concatenated.
+/// checksums and `head.checkSumAdjustment`. @p tables need not be sorted; a
+/// `head` table is patched in place with the final adjustment.
 [[nodiscard]] std::string
 build_sfnt(std::uint32_t sfnt_version,
            std::vector<std::pair<std::string, std::string>> tables);
 
-/// Serialize a code point -> glyph map into a `cmap` table.
-///
-/// LIMITATION: emits a single Windows (3,1) format-4 subtable, so only BMP code
-/// points (<= U+FFFF) are supported; a map containing a code point beyond the
-/// BMP (which would require a format-12 subtable) throws `std::runtime_error`.
-/// Within the BMP there is no further restriction: the map is split into
-/// maximal arithmetic runs (consecutive code points mapping to consecutive
-/// glyphs, `idRangeOffset = 0`), and a run of length one is trivially
-/// arithmetic, so the `glyphIdArray` path is never needed. This covers the
-/// uniform PUA re-encode (one run) and ordinary remaps; format-12 / multi-plane
-/// coverage is a follow-up.
+/// Serialize a code point -> glyph map into a `cmap` table: one Windows
+/// subtable, format 4 (3,1) while the map stays in the BMP, format 12 (3,10)
+/// once it reaches beyond it. Both split the map into maximal runs of
+/// consecutive code points mapping to consecutive glyphs, so format 4 never
+/// needs a `glyphIdArray`.
 [[nodiscard]] std::string
 serialize_cmap(const std::map<char32_t, std::uint16_t> &map);
 
-/// Serialize a minimal `name` table: nameIDs 1/2/4/6 (family / subfamily /
-/// full / PostScript), Windows platform (3,1), UTF-16BE.
-///
-/// OTS (the font sanitizer in Chrome/Firefox) requires `name` and rejects the
-/// whole font when it is absent — like `post` and `OS/2`, PDF-embedded fonts
-/// routinely omit it (a bare CFF has none; TrueType subsets often drop it).
-/// An empty @p font_name falls back to "ODR Font".
+// OTS (the font sanitizer in Chrome/Firefox) rejects a font that is missing
+// `name`, `post` or `OS/2` — the browser then drops the `@font-face` and
+// renders tofu — and PDF-embedded fonts routinely omit all three. The three
+// below synthesize minimal stand-ins; OTS reconciles the fields they leave
+// neutral (e.g. `fsSelection` against `head`).
+
+/// nameIDs 1/2/4/6 (family / subfamily / full / PostScript), Windows (3,1),
+/// UTF-16BE. An empty @p font_name falls back to "ODR Font".
 [[nodiscard]] std::string serialize_name(const std::string &font_name);
 
-/// Serialize a minimal version-3.0 `post` table (header only, no glyph names).
-///
-/// OTS (the font sanitizer in Chrome/Firefox) lists `post` among the tables an
-/// SFNT must carry and rejects the whole font when it is absent — the browser
-/// then drops the `@font-face` and renders tofu. PDF-embedded TrueType fonts
-/// routinely omit `post` (the viewer needs no glyph names), so a font copied
-/// through verbatim would be rejected. Format 3.0 declares "no glyph names",
-/// which is all a re-encoded display font needs.
+/// Version-3.0 `post`: the header alone, i.e. "no glyph names".
 [[nodiscard]] std::string serialize_post();
 
-/// Serialize a minimal version-4 `OS/2` table.
-///
-/// OTS (the font sanitizer in Chrome/Firefox) also requires `OS/2` and rejects
-/// the whole font when it is absent — like `post`, PDF-embedded TrueType fonts
-/// routinely omit it (the viewer takes its metrics elsewhere), so a font copied
-/// through verbatim is rejected. The synthesized table carries neutral weight
-/// and width (regular, medium) with the vertical metrics and character-range
-/// bounds derived from the arguments; OTS reconciles the remaining fields (e.g.
-/// the `fsSelection` style bits against `head`). @p units_per_em scales the
+/// Version-4 `OS/2`, neutral weight and width. @p units_per_em scales the
 /// sub/superscript and strikeout defaults; @p y_min / @p y_max are the font
 /// bounding box (ascender/descender fall back to 0.8/0.2 em when degenerate);
 /// @p first_char / @p last_char bound the `cmap`.
@@ -88,15 +72,10 @@ serialize_cmap(const std::map<char32_t, std::uint16_t> &map);
 /// never reached — when loaded via `@font-face`. `font.write()` then emits the
 /// re-encoded SFNT.
 ///
-/// @p extra adds real-Unicode -> glyph entries alongside the PUA range, so a
-/// run whose codes map 1:1 to those scalars can render the *real* Unicode
-/// directly (the HTML layer then collapses its dual selectable/visible spans
-/// into one). Keys must be in the BMP and outside the PUA (`U+E000..U+F8FF`) so
-/// they never shadow a glyph's own PUA code point; the caller guarantees this.
-/// The PUA range is always kept as a fallback.
-///
-/// Throws `std::runtime_error` if the glyph count exceeds the BMP PUA capacity
-/// (6400); multi-plane PUA spill-over is a follow-up.
+/// @p extra adds real-Unicode -> glyph entries alongside the PUA range (see
+/// `pua_cmap`), so a run whose codes map 1:1 to those scalars can render the
+/// *real* Unicode directly — the HTML layer then collapses its dual
+/// selectable/visible spans into one.
 void reencode_to_pua(sfnt::SfntFont &font,
                      const std::map<char32_t, std::uint16_t> &extra = {});
 

--- a/src/odr/internal/font/type1_charstring.cpp
+++ b/src/odr/internal/font/type1_charstring.cpp
@@ -2,13 +2,26 @@
 
 #include <algorithm>
 #include <cmath>
+#include <cstddef>
 #include <cstdint>
+#include <stdexcept>
 #include <string>
+#include <string_view>
 #include <vector>
 
 namespace odr::internal::font::type1 {
 
 namespace {
+
+/// Charstring byte at @p i; an operand cut short by the end of the charstring
+/// is malformed input, not something to read past.
+[[nodiscard]] std::uint8_t byte_at(const std::string_view cs,
+                                   const std::size_t i) {
+  if (i >= cs.size()) {
+    throw std::runtime_error("type1: truncated charstring");
+  }
+  return static_cast<std::uint8_t>(cs[i]);
+}
 
 // Type1 charstring operators (single byte; 12 = escape to a two-byte op).
 enum T1 : std::int32_t {
@@ -127,18 +140,18 @@ private:
           p += 1;
         } else if (b <= 250) {
           value = (static_cast<std::int32_t>(b) - 247) * 256 +
-                  static_cast<std::uint8_t>(cs[p + 1]) + 108;
+                  byte_at(cs, p + 1) + 108;
           p += 2;
         } else if (b <= 254) {
           value = -(static_cast<std::int32_t>(b) - 251) * 256 -
-                  static_cast<std::uint8_t>(cs[p + 1]) - 108;
+                  byte_at(cs, p + 1) - 108;
           p += 2;
         } else { // 255: Type1 32-bit integer
           value = static_cast<std::int32_t>(
-              (static_cast<std::uint8_t>(cs[p + 1]) << 24) |
-              (static_cast<std::uint8_t>(cs[p + 2]) << 16) |
-              (static_cast<std::uint8_t>(cs[p + 3]) << 8) |
-              static_cast<std::uint8_t>(cs[p + 4]));
+              static_cast<std::uint32_t>(byte_at(cs, p + 1)) << 24 |
+              static_cast<std::uint32_t>(byte_at(cs, p + 2)) << 16 |
+              static_cast<std::uint32_t>(byte_at(cs, p + 3)) << 8 |
+              byte_at(cs, p + 4));
           p += 5;
         }
         m_stack.push_back(value);
@@ -147,7 +160,7 @@ private:
       std::int32_t op = b;
       ++p;
       if (b == 12) {
-        op = 1200 + static_cast<std::uint8_t>(cs[p]);
+        op = 1200 + byte_at(cs, p);
         ++p;
       }
       handle(op, depth);

--- a/src/odr/internal/font/type1_charstring.hpp
+++ b/src/odr/internal/font/type1_charstring.hpp
@@ -24,7 +24,8 @@ struct Type2Charstring {
 /// charstring, so the caller emits it against the CFF `nominalWidthX`.
 ///
 /// Best-effort and display-oriented: hints are dropped (they affect rendering
-/// quality, not glyph shape), and unknown operators are skipped.
+/// quality, not glyph shape), and unknown operators are skipped. Throws
+/// `std::runtime_error` on a charstring that ends mid-operand.
 [[nodiscard]] Type2Charstring to_type2(std::string_view type1,
                                        const std::vector<std::string> &subrs);
 

--- a/src/odr/internal/font/type1_font.cpp
+++ b/src/odr/internal/font/type1_font.cpp
@@ -3,6 +3,7 @@
 #include <odr/internal/font/type1_crypt.hpp>
 #include <odr/internal/util/byte_util.hpp>
 
+#include <algorithm>
 #include <charconv>
 #include <cstdint>
 #include <optional>
@@ -54,6 +55,12 @@ namespace {
   } catch (const std::exception &) {
     return 0.0;
   }
+}
+
+/// A `/FontBBox` number as an FWord. Clamping keeps an out-of-range number out
+/// of the undefined double -> int16 conversion.
+[[nodiscard]] std::int16_t to_fword(const double value) {
+  return static_cast<std::int16_t>(std::clamp(value, -32768.0, 32767.0));
 }
 
 /// Parse the numbers inside the next `[...]` or `{...}` after @p key in @p s.
@@ -180,9 +187,8 @@ void Type1Font::parse_clear(const std::string_view clear) {
   }
   if (const std::vector<double> bbox = parse_number_array(clear, "/FontBBox");
       bbox.size() == 4) {
-    m_font_bbox = {
-        static_cast<std::int16_t>(bbox[0]), static_cast<std::int16_t>(bbox[1]),
-        static_cast<std::int16_t>(bbox[2]), static_cast<std::int16_t>(bbox[3])};
+    m_font_bbox = {to_fword(bbox[0]), to_fword(bbox[1]), to_fword(bbox[2]),
+                   to_fword(bbox[3])};
   }
 
   // /Encoding: `StandardEncoding def`, or a custom array built with
@@ -212,30 +218,36 @@ void Type1Font::parse_clear(const std::string_view clear) {
 }
 
 void Type1Font::parse_private(const std::string_view decrypted) {
-  std::int32_t len_iv = 4;
+  std::size_t len_iv = 4;
   if (const std::size_t k = decrypted.find("/lenIV");
       k != std::string_view::npos) {
     std::size_t p = k + 6;
     std::int32_t value = 0;
     if (parse_int(read_token(decrypted, p), value)) {
-      len_iv = value;
+      if (value < 0) {
+        throw std::runtime_error("type1: negative /lenIV");
+      }
+      len_iv = static_cast<std::size_t>(value);
     }
   }
-  m_len_iv = len_iv;
+
+  // /CharStrings starts where /Subrs ends (Subrs precede it).
+  const std::size_t cs = decrypted.find("/CharStrings");
 
   // /Subrs: entries `dup <index> <length> RD <bytes> NP`.
   if (const std::size_t k = decrypted.find("/Subrs");
       k != std::string_view::npos) {
     std::size_t p = k;
     while ((p = decrypted.find("dup ", p)) != std::string_view::npos) {
-      // Stop when /CharStrings starts (Subrs precede it).
-      const std::size_t cs = decrypted.find("/CharStrings");
       if (cs != std::string_view::npos && p > cs) {
         break;
       }
       std::size_t q = p + 4;
       std::int32_t index = 0;
-      if (!parse_int(read_token(decrypted, q), index) || index < 0) {
+      // Every subr needs at least one byte of input, so an index at or past the
+      // input size cannot name one — and must not size the vector.
+      if (!parse_int(read_token(decrypted, q), index) || index < 0 ||
+          static_cast<std::size_t>(index) >= decrypted.size()) {
         p += 4;
         continue;
       }
@@ -254,7 +266,6 @@ void Type1Font::parse_private(const std::string_view decrypted) {
   }
 
   // /CharStrings: entries `/<name> <length> RD <bytes> ND`.
-  const std::size_t cs = decrypted.find("/CharStrings");
   if (cs == std::string_view::npos) {
     return;
   }

--- a/src/odr/internal/font/type1_font.hpp
+++ b/src/odr/internal/font/type1_font.hpp
@@ -22,12 +22,10 @@ struct Glyph {
 ///
 /// A Type1 program has three sections: a clear-text header (font dictionary up
 /// to `eexec`), an `eexec`-encrypted private portion (`/Subrs`,
-/// `/CharStrings`), and a zero-padded trailer. This reads the header for
-/// `/FontMatrix`,
-/// `/FontBBox`, `/Encoding` and `/FontName`, decrypts the `eexec` section
-/// (`type1_crypt`) and extracts every glyph's decrypted charstring plus the
-/// `/Subrs`. It does **not** yet interpret the charstrings — that is the
-/// Type1 -> Type2 translation that follows, feeding 3.4's CFF -> OTF path.
+/// `/CharStrings`), and a zero-padded trailer. This reads `/FontMatrix`,
+/// `/FontBBox`, `/Encoding` and `/FontName` from the header, decrypts the
+/// `eexec` section (`type1_crypt`) and keeps every glyph's decrypted
+/// charstring plus the `/Subrs`; interpreting them is `type1_charstring`.
 ///
 /// Throws `std::runtime_error` when the program has no `eexec` section or no
 /// `/CharStrings`.
@@ -78,7 +76,6 @@ private:
   bool m_standard_encoding{true};
   std::vector<Glyph> m_glyphs;
   std::vector<std::string> m_subrs;
-  std::int32_t m_len_iv{4};
 };
 
 } // namespace odr::internal::font::type1

--- a/src/odr/internal/font/type1_transform.hpp
+++ b/src/odr/internal/font/type1_transform.hpp
@@ -10,11 +10,9 @@ class Type1Font;
 /// glyph's charstring to Type2 (`to_type2`, flattening the font's `/Subrs`) and
 /// assemble via the CFF builder, with `.notdef` placed at glyph 0.
 ///
-/// Returns the CFF bytes (not a `cff::CffFont`): a `CffFont` is the
-/// parse-and-keep-the-bytes reader, so producing one means parsing this output
-/// back — the caller does that (`CffFont{to_cff(font)}`), then `wrap_to_otf`
-/// wraps it for the browser, so an embedded Type1 font reuses the entire 3.4
-/// CFF path. Mirrors `cff::wrap_to_otf`, which likewise emits bytes.
+/// Returns the CFF bytes, not a `cff::CffFont`: the caller parses them back
+/// (`CffFont{to_cff(font)}`) and hands the result to `wrap_to_otf`, so an
+/// embedded Type1 font reuses the whole CFF path.
 [[nodiscard]] std::string to_cff(const Type1Font &font);
 
 } // namespace odr::internal::font::type1

--- a/src/odr/internal/html/document.cpp
+++ b/src/odr/internal/html/document.cpp
@@ -23,14 +23,19 @@
 namespace odr::internal::html {
 namespace {
 
+/// Whether the document renders as fixed-size pages on a backdrop rather than
+/// reflowing to the viewport.
+bool is_paged_content(const Document &document, const HtmlConfig &config) {
+  return (document.document_type() == DocumentType::text &&
+          config.text_document_margin) ||
+         document.document_type() == DocumentType::presentation ||
+         document.document_type() == DocumentType::drawing;
+}
+
 void front(const Document &document, const WritingState &state) {
   HtmlWriter &out = state.out();
 
-  const bool paged_content =
-      (document.document_type() == DocumentType::text &&
-       state.config().text_document_margin) ||
-      document.document_type() == DocumentType::presentation ||
-      document.document_type() == DocumentType::drawing;
+  const bool paged_content = is_paged_content(document, state.config());
 
   out.write_begin();
   out.write_header_begin();
@@ -78,13 +83,7 @@ void front(const Document &document, const WritingState &state) {
 void back(const Document &document, const WritingState &state) {
   HtmlWriter &out = state.out();
 
-  const bool paged_content =
-      (document.document_type() == DocumentType::text &&
-       state.config().text_document_margin) ||
-      document.document_type() == DocumentType::presentation ||
-      document.document_type() == DocumentType::drawing;
-
-  if (paged_content) {
+  if (is_paged_content(document, state.config())) {
     out.write_element_end("div");
   }
 
@@ -323,56 +322,30 @@ public:
   }
 };
 
-class SlideHtmlFragment final : public HtmlFragmentBase {
+/// A fragment rendering one top-level element handle (slide, sheet, page)
+/// through its `translate_*` function.
+template <typename Handle,
+          void (*Translate)(const Handle &, const WritingState &)>
+class ElementHtmlFragment final : public HtmlFragmentBase {
 public:
-  explicit SlideHtmlFragment(std::string name, const std::size_t index,
-                             std::string path, Document document,
-                             const Slide &slide)
+  explicit ElementHtmlFragment(std::string name, const std::size_t index,
+                               std::string path, Document document,
+                               const Handle &element)
       : HtmlFragmentBase(std::move(name), index, std::move(path),
                          std::move(document)),
-        m_slide{slide} {}
+        m_element{element} {}
 
   void write_fragment(HtmlWriter &, WritingState &state) const override {
-    translate_slide(m_slide, state);
+    Translate(m_element, state);
   }
 
 private:
-  Slide m_slide;
+  Handle m_element;
 };
 
-class SheetHtmlFragment final : public HtmlFragmentBase {
-public:
-  explicit SheetHtmlFragment(std::string name, const std::size_t index,
-                             std::string path, Document document,
-                             const Sheet &sheet)
-      : HtmlFragmentBase(std::move(name), index, std::move(path),
-                         std::move(document)),
-        m_sheet{sheet} {}
-
-  void write_fragment(HtmlWriter &, WritingState &state) const override {
-    translate_sheet(m_sheet, state);
-  }
-
-private:
-  Sheet m_sheet;
-};
-
-class PageHtmlFragment final : public HtmlFragmentBase {
-public:
-  explicit PageHtmlFragment(std::string name, const std::size_t index,
-                            std::string path, Document document,
-                            const Page &page)
-      : HtmlFragmentBase(std::move(name), index, std::move(path),
-                         std::move(document)),
-        m_page{page} {}
-
-  void write_fragment(HtmlWriter &, WritingState &state) const override {
-    translate_page(m_page, state);
-  }
-
-private:
-  Page m_page;
-};
+using SlideHtmlFragment = ElementHtmlFragment<Slide, translate_slide>;
+using SheetHtmlFragment = ElementHtmlFragment<Sheet, translate_sheet>;
+using PageHtmlFragment = ElementHtmlFragment<Page, translate_page>;
 
 } // namespace
 } // namespace odr::internal::html

--- a/src/odr/internal/html/document_element.cpp
+++ b/src/odr/internal/html/document_element.cpp
@@ -23,40 +23,58 @@ void html::translate_children(const ElementRange &range,
 
 void html::translate_element(const Element &element,
                              const WritingState &state) {
-  if (element.type() == ElementType::text) {
+  switch (element.type()) {
+  case ElementType::text:
     translate_text(element, state);
-  } else if (element.type() == ElementType::line_break) {
+    break;
+  case ElementType::line_break:
     translate_line_break(element, state);
-  } else if (element.type() == ElementType::paragraph) {
+    break;
+  case ElementType::paragraph:
     translate_paragraph(element, state);
-  } else if (element.type() == ElementType::span) {
+    break;
+  case ElementType::span:
     translate_span(element, state);
-  } else if (element.type() == ElementType::link) {
+    break;
+  case ElementType::link:
     translate_link(element, state);
-  } else if (element.type() == ElementType::bookmark) {
+    break;
+  case ElementType::bookmark:
     translate_bookmark(element, state);
-  } else if (element.type() == ElementType::list) {
+    break;
+  case ElementType::list:
     translate_list(element, state);
-  } else if (element.type() == ElementType::list_item) {
+    break;
+  case ElementType::list_item:
     translate_list_item(element, state);
-  } else if (element.type() == ElementType::table) {
+    break;
+  case ElementType::table:
     translate_table(element, state);
-  } else if (element.type() == ElementType::frame) {
+    break;
+  case ElementType::frame:
     translate_frame(element, state);
-  } else if (element.type() == ElementType::image) {
+    break;
+  case ElementType::image:
     translate_image(element, state);
-  } else if (element.type() == ElementType::rect) {
+    break;
+  case ElementType::rect:
     translate_rect(element, state);
-  } else if (element.type() == ElementType::line) {
+    break;
+  case ElementType::line:
     translate_line(element, state);
-  } else if (element.type() == ElementType::circle) {
+    break;
+  case ElementType::circle:
     translate_circle(element, state);
-  } else if (element.type() == ElementType::custom_shape) {
+    break;
+  case ElementType::custom_shape:
     translate_custom_shape(element, state);
-  } else if (element.type() == ElementType::group) {
+    break;
+  case ElementType::group:
     translate_children(element.children(), state);
-  } else {
+    break;
+  default:
     // TODO log
+    break;
   }
 }
 
@@ -196,36 +214,34 @@ void html::translate_sheet(const Sheet &sheet, const WritingState &state) {
   state.out().write_element_end("table");
 }
 
-void html::translate_slide(const Slide &slide, const WritingState &state) {
+namespace {
+
+/// A slide or a drawing page: the master page's content under the page's own,
+/// inside one outer page box. There is no inner (margin) box — unlike a text
+/// document, both anchor their children absolutely at page coordinates.
+template <typename PageLike>
+void translate_page_like(const PageLike &page,
+                         const html::WritingState &state) {
   state.out().write_element_begin(
-      "div", HtmlElementOptions()
-                 .set_class("odr-page-outer")
-                 .set_style(translate_outer_page_style(slide.page_layout())));
-  //  state.out().write_element_begin(
-  //      "div", HtmlElementOptions().set_class("odr-page-inner").set_style(
-  //                 translate_inner_page_style(slide.page_layout())));
+      "div",
+      html::HtmlElementOptions()
+          .set_class("odr-page-outer")
+          .set_style(html::translate_outer_page_style(page.page_layout())));
 
-  translate_master_page(slide.master_page(), state);
-  translate_children(slide.children(), state);
+  html::translate_master_page(page.master_page(), state);
+  html::translate_children(page.children(), state);
 
-  //  state.out().write_element_end("div");
   state.out().write_element_end("div");
 }
 
+} // namespace
+
+void html::translate_slide(const Slide &slide, const WritingState &state) {
+  translate_page_like(slide, state);
+}
+
 void html::translate_page(const Page &page, const WritingState &state) {
-  state.out().write_element_begin(
-      "div", HtmlElementOptions()
-                 .set_class("odr-page-outer")
-                 .set_style(translate_outer_page_style(page.page_layout())));
-  //  state.out().write_element_begin(
-  //      "div", HtmlElementOptions().set_class("odr-page-inner").set_style(
-  //                 translate_inner_page_style(page.page_layout())));
-
-  translate_master_page(page.master_page(), state);
-  translate_children(page.children(), state);
-
-  //  state.out().write_element_end("div");
-  state.out().write_element_end("div");
+  translate_page_like(page, state);
 }
 
 void html::translate_master_page(const MasterPage &masterPage,
@@ -307,7 +323,7 @@ void html::translate_link(const Element &element, const WritingState &state) {
 
   state.out().write_element_begin(
       "a", HtmlElementOptions().set_inline(true).set_attributes(
-               HtmlAttributesVector{{"href", link.href()}}));
+               HtmlAttributesVector{{"href", escape_attribute(link.href())}}));
   translate_children(link.children(), state);
   state.out().write_element_end("a");
 }
@@ -317,8 +333,9 @@ void html::translate_bookmark(const Element &element,
   const Bookmark bookmark = element.as_bookmark();
 
   state.out().write_element_begin(
-      "a", HtmlElementOptions().set_inline(true).set_attributes(
-               HtmlAttributesVector{{"id", bookmark.name()}}));
+      "a",
+      HtmlElementOptions().set_inline(true).set_attributes(
+          HtmlAttributesVector{{"id", escape_attribute(bookmark.name())}}));
   state.out().write_element_end("a");
 }
 
@@ -425,7 +442,7 @@ void html::translate_image(const Element &element, const WritingState &state) {
           .set_attributes([&](const HtmlAttributeWriterCallback &clb) {
             clb("alt", "Error: image not found or unsupported");
             if (resource_location.has_value()) {
-              clb("src", resource_location.value());
+              clb("src", escape_attribute(resource_location.value()));
             } else {
               clb("src", [&](std::ostream &o) {
                 // reached only for internal images, which have a file

--- a/src/odr/internal/html/document_style.cpp
+++ b/src/odr/internal/html/document_style.cpp
@@ -142,7 +142,9 @@ std::string html::translate_text_style(const TextStyle &text_style) {
   std::string result;
   if (const std::optional<std::string_view> font_name = text_style.font_name;
       font_name.has_value()) {
-    result.append("font-family:").append(*font_name).append(";");
+    result.append("font-family:")
+        .append(escape_attribute(std::string(*font_name)))
+        .append(";");
   }
   if (const std::optional<Measure> font_size = text_style.font_size;
       font_size.has_value()) {
@@ -168,7 +170,9 @@ std::string html::translate_text_style(const TextStyle &text_style) {
   }
   if (const std::optional<std::string> font_shadow = text_style.font_shadow;
       font_shadow.has_value()) {
-    result.append("text-shadow:").append(*font_shadow).append(";");
+    result.append("text-shadow:")
+        .append(escape_attribute(*font_shadow))
+        .append(";");
   }
   if (const std::optional<Color> font_color = text_style.font_color;
       font_color.has_value()) {
@@ -329,21 +333,29 @@ html::translate_table_cell_style(const TableCellStyle &table_cell_style) {
   if (const std::optional<std::string> border_right =
           table_cell_style.border.right;
       border_right.has_value()) {
-    result.append("border-right:").append(*border_right).append(";");
+    result.append("border-right:")
+        .append(escape_attribute(*border_right))
+        .append(";");
   }
   if (const std::optional<std::string> border_top = table_cell_style.border.top;
       border_top.has_value()) {
-    result.append("border-top:").append(*border_top).append(";");
+    result.append("border-top:")
+        .append(escape_attribute(*border_top))
+        .append(";");
   }
   if (const std::optional<std::string> border_left =
           table_cell_style.border.left;
       border_left.has_value()) {
-    result.append("border-left:").append(*border_left).append(";");
+    result.append("border-left:")
+        .append(escape_attribute(*border_left))
+        .append(";");
   }
   if (const std::optional<std::string> border_bottom =
           table_cell_style.border.bottom;
       border_bottom.has_value()) {
-    result.append("border-bottom:").append(*border_bottom).append(";");
+    result.append("border-bottom:")
+        .append(escape_attribute(*border_bottom))
+        .append(";");
   }
   if (const std::optional<double> text_rotation =
           table_cell_style.text_rotation;

--- a/src/odr/internal/html/filesystem.cpp
+++ b/src/odr/internal/html/filesystem.cpp
@@ -28,11 +28,7 @@ public:
   [[nodiscard]] const HtmlViews &list_views() const override { return m_views; }
 
   [[nodiscard]] bool exists(const std::string &path) const override {
-    if (path == "files.html") {
-      return true;
-    }
-
-    return false;
+    return path == "files.html";
   }
 
   [[nodiscard]] std::string mimetype(const std::string &path) const override {
@@ -81,46 +77,38 @@ public:
 
     out.write_body_begin();
 
+    const auto span = [&out](const HtmlWritable &content) {
+      out.write_element_begin("span");
+      out.write_raw(content);
+      out.write_element_end("span");
+    };
+
     for (; !file_walker.end(); file_walker.next()) {
-      Path file_path(file_walker.path());
+      const Path file_path(file_walker.path());
       const bool is_file = file_walker.is_file();
 
       out.write_element_begin("p");
 
-      out.write_element_begin("span");
-      out.write_raw(file_path.string());
-      out.write_element_end("span");
-
-      out.write_element_begin("span");
-      out.write_raw(" ");
-      out.write_element_end("span");
-
-      out.write_element_begin("span");
-      out.write_raw(file_walker.is_file() ? "file" : "directory");
-      out.write_element_end("span");
+      span(escape_text(file_path.string()));
+      span(" ");
+      span(is_file ? "file" : "directory");
 
       if (is_file) {
-        out.write_element_begin("span");
-        out.write_raw(" ");
-        out.write_element_end("span");
+        span(" ");
 
         File file = m_filesystem.open(file_path.string());
 
-        out.write_element_begin("span");
-        out.write_raw(std::to_string(file.size()));
-        out.write_element_end("span");
+        span(std::to_string(file.size()));
 
         if (const std::unique_ptr<std::istream> stream = file.stream();
             stream != nullptr) {
-          out.write_element_begin("span");
-          out.write_raw(" ");
-          out.write_element_end("span");
+          span(" ");
 
           out.write_element_begin(
               "a",
               HtmlElementOptions().set_attributes(HtmlAttributesVector{
                   {"href", file_to_url(*stream, "application/octet-stream")},
-                  {"download", file_path.basename()}}));
+                  {"download", escape_attribute(file_path.basename())}}));
           out.write_raw("download");
           out.write_element_end("a");
         }

--- a/src/odr/internal/html/image_file.cpp
+++ b/src/odr/internal/html/image_file.cpp
@@ -65,11 +65,7 @@ public:
   [[nodiscard]] const HtmlViews &list_views() const override { return m_views; }
 
   [[nodiscard]] bool exists(const std::string &path) const override {
-    if (path == "image.html") {
-      return true;
-    }
-
-    return false;
+    return path == "image.html";
   }
 
   [[nodiscard]] std::string mimetype(const std::string &path) const override {

--- a/src/odr/internal/html/pdf_file.cpp
+++ b/src/odr/internal/html/pdf_file.cpp
@@ -43,17 +43,15 @@ namespace odr::internal::html {
 
 namespace {
 
-/// Round to 0.01 user-space units; sub-precision beyond that is invisible and
-/// the extra digits add up across a page full of path data.
+/// Round to 0.01 units; finer precision is invisible and the extra digits add
+/// up across a page full of path data.
 double round2(const double v) { return std::round(v * 100.0) / 100.0; }
 
 constexpr double pt_to_in = 1.0 / 72.0;
 
-/// Serialize a transform as an SVG `matrix(...)`. Only the translation (e, f)
-/// is rounded — it lives in page-box units where 1/100 px is plenty; the linear
-/// part (a..d) keeps full precision so small scale/skew factors aren't
-/// quantized to zero. Used for `transform`, `gradientTransform` and
-/// `patternTransform`.
+/// A transform as an SVG `matrix(...)`. Only the translation is rounded; the
+/// linear part keeps full precision so small scale/skew factors aren't
+/// quantized to zero.
 std::string svg_matrix(const util::math::Transform2D &m) {
   std::ostringstream f;
   f << "matrix(" << m.a << ',' << m.b << ',' << m.c << ',' << m.d << ','
@@ -73,14 +71,12 @@ struct LinkOut {
                         ///< `target="_self"`)
 };
 
-/// Maps a link's 0-based target page index to the href navigating to it: a
-/// "#pN" anchor in the combined document, a page-view file name in a
-/// standalone page. Returns "" to drop the link (target page not rendered).
+/// A link's 0-based target page index to the href navigating to it. Returns ""
+/// to drop the link (target page not rendered).
 using PageHref = std::function<std::string(std::size_t)>;
 
-/// Resolves a link annotation's destination to a page: a `page-object ->
-/// 0-based index` map plus the catalog's named-destination table (`/Dests`
-/// dictionary and the `/Names /Dests` name tree, ISO 32000-1 12.3.2.3).
+/// Resolves a link annotation's destination to a page index, via the catalog's
+/// named-destination tables (ISO 32000-1 12.3.2.3).
 struct LinkResolver {
   pdf::DocumentParser &parser;
   std::map<pdf::ObjectReference, std::size_t> page_index;
@@ -180,25 +176,22 @@ LinkResolver build_link_resolver(pdf::DocumentParser &parser,
   return resolver;
 }
 
-/// Whether a `/URI` action target is safe to emit as an `href`. A PDF is
-/// untrusted input, so active schemes (`javascript:`, `data:`, `vbscript:`, …)
-/// must not become a clickable link that executes in the generated document.
-/// We allow only the common navigable schemes plus scheme-less (relative)
-/// references. Embedded ASCII whitespace/control bytes are ignored when reading
-/// the scheme, matching browsers that strip them before dispatch (so
-/// `java\tscript:` cannot slip through).
+/// Whether a `/URI` action target is safe to emit as an `href`: only the
+/// navigable schemes plus scheme-less (relative) references, so `javascript:`
+/// and friends cannot become a clickable link. Embedded whitespace/control
+/// bytes are ignored while reading the scheme, as browsers strip them before
+/// dispatch (`java\tscript:` must not slip through).
 bool is_safe_uri(std::string_view uri) {
   std::string scheme;
   for (const char ch : uri) {
     const auto c = static_cast<unsigned char>(ch);
     if (ch == ':') {
-      for (char &s : scheme) {
-        s = static_cast<char>(std::tolower(static_cast<unsigned char>(s)));
-      }
-      static constexpr std::string_view allowed[] = {"http", "https", "mailto",
-                                                     "ftp",  "ftps",  "tel"};
-      return std::find(std::begin(allowed), std::end(allowed), scheme) !=
-             std::end(allowed);
+      std::ranges::transform(scheme, scheme.begin(), [](const char s) {
+        return static_cast<char>(std::tolower(static_cast<unsigned char>(s)));
+      });
+      static constexpr std::array<std::string_view, 6> allowed = {
+          "http", "https", "mailto", "ftp", "ftps", "tel"};
+      return std::ranges::find(allowed, scheme) != allowed.end();
     }
     if (ch == '/' || ch == '?' || ch == '#') {
       return true; // path/query/fragment reached first -> relative reference
@@ -215,10 +208,8 @@ bool is_safe_uri(std::string_view uri) {
   return true; // no ':' -> relative reference
 }
 
-/// Resolve a page's `/Link` annotations (ISO 32000-1 12.5.6.5) to positioned
-/// overlays: a `/URI` action becomes an external link, a `/GoTo` action or a
-/// direct `/Dest` an internal link via `page_href`. `to_box` maps PDF user
-/// space to the page box (points, y-down).
+/// A page's `/Link` annotations (ISO 32000-1 12.5.6.5) as positioned overlays.
+/// `to_box` maps PDF user space to the page box (points, y-down).
 std::vector<LinkOut> collect_page_links(const pdf::Page &page,
                                         const util::math::Transform2D &to_box,
                                         LinkResolver &resolver,
@@ -294,8 +285,7 @@ void write_page_links(HtmlWriter &out, const std::vector<LinkOut> &links) {
   for (const LinkOut &link : links) {
     std::ostringstream a;
     // Internal `#pN` links must override the document's `<base
-    // target="_blank">` so they scroll within the rendered PDF instead of
-    // opening a new copy.
+    // target="_blank">` or they open a new copy instead of scrolling.
     a << "<a class=\"lk\" href=\"" << link.href << '"'
       << (link.internal ? " target=\"_self\"" : "")
       << " style=\"left:" << round2(link.left) << "pt;top:" << round2(link.top)
@@ -311,10 +301,8 @@ std::int32_t to255(const double v) {
       std::lround(std::clamp(v, 0.0, 1.0) * 255.0));
 }
 
-/// Convert a PDF device color to a CSS `rgb(...)` string. Non-device color
-/// spaces (Separation/ICCBased/…) are already converted to RGB at extract time;
-/// only the unknown space reaches here, falling back to black (the PDF initial
-/// color).
+/// A PDF device color as CSS `rgb(...)`. Other spaces are already converted at
+/// extract time; only `unknown` reaches here, falling back to black.
 std::string device_color_to_css(const pdf::GraphicsState::Color &color) {
   std::int32_t r = 0;
   std::int32_t g = 0;
@@ -356,11 +344,10 @@ std::string rgb_to_css(const std::array<double, 3> &rgb) {
   return std::move(s).str();
 }
 
-/// Map a PDF blend-mode name (`/ExtGState` `/BM`, ISO 32000-1 11.3.5) to its
-/// CSS `mix-blend-mode` keyword. CSS derives its blend modes from PDF, so the
-/// separable and non-separable modes map 1:1 (camelCase -> kebab-case). Returns
-/// "" for `Normal` and for any unrecognized name (rendered normal), so a caller
-/// can skip the property entirely.
+/// A PDF blend-mode name (`/BM`, ISO 32000-1 11.3.5) as its CSS
+/// `mix-blend-mode` keyword — CSS took its blend modes from PDF, so they map
+/// 1:1. "" for `Normal` and for anything unrecognized, so callers can skip the
+/// property entirely.
 std::string blend_mode_to_css(const std::string &blend_mode) {
   static const std::unordered_map<std::string, std::string> map = {
       {"Multiply", "multiply"},     {"Screen", "screen"},
@@ -376,9 +363,8 @@ std::string blend_mode_to_css(const std::string &blend_mode) {
 }
 
 /// The CSS declaration a non-embedded font renders through: its substitute
-/// `font-family` stack plus the weight/style implied by the `/BaseFont` name
-/// and `/FontDescriptor` flags. Interned as an `ff` atomic class on the
-/// fallback (`font == 0`) runs of either text mode.
+/// family stack plus the weight/style implied by `/BaseFont` and the
+/// `/FontDescriptor` flags.
 std::string font_substitute_declaration(const pdf::FontSubstitute &substitute) {
   std::string declaration = "font-family:" + substitute.css_family;
   if (substitute.bold) {
@@ -390,10 +376,8 @@ std::string font_substitute_declaration(const pdf::FontSubstitute &substitute) {
   return declaration;
 }
 
-/// The `local(...)` sources of a CSS `font-family` stack, dropping the generic
-/// keywords an `@font-face src` cannot name. Returns e.g.
-/// "local('Times New Roman'),local(Times)" for "'Times New Roman',Times,serif",
-/// or "" when the stack names no concrete font (generic-only).
+/// The `local(...)` sources of a `font-family` stack, dropping the generic
+/// keywords an `@font-face src` cannot name. "" when the stack is generic-only.
 std::string local_font_sources(const std::string_view css_family) {
   static constexpr std::array<std::string_view, 6> generics = {
       "serif", "sans-serif", "monospace", "cursive", "fantasy", "system-ui"};
@@ -410,8 +394,7 @@ std::string local_font_sources(const std::string_view css_family) {
     while (!name.empty() && name.back() == ' ') {
       name.remove_suffix(1);
     }
-    const bool generic =
-        std::find(generics.begin(), generics.end(), name) != generics.end();
+    const bool generic = std::ranges::find(generics, name) != generics.end();
     if (!name.empty() && !generic) {
       if (!src.empty()) {
         src += ',';
@@ -428,13 +411,10 @@ std::string local_font_sources(const std::string_view css_family) {
   return src;
 }
 
-/// Registers one `@font-face` per (substitute family, style, ascent) that
-/// overrides the face's ascent/descent so a glyph's baseline lands exactly at
-/// the `top` `add_position_classes` derives from `ascent_em` — independent of
-/// the metrics of whichever local font actually resolves. Without the override
-/// the browser positions the baseline using the resolved font's own ascent,
-/// which for a large non-embedded run (e.g. a 120pt Times title) drops it well
-/// below the intended baseline.
+/// One `@font-face` per (substitute family, style, ascent) overriding the
+/// face's ascent/descent, so a glyph's baseline lands at the `top`
+/// `add_position_classes` derived from `ascent_em` rather than wherever
+/// whichever local font resolves would put it.
 class SubstituteFontFaces {
 public:
   /// The `font-family:...` (plus weight/style) declaration for `substitute`,
@@ -446,10 +426,9 @@ public:
     if (src.empty()) {
       return font_substitute_declaration(substitute);
     }
-    // ascent-override + descent-override sum to one em, so `line-height:1`
-    // leaves no leading and the baseline sits at exactly `ascent_em` of the em
-    // box. `ascent_em` is clamped to [0.5, 1.2]; the `max` keeps descent
-    // non-negative for the rare ascent > 1 (a slight baseline approximation).
+    // The two overrides sum to one em, so `line-height:1` leaves no leading and
+    // the baseline sits at exactly `ascent_em`. `max` keeps descent
+    // non-negative for the rare clamped ascent > 1.
     const double ascent = ascent_em;
     const double descent = std::max(0.0, 1.0 - ascent_em);
     std::ostringstream key;
@@ -489,9 +468,8 @@ private:
   std::vector<std::string> m_faces;
 };
 
-/// Build an SVG `d` attribute from a path's subpaths, each point mapped through
-/// `to_box` (PDF user space -> the page box, y-down). Lines become `L`, cubic
-/// Béziers `C`, and an explicitly closed subpath ends with `Z`.
+/// An SVG `d` attribute for a path's subpaths, each point mapped through
+/// `to_box` (PDF user space -> the page box, y-down).
 std::string svg_path_d(const std::vector<pdf::Subpath> &subpaths,
                        const util::math::Transform2D &to_box) {
   std::ostringstream d;
@@ -522,13 +500,9 @@ std::string svg_path_d(const std::vector<pdf::Subpath> &subpaths,
   return std::move(d).str();
 }
 
-/// Serialize a painted path to an SVG `<path .../>` fragment in the page
-/// viewBox, or "" when it paints nothing. Fill honours the even-odd rule;
-/// stroke carries width (CTM-scaled in user space), caps, joins, miter limit
-/// and the dash pattern. A zero stroke width renders as a thin hairline.
-/// `clip_id`, when non-empty, references a `<clipPath>` installed via
-/// `clip-path`. `fill_url_id`, when non-empty, fills the path with that paint
-/// server (a shading gradient or a tiling `<pattern>`) instead of `fill_color`.
+/// A painted path as an SVG `<path .../>` fragment in the page viewBox, or ""
+/// when it paints nothing. `clip_id` and `fill_url_id`, when non-empty, name a
+/// `<clipPath>` and a paint server (gradient or tiling pattern) to reference.
 std::string svg_path_fragment(const pdf::PathElement &path,
                               const util::math::Transform2D &to_box,
                               const std::string &clip_id,
@@ -563,8 +537,7 @@ std::string svg_path_fragment(const pdf::PathElement &path,
     if (path.stroke_alpha < 1) {
       f << " stroke-opacity=\"" << round2(path.stroke_alpha) << '"';
     }
-    // A 0 width is "device-thinnest" in PDF; SVG would draw nothing, so floor
-    // it to a sub-point hairline.
+    // A 0 width is "device-thinnest" in PDF; SVG would draw nothing.
     const double width = path.line_width > 0 ? path.line_width : 0.5;
     f << " stroke-width=\"" << round2(width) << '"';
     if (path.line_cap == 1) {
@@ -603,16 +576,12 @@ std::string svg_path_fragment(const pdf::PathElement &path,
   return std::move(f).str();
 }
 
-/// Serialize an image XObject to an SVG `<image>` fragment in the page viewBox,
-/// or "" when it carries no pass-through bytes. The image fills the unit square
-/// in user space (ISO 32000-1 8.10.5); the transform maps that square — through
-/// a vertical flip (the image's first row is its top, SVG draws y-down) and the
-/// CTM — into the page box. `clip_id`, when non-empty, installs a clip via a
-/// wrapping `<g clip-path>`. The clip geometry is in the page viewBox
-/// (`userSpaceOnUse`), but the `<image>` carries its own `transform`, so a
-/// `clip-path` placed *on the image* would be resolved in the image's
-/// post-transform unit-square space and clip the whole image away. The `<g>`
-/// carries no transform, so the clip is read in the viewBox where it lives.
+/// An image XObject as an SVG `<image>` fragment in the page viewBox, or ""
+/// when it carries no pass-through bytes. The image fills the unit square in
+/// user space (ISO 32000-1 8.10.5), flipped vertically because its first row is
+/// its top. `clip_id` is installed on a wrapping `<g>`, not on the `<image>`:
+/// the clip geometry is `userSpaceOnUse` in the viewBox, and on the image it
+/// would resolve in the image's post-transform unit-square space instead.
 std::string svg_image_fragment(const pdf::ImageElement &image,
                                const util::math::Transform2D &to_box,
                                const std::string &clip_id) {
@@ -643,11 +612,9 @@ std::string svg_image_fragment(const pdf::ImageElement &image,
   return std::move(f).str();
 }
 
-/// Shared bookkeeping for the per-page `<defs>` registries below (clips,
-/// gradients, tiling patterns): a signature->id cache that deduplicates
-/// repeated definitions, a per-page monotonic id counter, and the accumulated
-/// `<defs>` markup (emitted once into the page's hidden `<svg>`). Ids are
-/// namespaced per page as `<prefix><page>_<n>`.
+/// Shared bookkeeping for the per-page `<defs>` registries below: a
+/// signature->id cache deduplicating repeated definitions plus the accumulated
+/// `<defs>` markup. Ids are namespaced per page as `<prefix><page>_<n>`.
 class DefsRegistry {
 public:
   explicit DefsRegistry(const std::uint32_t page) : m_page{page} {}
@@ -655,9 +622,8 @@ public:
   [[nodiscard]] std::string defs() const { return m_defs.str(); }
 
 protected:
-  /// The id for `signature`, minting `<prefix><page>_<n>` the first time it is
-  /// seen. `inserted` is true only on that first sight — when the caller still
-  /// needs to emit the definition into `m_defs`.
+  /// The id for `signature`. `inserted` is true only on first sight, when the
+  /// caller still has to emit the definition into `m_defs`.
   struct Entry {
     std::string id;
     bool inserted;
@@ -679,12 +645,10 @@ private:
   std::unordered_map<std::string, std::string> m_id_by_signature;
 };
 
-/// Registers a page's clip regions as nested `<clipPath>` defs, deduplicating
-/// shared prefixes. PDF's current clip is the *intersection* of an ordered list
-/// of regions; SVG expresses intersection by chaining `clip-path` from one
-/// `<clipPath>` to the next, so region i's clipPath references region i-1's and
-/// the painted element references the last. Ids are namespaced per page
-/// (`c<page>_<n>`).
+/// A page's clip regions as nested `<clipPath>` defs (`c<page>_<n>`). PDF's
+/// current clip is the *intersection* of an ordered region list; SVG expresses
+/// intersection by chaining `clip-path`, so region i references region i-1 and
+/// the painted element references the last.
 class ClipRegistry : public DefsRegistry {
 public:
   using DefsRegistry::DefsRegistry;
@@ -718,18 +682,13 @@ public:
   }
 };
 
-/// Registers a page's shadings (axial/radial) as `<linearGradient>`/
-/// `<radialGradient>` defs, deduplicating by shading and placement. The
-/// shading's pre-sampled colour stops become `<stop>`s; `gradientTransform`
-/// (shading space -> page box) places the gradient in the page's user space, so
-/// referencing elements use `gradientUnits="userSpaceOnUse"`. Ids are
-/// namespaced per page (`g<page>_<n>`).
+/// A page's axial/radial shadings as `<linearGradient>`/`<radialGradient>` defs
+/// (`g<page>_<n>`), placed by `gradientTransform` in `userSpaceOnUse`.
 ///
-/// DEFERRED (out of scope for this stage): PDF `/Extend` is approximated by
-/// SVG's default `pad` spread (the end stops extend outward), so a non-extended
-/// shading is over-painted beyond its interval instead of being masked to it;
-/// `Shading::background` and `Shading::bbox` are likewise not yet honoured.
-/// Honouring them needs the fill clipped to the gradient band/annulus.
+/// DEFERRED: `/Extend` is approximated by SVG's default `pad` spread, so a
+/// non-extended shading over-paints beyond its interval; `Shading::background`
+/// and `Shading::bbox` are not honoured. Both need the fill clipped to the
+/// gradient band/annulus.
 class GradientRegistry : public DefsRegistry {
 public:
   using DefsRegistry::DefsRegistry;
@@ -773,10 +732,9 @@ public:
   }
 };
 
-/// Serialize an `sh` shading flood to an SVG `<rect>` covering the page box,
-/// filled with `gradient_id` and bounded by `clip_id` (the clip in force at
-/// `sh` time). Returns "" when the shading produced no gradient. The rect spans
-/// the whole page; the clip (and the gradient's own extent) bound the paint.
+/// An `sh` shading flood as an SVG `<rect>` spanning the page box, filled with
+/// `gradient_id`; `clip_id` (and the gradient's own extent) bound the paint.
+/// "" when the shading produced no gradient.
 std::string svg_shading_fragment(const std::string &gradient_id,
                                  const std::string &clip_id, const double width,
                                  const double height, const double alpha,
@@ -800,17 +758,13 @@ std::string svg_shading_fragment(const std::string &gradient_id,
   return std::move(f).str();
 }
 
-/// Registers a page's tiling patterns (`/PatternType 1`) as SVG `<pattern>`
-/// defs. The pattern's content stream is run as a mini page (`extract_page`)
-/// into tile fragments laid out in pattern space; the `<pattern>` repeats them
-/// every `/XStep`/`/YStep`, and `patternTransform` (pattern space -> page box)
-/// places the lattice. An uncoloured pattern (`/PaintType 2`) ignores its
-/// content's own colours and paints in the path's fill colour, so the cache key
-/// folds that colour in. Each cell is clipped to its `/BBox` so marks outside
-/// the cell (or in the gap when a step exceeds the BBox) don't leak into the
-/// tile. Ids are namespaced per page (`pat<page>_<n>`). Only paths and images
-/// inside the tile are rendered (nested text/shadings/patterns are skipped —
-/// rare). Returns "" for an unrepresentable pattern.
+/// A page's tiling patterns (`/PatternType 1`) as SVG `<pattern>` defs
+/// (`pat<page>_<n>`). The content stream is run as a mini page into tile
+/// fragments in pattern space, repeated every `/XStep`/`/YStep` and placed by
+/// `patternTransform`. An uncoloured pattern (`/PaintType 2`) paints in the
+/// path's fill colour, so the cache key folds that colour in. Only paths and
+/// images are rendered (nested text/shadings/patterns are skipped — rare).
+/// "" for an unrepresentable pattern.
 class PatternRegistry : public DefsRegistry {
 public:
   using DefsRegistry::DefsRegistry;
@@ -859,8 +813,7 @@ public:
            << "\" height=\"" << round2(std::abs(pattern.y_step))
            << "\" patternTransform=\"" << svg_matrix(m) << "\">";
     // Clip each cell to its `/BBox` (ISO 32000-1 8.7.3.1). An overlapping
-    // lattice (a step smaller than the BBox) can't be expressed as a single SVG
-    // `<pattern>` and is not reproduced.
+    // lattice (step < BBox) has no single-`<pattern>` equivalent and is lost.
     const double bbox_w = pattern.bbox[2] - pattern.bbox[0];
     const double bbox_h = pattern.bbox[3] - pattern.bbox[1];
     if (bbox_w > 0 && bbox_h > 0) {
@@ -879,13 +832,11 @@ public:
 
 class MaskRegistry;
 
-/// Serialize one graphic page element (a painted path, a shading flood, an
-/// image, or a nested transparency group) to an SVG fragment in the page
-/// viewBox, registering any clip, gradient, pattern or soft mask it needs.
-/// Returns "" for a text element or one that paints nothing. A soft mask on the
-/// element wraps its fragment in a masked `<g>`; a `GroupElement` renders its
-/// children then wraps them in one `<g>` carrying the group's opacity, blend
-/// and mask (so the group composites as a unit before those apply).
+/// One graphic page element as an SVG fragment in the page viewBox,
+/// registering any clip, gradient, pattern or soft mask it needs. "" for a text
+/// element or one that paints nothing. A `GroupElement`'s children are wrapped
+/// in a single `<g>` so the group composites as a unit before its
+/// opacity/blend/mask apply.
 std::string render_graphic_fragment(const pdf::PageElement &element,
                                     const util::math::Transform2D &to_box,
                                     double width, double height,
@@ -894,14 +845,10 @@ std::string render_graphic_fragment(const pdf::PageElement &element,
                                     PatternRegistry &patterns,
                                     MaskRegistry &masks, const Logger &logger);
 
-/// Registers a page's soft masks (`/SMask`, ISO 32000-1 11.6.5.2) as `<mask>`
-/// defs. The extractor has rendered each mask's transparency group into a list
-/// of graphic elements (in user space); those are serialized into the mask body
-/// with the page's own clip/gradient/pattern registries, so their ids stay
-/// unique within the page. Coverage comes from luminance by default
-/// (`/Luminosity` -> the SVG mask default) or from alpha (`/Alpha` ->
-/// `mask-type="alpha"`); a non-black `/BC` backdrop floods behind the group.
-/// Ids are namespaced per page (`m<page>_<n>`).
+/// A page's soft masks (`/SMask`, ISO 32000-1 11.6.5.2) as `<mask>` defs
+/// (`m<page>_<n>`). The extractor has already rendered each mask's transparency
+/// group to graphic elements; those are serialized through the page's own
+/// clip/gradient/pattern registries so their ids stay unique within the page.
 class MaskRegistry : public DefsRegistry {
 public:
   using DefsRegistry::DefsRegistry;
@@ -911,9 +858,8 @@ public:
                             const double width, const double height,
                             ClipRegistry &clips, GradientRegistry &gradients,
                             PatternRegistry &patterns, const Logger &logger) {
-    // A fresh `SoftMask` is built for every `gs`, but many are identical (the
-    // same drop-shadow reused across a run of glyphs, say). Dedupe on the
-    // rendered body + type + backdrop so those collapse to a single def.
+    // A fresh `SoftMask` is built for every `gs`, but many are identical (one
+    // drop-shadow across a run of glyphs); dedupe on the rendered body.
     std::ostringstream body;
     for (const pdf::PageElement &element : mask.group) {
       body << render_graphic_fragment(element, to_box, width, height, clips,
@@ -936,9 +882,7 @@ public:
       m_defs << " mask-type=\"alpha\"";
     }
     m_defs << '>';
-    // A non-black `/BC` backdrop floods the mask region behind the group; the
-    // default (black) needs none — SVG's mask background is already luminance
-    // 0.
+    // Black — SVG's mask background already — needs no backdrop rect.
     if (mask.backdrop.has_value() &&
         ((*mask.backdrop)[0] + (*mask.backdrop)[1] + (*mask.backdrop)[2] > 0)) {
       m_defs << "<rect x=\"0\" y=\"0\" width=\"" << round2(width)
@@ -1048,18 +992,12 @@ std::string render_graphic_fragment(const pdf::PageElement &element,
   return {};
 }
 
-/// Lifts text out of transparency groups so this HTML backend can still render
-/// and select it. A `GroupElement`'s opacity/blend/mask is carried by an SVG
-/// `<g>`, but text is painted as positioned markup, not SVG, so it cannot ride
-/// inside that `<g>`. The extractor faithfully nests such text in the group; to
-/// avoid dropping it from both the visual and selection layers, each interior
-/// `TextElement` is hoisted to the top level — where the ordinary text pipeline
-/// renders it and `extract_text`-style top-level scans pick it up. The only
-/// thing forgone is the group effect on the text itself (see pdf/AGENTS.md
-/// gaps); the group's graphics are untouched and still composited as a unit.
-/// Nesting is flattened recursively; hoisted text is emitted at the group's
-/// position (ahead of the composited graphics), and a group left with no
-/// graphics is dropped.
+/// Hoists text out of transparency groups (recursively) to the top level. A
+/// group's effects ride an SVG `<g>`, but text is positioned markup, not SVG,
+/// so it cannot sit inside that `<g>` — without the hoist it would be dropped
+/// from both the visual and the selection layer. Forgone: the group effect on
+/// the text itself (see pdf/AGENTS.md gaps). The group's graphics are untouched
+/// and still composite as a unit; a group left with none is dropped.
 std::vector<pdf::PageElement>
 lift_group_text(std::vector<pdf::PageElement> elements) {
   std::vector<pdf::PageElement> result;
@@ -1097,14 +1035,11 @@ lift_group_text(std::vector<pdf::PageElement> elements) {
   return result;
 }
 
-/// Deduplicates CSS declarations into atomic, single-property classes. PDF text
-/// emits one absolutely-positioned line block per detected line, and the same
-/// font sizes, offsets and spacings recur across the (potentially millions of)
-/// elements. Writing each declaration inline bloats the document. Instead,
-/// every distinct declaration is registered once here, named `<prefix><n>` in
-/// first-seen order (e.g. `f1`, `f2` for font sizes, `t1` for a top offset),
-/// emitted once in <head>, and referenced by class on each element. This is
-/// representation-only: the computed style of every element is unchanged.
+/// Deduplicates CSS declarations into atomic, single-property classes named
+/// `<prefix><n>` in first-seen order, emitted once in `<head>`. The same font
+/// sizes, offsets and spacings recur across up to millions of positioned
+/// elements, and inline declarations bloat the document. Representation-only:
+/// no element's computed style changes.
 class AtomicStyles {
 public:
   /// `prefix` selects the property family; `declaration` is a full CSS
@@ -1121,9 +1056,8 @@ public:
     return it->second;
   }
 
-  /// Writes one rule per line (`.f1{font-size:9.96pt}`) so regeneration diffs
-  /// stay legible. Each rule is preceded by a newline; the caller has already
-  /// written the constant rules on the opening `<style>` line.
+  /// One rule per line (`.f1{font-size:9.96pt}`) so regeneration diffs stay
+  /// legible; each is preceded by a newline.
   void write_rules(std::ostream &o) const {
     for (const auto *entry : m_order) {
       o << "\n." << entry->second << '{' << entry->first << '}';
@@ -1144,11 +1078,10 @@ public:
       : HtmlService(std::move(config), logger),
         m_pdf_file{std::move(pdf_file)} {}
 
-  /// Parses the document once, applies the `[page_range_begin,
-  /// page_range_end)` page range and builds the view list: the combined
-  /// document plus one standalone view per rendered page. The parser and its
-  /// object cache are kept for the service's lifetime so the page views
-  /// render off one shared parse.
+  /// Parses once, applies the `[page_range_begin, page_range_end)` range and
+  /// builds the views: the combined document plus one per rendered page. The
+  /// parser and its object cache live for the service's lifetime so every view
+  /// renders off that one parse.
   void warmup() const override {
     std::lock_guard lock(m_mutex);
 
@@ -1241,10 +1174,9 @@ public:
     return write_pages(out, m_pages, m_first_page + 1, page_href);
   }
 
-  /// One standalone page (the `page{index}.html` view); internal links
-  /// navigate between the page files, rebased onto this page's own directory
-  /// (the browser resolves an href against the current document, so a nested
-  /// `page_output_file_name` must not be emitted output-root-relative).
+  /// One standalone page (the `page{index}.html` view). Internal links are
+  /// rebased onto this page's own directory: the browser resolves an href
+  /// against the current document, not the output root.
   HtmlResources write_page(const std::size_t page_index,
                            HtmlWriter &out) const {
     const RelPath from_dir = RelPath(m_views[page_index + 1].path()).parent();
@@ -1270,38 +1202,26 @@ public:
     return write_pages_dual_layer(out, pages, first_page_number, page_href);
   }
 
-  // =========================================================================
-  // DUAL-LAYER MODE
-  // =========================================================================
+  // ---- DUAL-LAYER MODE ----------------------------------------------------
   //
-  // Two separate layers per page:
+  // Visual layer (`.vis`, aria-hidden): paint-order glyphs in PUA-re-encoded
+  // fonts, grouped into baseline line blocks (`.t`) whose runs flow inline. A
+  // path or image closes the open block and goes into an SVG. Invisible text
+  // (Tr 3/7) is omitted.
   //
-  //  Visual layer (`<div class="vis" aria-hidden="true">`): paint-order glyph
-  //  rendering. Text runs are grouped into line blocks (`<div class="t ...">`)
-  //  by baseline; runs within a block flow inline, each nudged by a
-  //  `margin-left`. A path or image in paint order closes the open block and
-  //  is emitted into an SVG; the next text opens a fresh block. Fonts are
-  //  re-encoded to the PUA (no real-Unicode cmap entries needed — the visual
-  //  layer is `user-select:none`). Invisible text (Tr 3/7) is omitted here.
-  //
-  //  Selection layer (`<div class="sel">`): transparent, selectable real
-  //  Unicode. Text runs are grouped into per-line divs (`<div class="t ...
-  //  i">`) in content-stream order; space detection inserts separator spans
-  //  on line/column breaks or wide gaps. Each run span is
-  //  `display:inline-block; width:Xpt` with CSS `text-align:justify;
-  //  text-align-last:justify; text-justify:inter-character` so the browser
-  //  spreads the characters to fill the PDF advance without JavaScript.
-  //  For gap spans between runs a zero-content `display:inline-block;
-  //  width:Ypt` span is emitted.
+  // Selection layer (`.sel`): transparent real Unicode in content-stream
+  // order, one line block per detected line. Each run is an inline-block of
+  // the PDF advance width, spread to fill it by CSS
+  // `text-justify:inter-character` — no JavaScript; gaps are zero-content
+  // spacer spans.
 
-  /// One run inside a visual line block. `classes` carries margin-left, font
-  /// size, font-family+colour — the line block holds placement only.
+  /// One run inside a visual line block: margin-left, font size,
+  /// font-family+colour. The line block holds placement only.
   struct VisRunOut {
     std::string classes;
     std::string text; ///< PUA glyph string (or real unicode for fallback path)
   };
-  /// One line block in the visual layer: absolutely positioned at the first
-  /// run's origin. Runs flow inline, each nudged by margin-left.
+  /// One visual line block, absolutely positioned at its first run's origin.
   struct VisLineOut {
     std::string classes; ///< "t lN tN [mN]" (or matrix transform)
     std::vector<VisRunOut> runs;
@@ -1309,19 +1229,16 @@ public:
   struct PathOut {
     std::string svg;
   };
-  /// Visual-layer paint-order item: a line block of glyphs, or an SVG
-  /// fragment.
+  /// Visual-layer paint-order item: a glyph line block, or an SVG fragment.
   using VisItem = std::variant<VisLineOut, PathOut>;
 
-  /// One run in the selection layer: an inline-block span with a fixed width
-  /// (for CSS justify) and optional margin-left (gap from previous run). An
-  /// empty `text` with non-zero `width` is a spacer-only span (no text node).
+  /// One selection-layer run: an inline-block span of fixed width (for CSS
+  /// justify). Empty `text` means a spacer-only span.
   struct SelRunOut {
     std::string classes; ///< "sr wN [mlN]"
     std::string text; ///< real unicode (HTML-escaped), may be empty for spacer
   };
-  /// One line block in the selection layer: absolutely positioned,
-  /// transparent.
+  /// One selection-layer line block: absolutely positioned, transparent.
   struct SelLineOut {
     std::string classes; ///< "t lN tN i"
     std::vector<SelRunOut> runs;
@@ -1374,9 +1291,8 @@ public:
       classes += styles.intern(prefix, std::move(declaration));
     };
 
-    // Strips a trailing `wN` (width) class token, if present, so a merged
-    // selection run's width can be re-declared. Assumes at most one `w`
-    // class is ever attached to a selection run.
+    // Strips a trailing `wN` (width) token so a merged selection run's width
+    // can be re-declared. At most one is ever attached.
     const auto strip_width_class = [](std::string &classes) {
       const std::size_t pos = classes.rfind(' ');
       if (pos == std::string::npos) {
@@ -1385,8 +1301,9 @@ public:
       const std::string_view tail(classes.data() + pos + 1,
                                   classes.size() - pos - 1);
       if (tail.size() > 1 && tail.front() == 'w' &&
-          std::all_of(tail.begin() + 1, tail.end(),
-                      [](unsigned char c) { return std::isdigit(c) != 0; })) {
+          std::ranges::all_of(tail.substr(1), [](const char c) {
+            return std::isdigit(static_cast<unsigned char>(c)) != 0;
+          })) {
         classes.resize(pos);
       }
     };
@@ -1415,8 +1332,7 @@ public:
       PatternRegistry patterns(static_cast<std::uint32_t>(pages_out.size()));
       MaskRegistry masks(static_cast<std::uint32_t>(pages_out.size()));
 
-      // Visual layer state: open line block.
-      /// index of open VisLineOut in vis_items, -1 = none
+      /// index of the open VisLineOut in vis_items, -1 = none
       std::int32_t vis_cur_line = -1;
       double vis_prev_end = 0;
       double vis_prev_baseline = 0;
@@ -1424,21 +1340,18 @@ public:
       bool vis_prev_was_matrix = false;
       const auto vis_close_line = [&] { vis_cur_line = -1; };
 
-      // Selection layer state: in-content-stream reading-order grouping.
+      // Selection layer state: content-stream (reading) order grouping.
       bool sel_have_prev = false;
       double sel_prev_baseline = 0;
       double sel_prev_end = 0;
-      /// previous run's advance height, for the line-break test (see
-      /// starts_new_line)
+      /// previous run's advance height, for `starts_new_line`
       double sel_prev_font_pt = 0;
       bool sel_prev_ends_space = false;
       bool sel_prev_was_matrix = false;
       std::int32_t sel_cur_line = -1;
-      /// `ox` of the open `.sr` run's start, for recomputing its width on
-      /// merge.
+      /// `ox` where the open `.sr` run starts, to recompute its width on merge
       double sel_cur_run_start_ox = 0;
-      /// font-size of the previous element, for the trailing space that closes
-      /// its line.
+      /// font-size of the previous element, for its line's trailing space
       double sel_prev_font_size_pt = 0;
 
       for (const pdf::PageElement &element : lift_group_text(
@@ -1465,11 +1378,9 @@ public:
         const std::string color_suffix = color_class(text, invisible, styles);
 
         // --- Visual layer ---------------------------------------------------
-        // Invisible runs (Tr 3/7) paint nothing; omit them from the visual
-        // layer. Type3 runs are painted by their char procs (separate path/
-        // image elements), so they too contribute only to the selection layer.
+        // Invisible runs paint nothing and Type3 runs are painted by their char
+        // procs, so both contribute to the selection layer only.
         if (!invisible && !text.render_as_graphics) {
-          // Determine if this run continues the current visual line block.
           bool new_vis_line =
               is_matrix || vis_prev_was_matrix || vis_cur_line < 0;
           double vis_margin_pt = 0;
@@ -1483,7 +1394,6 @@ public:
           }
 
           if (new_vis_line) {
-            // Build the line block's placement classes.
             std::string line_base = "t";
             add_position_classes(line_base, add_class, m, is_matrix, ox,
                                  baseline, asc * text.size);
@@ -1493,19 +1403,14 @@ public:
             vis_cur_line = static_cast<int>(page_out.vis_items.size()) - 1;
           }
 
-          // Build the run's span classes: font-size, font-family+colour,
-          // margin-left (gap from previous run's right edge, or the line
-          // block's new-run offset from its own origin for new-line runs).
           std::string run_classes = "g"; // user-select:none
           add_class(run_classes, "f", pt_decl("font-size", font_size_pt));
           if (font != 0) {
             run_classes += ' ';
             run_classes += font_class(font_class_used, font, invisible);
           } else if (text.font != nullptr && text.font->substitute) {
-            // Non-embedded font: render the real Unicode in the substitute
-            // family (embedded fonts carry the family in `font_class`). The
-            // metric-overriding face pins the baseline to `asc` (see
-            // `SubstituteFontFaces`).
+            // Non-embedded: real Unicode in the substitute family, whose
+            // metric-overriding face pins the baseline to `asc`.
             add_class(
                 run_classes, "ff",
                 substitute_faces.declaration(*text.font->substitute, asc));
@@ -1515,8 +1420,6 @@ public:
           }
           run_classes += color_suffix;
 
-          // Run text: PUA glyphs for embedded font, or real unicode for
-          // fallback.
           std::string run_text;
           if (font != 0) {
             run_text = escape_text(glyph_run_str(*text.font, text.codes));
@@ -1528,11 +1431,9 @@ public:
               cs_pt != 0) {
             add_class(run_classes, "s", pt_decl("letter-spacing", cs_pt));
           }
-          // CSS `word-spacing` only affects real U+0020 separators, so it is
-          // inert on the PUA glyph runs (font != 0, which never emit a literal
-          // space) — apply it solely on the real-unicode fallback path. Skip
-          // composite fonts: PDF Tw applies only to single-byte code 32, as in
-          // the single-layer path.
+          // CSS `word-spacing` only affects real U+0020, so it is inert on PUA
+          // glyph runs — fallback path only. Composite fonts are skipped: PDF
+          // Tw applies to single-byte code 32 alone.
           if (font == 0 && !(text.font != nullptr && text.font->composite)) {
             if (const double ws_pt = round2(text.word_spacing * scale);
                 ws_pt != 0) {
@@ -1551,19 +1452,13 @@ public:
         }
 
         // --- Selection layer -----------------------------------------------
-        // Transparent, selectable real-unicode text in content-stream
-        // (reading) order. Each run is an inline-block span with a fixed width
-        // (the PDF advance) and CSS `text-justify:inter-character` so the
-        // browser distributes characters to fill that width without JS. Gaps
-        // between runs on the same baseline are zero-content spacer spans.
         // Matrix runs get their own single-run line block.
         if (!text.text.empty()) {
           const double width_pt = round2(extent);
           const double gap_pt = std::max(0.0, ox - sel_prev_end);
           const bool starts_space = text.text.front() == ' ';
-          // `core` is the run text with a leading inferred space stripped
-          // (the gap between runs is covered by the spacer span, not the
-          // run text).
+          // A leading inferred space is dropped: the gap between runs is
+          // covered by the spacer span, not by the run text.
           std::string core = starts_space ? text.text.substr(1) : text.text;
 
           bool new_sel_line =
@@ -1576,9 +1471,8 @@ public:
           }
 
           if (new_sel_line) {
-            // Close previous line with a trailing space if needed. `sg`
-            // (spacer), not `sr` (text run) — it carries no PDF-derived
-            // width, just a lone space.
+            // Close the previous line with a trailing space. `sg`, not `sr`:
+            // it carries no PDF-derived width, just the space.
             if (sel_cur_line >= 0 && sel_have_prev && !sel_prev_ends_space) {
               std::string space_cls = "sg";
               add_class(space_cls, "f",
@@ -1586,14 +1480,12 @@ public:
               page_out.sel_lines[sel_cur_line].runs.push_back(
                   SelRunOut{std::move(space_cls), " "});
             }
-            // Build the line block's placement.
             std::string sel_base = "t";
             add_position_classes(sel_base, add_class, m, is_matrix, ox,
                                  baseline, asc * text.size);
             sel_base += " i"; // transparent
             page_out.sel_lines.push_back(SelLineOut{std::move(sel_base), {}});
             sel_cur_line = static_cast<int>(page_out.sel_lines.size()) - 1;
-            // Emit the run span.
             if (!core.empty()) {
               std::string cls = "sr";
               add_class(cls, "f", pt_decl("font-size", font_size_pt));
@@ -1605,11 +1497,9 @@ public:
               sel_cur_run_start_ox = ox;
             }
           } else if (sel_gap || sel_prev_ends_space || starts_space) {
-            // Emit a spacer span for the gap, then the run span.
             std::vector<SelRunOut> &runs =
                 page_out.sel_lines[sel_cur_line].runs;
             if (!sel_prev_ends_space && !runs.empty()) {
-              // Spacer: display:inline-block with the gap width.
               std::string gap_cls = "sg";
               add_class(gap_cls, "f", pt_decl("font-size", font_size_pt));
               const double rounded_gap = round2(gap_pt);
@@ -1629,13 +1519,10 @@ public:
               sel_cur_run_start_ox = ox;
             }
           } else {
-            // Tight continuation on the same baseline — merge into the
-            // previous selection run's text so the browser treats the whole
-            // sequence as one word for double-click and find-in-page. Widen
-            // the run's declared width to the full merged extent (measured
-            // from where that run started) so CSS justify keeps spreading
-            // characters across the true PDF advance instead of the first
-            // sub-run's narrower one.
+            // Tight continuation on the same baseline: merge into the previous
+            // run so the browser reads the sequence as one word, and widen that
+            // run to the full merged extent so CSS justify still spreads across
+            // the true PDF advance.
             std::vector<SelRunOut> &runs =
                 page_out.sel_lines[sel_cur_line].runs;
             if (!runs.empty()) {
@@ -1662,11 +1549,9 @@ public:
         }
       }
 
-      // Selection lines are kept in content-stream order. Re-sorting by
-      // baseline y would order out-of-order single-column content correctly but
-      // interleave multi-column layouts (the stream keeps columns contiguous);
-      // reading order can't be recovered by a scalar sort. Proper page
-      // segmentation (column detection / XY-cut) is the eventual fix.
+      // Selection lines stay in content-stream order: sorting by baseline y
+      // would interleave multi-column layouts, which the stream keeps
+      // contiguous. The fix is page segmentation (XY-cut), not a scalar sort.
       page_out.clip_defs =
           clips.defs() + gradients.defs() + patterns.defs() + masks.defs();
     }
@@ -1678,24 +1563,15 @@ public:
     }
     substitute_faces.append_faces(font_faces);
 
-    // Write HTML.
     write_header_common(out, font_faces, font_styles, styles, [&] {
       // Visual layer glyph spans: not selectable (selection rides the `.sel`
       // layer).
       out.out() << ".g{user-select:none}";
-      // Fallback font for the selection layer: `size-adjust` shrinks a local
-      // system font so its natural width lands near the PDF-derived `.sr`/`.sg`
-      // widths, leaving a small gap for `text-justify:inter-character` to fill.
-      // CSS justify only ever *adds* spacing, so undershooting is free (the
-      // text just spreads further; the layer is invisible) while overshooting
-      // overflows and is clipped by `overflow:hidden` — hence
-      // `pdf_dual_layer_fallback_font_size_adjust` (config, 0-1) is
-      // deliberately low. The vertical rescale is harmless: `.sr`/`.sg` fix
-      // their box height via `line-height:1` and baseline-align via
-      // `overflow:hidden` (below), never consulting the font's ascent/descent.
-      // If no `pdf_dual_layer_fallback_fonts` resolve locally the rule is
-      // skipped and
-      // `.i` falls through to plain `sans-serif`.
+      // Selection-layer fallback font: `size-adjust` shrinks a local system
+      // font under the PDF-derived `.sr`/`.sg` widths. CSS justify only ever
+      // *adds* spacing, so undershooting is free while overshooting overflows
+      // and is clipped — hence the deliberately low config default. With no
+      // fonts configured `.i` falls through to plain `sans-serif`.
       if (const std::vector<std::string> &fonts =
               config().pdf_dual_layer_fallback_fonts;
           !fonts.empty()) {
@@ -1723,18 +1599,15 @@ public:
       }
       // Transparent text for the selection layer line blocks.
       out.out() << ".i{color:transparent;font-family:sf,sans-serif}";
-      // Selection-layer run span: inline-block with CSS justify so the browser
-      // spreads characters to fill the declared width (the PDF advance) without
-      // JS; `overflow:hidden` clips a wider system font. `.t`'s inherited `pre`
-      // (not `nowrap`) blocks wrapping while preserving a run's own
+      // Selection-layer run span. `overflow:hidden` clips a wider system font;
+      // `.t`'s inherited `pre` blocks wrapping while preserving a run's own
       // leading/trailing space, which is real PDF content.
       out.out() << ".sr{display:inline-block;text-align:justify;"
                    "text-align-last:justify;text-justify:inter-character;"
                    "overflow:hidden}";
-      // Selection-layer gap spacer: inline-block, no text, just width.
-      // `overflow:hidden` matches `.sr`: an inline-block baseline-aligns to its
-      // bottom margin edge only when overflow isn't visible, so without it the
-      // spacer and run boxes align differently and the spacer shifts in y.
+      // Selection-layer gap spacer. `overflow:hidden` matches `.sr`: an
+      // inline-block baseline-aligns to its bottom margin edge only when
+      // overflow isn't visible, so without it the spacer shifts in y.
       out.out() << ".sg{display:inline-block;overflow:hidden}";
     });
 
@@ -1803,29 +1676,20 @@ public:
     return resources;
   }
 
-  // =========================================================================
-  // SINGLE-LAYER MODE
-  // =========================================================================
+  // ---- SINGLE-LAYER MODE --------------------------------------------------
   //
-  // One combined text layer per page (paint order). Text runs are grouped into
-  // line blocks (`<div class="t ...">`) in paint order; individual runs flow
-  // inline within the block, each nudged by a `margin-left` (the gen-time gap
-  // from the previous run's right edge, matching the embedded font's advance
-  // exactly when the font's `hmtx` matches the PDF `/Widths`).
+  // One combined text layer per page: runs grouped into paint-order line
+  // blocks (`.t`), each run nudged by a `margin-left` gap.
   //
-  // Unicode mapping uses frequency analysis: a pre-pass over all pages counts
-  // (uchar, glyph) co-occurrences per font, then the post-pass picks the
-  // most-frequent glyph for each uchar as the cmap entry. This ensures the
-  // common case wins instead of an arbitrary first-come-first-serve order.
+  // The embedded font's cmap is built by frequency analysis — a pre-pass counts
+  // (uchar, glyph) co-occurrences per font and the winner takes the entry — so
+  // the common shape wins instead of whichever run came first.
   //
-  // Clean runs (all (uchar, glyph) pairs match the frequency winner) render
-  // the real Unicode directly in the embedded font — natively findable and
-  // selectable. Unclean visible runs paint their glyphs via
-  // `::before{content:attr(data-g)}` CSS generated content (kept out of the
-  // DOM text stream so they never break find mid-word), with a zero-width
-  // `display:inline-block; overflow:hidden` overlay carrying the real Unicode
-  // alongside. No-unicode runs show only the glyph. Invisible (Tr 3/7) and
-  // fallback (no embedded font) runs render the real Unicode as ordinary text.
+  // A run whose pairs all match the winner ("clean") renders real Unicode
+  // directly in the embedded font, natively findable. An unclean run paints
+  // glyphs via `::before{content:attr(data-g)}` — out of the DOM text stream,
+  // so find never breaks mid-word — with a zero-width `.ov` overlay carrying
+  // the Unicode. Invisible and fallback runs render Unicode as ordinary text.
 
   struct SingleRunOut {
     std::string margin;     ///< "" or a `margin-left` class
@@ -1865,19 +1729,15 @@ public:
     pdf::DocumentParser &parser = *m_parser;
     LinkResolver &link_resolver = *m_link_resolver;
 
-    // ---- Font registration ------------------------------------------------
     // A real-Unicode scalar gets a cmap entry only inside the BMP and outside
-    // the PUA (`U+E000..U+F8FF`), so glyph-deterministic PUA code points are
-    // never shadowed.
+    // the PUA, so the glyph-deterministic PUA code points are never shadowed.
     const auto collapsible_unicode = [](const char32_t c) {
       return c <= 0xFFFF && !(c >= 0xE000 && c <= 0xF8FF);
     };
 
-    // A leading inferred space (space inference) carries no character code or
-    // advance, so the "collapsible" 1:1 alignment is between the codes and the
-    // run text *after* that space. These helpers view the run text past it: the
-    // core character count (to test 1:1 against `advances`) and the byte offset
-    // where the codes begin (to walk `text` alongside `font->codes`).
+    // A leading inferred space carries no character code or advance, so the 1:1
+    // codes-to-text alignment starts after it. These helpers view the run text
+    // past that space.
     const auto core_char_count = [](const pdf::TextElement &t) {
       return util::string::utf8_length(t.text) -
              (t.leading_space_inferred ? 1u : 0u);
@@ -1935,12 +1795,8 @@ public:
     }
 
     // ---- Pre-pass: frequency analysis ------------------------------------
-    // Count (uchar, glyph) co-occurrences per font over all pages. The main
-    // pass then uses the frequency winner for each uchar instead of first-come-
-    // first-serve, so the most common glyph shape wins its cmap entry.
-    // This re-runs `extract_page` on every page (the main pass parses each a
-    // second time) — a deliberate tradeoff: re-parsing the already-decoded
-    // stream is cheap next to buffering every page's element list in memory.
+    // Every page is extracted twice (here and in the main pass): re-parsing an
+    // already-decoded stream is cheaper than buffering every page's elements.
     for (std::size_t pi = 0; pi < pages.size(); ++pi) {
       const pdf::Page &page = *pages[pi];
       for (const pdf::PageElement &element : lift_group_text(pdf::extract_page(
@@ -1953,8 +1809,8 @@ public:
         if (font == 0) {
           continue;
         }
-        // Only collapsible-candidate runs contribute to frequency counts. A
-        // leading inferred space is skipped so a run carrying one still votes.
+        // Only collapsible-candidate runs vote; the leading inferred space is
+        // skipped so a run carrying one still does.
         if (core_char_count(*text) != text->advances.size()) {
           continue;
         }
@@ -1970,8 +1826,8 @@ public:
       }
     }
 
-    // Compute the frequency winner for each (font, uchar): the glyph with the
-    // highest count becomes the cmap entry. Ties broken by lower glyph id.
+    // The winning glyph per (font, uchar) takes the cmap entry; the map's
+    // ascending glyph order makes strict `>` break ties by lower glyph id.
     for (std::uint32_t fi = 0; fi < family_count; ++fi) {
       for (const auto &[uchar, counts] : glyph_freq[fi]) {
         std::uint16_t best_glyph = 0;
@@ -2043,14 +1899,9 @@ public:
         const double ws_pt = round2(text.word_spacing * scale);
         const std::string color_suffix = color_class(text, invisible, styles);
 
-        // ---- Run payload ------------------------------------------------
-        // Decide whether this is a clean collapse (real unicode renders
-        // directly via the frequency-winner cmap entries) or unclean (glyph
-        // painted via generated content, unicode as overlay).
         SingleRunOut run;
-        // `color_suffix` carries a leading space for the dual-layer paths that
-        // concatenate it onto a class string; the single-layer run stores just
-        // the class name.
+        // `color_suffix` leads with a space for the dual-layer paths that
+        // concatenate it; a single-layer run stores the bare class name.
         run.color =
             color_suffix.empty() ? std::string() : color_suffix.substr(1);
 
@@ -2058,11 +1909,10 @@ public:
           // Fallback / invisible: render real unicode directly.
           run.text = escape_markup(text.text);
         } else {
-          // Check collapse: 1:1 codes↔core-text and every (uchar, glyph)
-          // matches the frequency winner. A leading inferred space is metadata,
-          // not a coded char, so it is excluded from the alignment (otherwise a
-          // recovered word break would force the whole run onto the PUA path).
-          // `font != 0` here already implies `text.font != nullptr`.
+          // Collapse needs 1:1 codes-to-core-text and every (uchar, glyph) to
+          // match the frequency winner. The leading inferred space is metadata,
+          // not a coded char, so excluding it keeps a recovered word break from
+          // forcing the whole run onto the PUA path.
           bool collapse = core_char_count(text) > 0 &&
                           core_char_count(text) == text.advances.size();
           if (collapse) {
@@ -2081,14 +1931,11 @@ public:
             }
           }
           if (collapse) {
-            // Real Unicode renders directly via the cmap. Any leading inferred
-            // space becomes a dedicated selectable space span (`lead_space`),
-            // never a literal space in `text`, so `white-space:pre` cannot
-            // shift the glyphs right of their placement origin. When the run
-            // continues its line over a positive gap the span carries that gap
-            // as its width (pdf2htmlEX's model: one real space that is both the
-            // copyable character and the visible advance); otherwise it stays
-            // zero-width. See the `.sp`/`.ov` split in the main pass.
+            // A leading inferred space becomes its own span, never a literal
+            // space in `text`, so `white-space:pre` cannot shift the glyphs off
+            // their placement origin. Over a positive gap that span carries the
+            // gap as its width (pdf2htmlEX's model: one real space that is both
+            // the copyable character and the advance), else it is zero-width.
             run.lead_space = text.leading_space_inferred;
             run.text = escape_markup(
                 std::string(core_text_begin(text), text.text.end()));
@@ -2102,9 +1949,8 @@ public:
         }
 
         // ---- Flow grouping -----------------------------------------------
-        // The visible substitute family of a non-embedded font (`font == 0`);
-        // part of the flow key so two different substitutes (e.g. a Helvetica
-        // run then a Times run) never share one line block's `font_class`.
+        // The substitute family is part of the flow key, so a Helvetica run and
+        // a Times run never share one line block's `font_class`.
         const std::string substitute_declaration =
             (font == 0 && !invisible && text.font != nullptr &&
              text.font->substitute)
@@ -2163,8 +2009,7 @@ public:
         } else {
           if (run.lead_space && margin_pt > 0) {
             // Recovered word break over a positive gap: fold the advance into
-            // the selectable space span (pdf2htmlEX-style width-bearing space)
-            // rather than a zero-width `.ov` plus a `margin-left` on the run.
+            // the space span rather than a `margin-left` on the run.
             run.lead_space_width =
                 styles.intern("w", pt_decl("width", margin_pt));
           } else if (margin_pt != 0) {
@@ -2195,31 +2040,23 @@ public:
     write_header_common(out, font_faces, font_styles, styles, [&] {
       // Invisible text render modes (Tr 3/7).
       out.out() << ".i{color:transparent}";
-      // Unclean glyphs painted via CSS generated content (`data-g` attr), kept
-      // out of the DOM text stream so they never break find/double-click.
+      // Unclean glyphs via generated content, out of the DOM text stream.
       out.out() << ".gl::before{content:attr(data-g)}";
-      // Zero-width inline-block overlay carrying the real Unicode of an unclean
-      // run: invisible, zero-width, but still found/selected in reading order.
-      // `inline-block` lets `width:0` apply (a regular inline box ignores it);
-      // `overflow:hidden` clips the invisible text to zero width.
+      // The real Unicode of an unclean run: invisible and zero-width, but still
+      // found and selected in reading order. `inline-block` is what lets
+      // `width:0` apply at all.
       out.out() << ".ov{display:inline-block;width:0;overflow:hidden;"
                    "color:transparent;vertical-align:baseline}";
-      // Width-bearing selectable space for a recovered word break (pdf2htmlEX's
-      // model): a real `" "` inside an inline-block sized to the gap by a `wN`
-      // class, so the space is markable/copyable *and* carries the advance
-      // (no `margin-left` on the following run). No `overflow:hidden`: it would
-      // not clip the space glyph (transparent, and the declared width already
-      // fixes the advance) but *would* move the inline-block's baseline to its
-      // bottom margin edge (CSS quirk when overflow != visible), lifting the
-      // space's selection box off the text baseline so it highlights at the
-      // wrong height. `vertical-align:baseline` on a `visible` box keeps the
-      // space aligned with the neighbouring glyphs.
+      // Width-bearing selectable space for a recovered word break: a real `" "`
+      // sized to the gap by a `wN` class, copyable *and* carrying the advance.
+      // Deliberately no `overflow:hidden`: it would move the inline-block's
+      // baseline to its bottom margin edge and highlight the space at the wrong
+      // height, while clipping nothing (the space is transparent).
       out.out() << ".sp{display:inline-block;"
                    "color:transparent;vertical-align:baseline}";
     });
 
-    // Helper: derive a run's leading-span class from `head` prefix plus its
-    // optional margin-left and colour override.
+    // A run's span class: `head` plus its optional margin-left and colour.
     const auto run_class = [](const SingleRunOut &run, const char *head) {
       std::string cls = head;
       const auto add = [&](const std::string &t) {
@@ -2248,11 +2085,9 @@ public:
         if (run.glyph_data.empty()) {
           // Clean / invisible / fallback: real Unicode renders directly.
           if (run.lead_space) {
-            // Recovered word-break space: a real, selectable/copyable `" "`.
-            // With a `wN` width it carries the gap (pdf2htmlEX-style,
-            // markable); without one it is zero-width `.ov` (line-leading or
-            // negative gap) and never shifts the glyphs under
-            // `white-space:pre`.
+            // With a `wN` width the space carries the gap; without one it is a
+            // zero-width `.ov` (line-leading or negative gap) that cannot shift
+            // the glyphs under `white-space:pre`.
             const std::string space_cls = run.lead_space_width.empty()
                                               ? std::string("ov")
                                               : "sp " + run.lead_space_width;
@@ -2318,13 +2153,11 @@ public:
     return std::move(s).str();
   }
 
-  /// Whether a run at (`ox`, `baseline`) starts a new visual line rather than
-  /// continuing the previous run: its baseline jumped by more than 0.6× the
-  /// previous run's advance height, or its origin sits left of the previous
-  /// run's right edge (minus half that height) — a carriage return. Shared by
-  /// all three layers (visual, selection, single) so the heuristic, which is
-  /// always measured against the *previous* run's `prev_font_pt`, cannot drift
-  /// between them. Callers gate on `prev_font_pt > 0`.
+  /// Whether a run at (`ox`, `baseline`) starts a new visual line: its baseline
+  /// jumped by more than 0.6× the previous run's advance height, or its origin
+  /// sits left of that run's right edge — a carriage return. Shared by all
+  /// three layers so the heuristic cannot drift between them; callers gate on
+  /// `prev_font_pt > 0`.
   static bool starts_new_line(const double baseline, const double prev_baseline,
                               const double ox, const double prev_end,
                               const double prev_font_pt) {
@@ -2332,10 +2165,8 @@ public:
            ox < prev_end - 0.5 * prev_font_pt;
   }
 
-  /// The per-run geometry derived from a `TextElement` and the page's `to_box`
-  /// transform. Identical in every text mode, so it lives in one place — no
-  /// call site can compute it differently (that is how findings like the 180°
-  /// rotation and the drifting line-break threshold crept in).
+  /// Per-run geometry from a `TextElement` and the page's `to_box`. Identical
+  /// in every text mode, and kept in one place so no call site can drift.
   struct RunGeometry {
     util::math::Transform2D m; ///< glyph space -> page box (y-down, pt later)
     bool invisible;            ///< Tr 3/7 — paints nothing, selectable only
@@ -2357,9 +2188,8 @@ public:
     const bool invisible =
         text.rendering_mode == pdf::TextRenderingMode::invisible ||
         text.rendering_mode == pdf::TextRenderingMode::clip;
-    // `m.a > 0` keeps the axis-aligned fast path from swallowing a pure 180°
-    // rotation (a = d = -1, b = c = 0), which would otherwise feed a negative
-    // `m.a` into `font_size_pt` and the left/top math.
+    // `m.a > 0` keeps a pure 180° rotation (a = d = -1) off the axis-aligned
+    // fast path, where it would feed a negative `m.a` into the placement math.
     const bool is_matrix = !(m.b == 0 && m.c == 0 && m.a == m.d && m.a > 0);
     const double tz = text.horizontal_scaling / 100.0;
     const double axis = tz != 0 ? std::hypot(m.a, m.b) / tz : 0;
@@ -2378,8 +2208,7 @@ public:
   }
 
   /// The colour class suffix (with a leading space) for a run's paint colour,
-  /// or "" for black / invisible. Interns the declaration in `styles`. Shared
-  /// by both modes' run emission.
+  /// or "" for black / invisible.
   static std::string color_class(const pdf::TextElement &text,
                                  const bool invisible, AtomicStyles &styles) {
     if (invisible) {
@@ -2393,9 +2222,8 @@ public:
         text.rendering_mode == pdf::TextRenderingMode::fill_stroke_clip;
     const pdf::GraphicsState::Color &paint =
         stroked ? text.stroke_color : text.fill_color;
-    // The single span carries one opacity. A fill-and-stroke glyph paints both,
-    // so take the more opaque of the two: a transparent fill (`ca 0`) must not
-    // hide an opaque stroke (`CA 1`) and drop the outlined glyph entirely.
+    // The span carries one opacity, so a fill-and-stroke glyph takes the more
+    // opaque of the two: a transparent fill must not drop an opaque outline.
     const double alpha = stroked ? text.stroke_alpha
                          : fill_and_stroke
                              ? std::max(text.fill_alpha, text.stroke_alpha)
@@ -2417,8 +2245,7 @@ public:
     return ' ' + styles.intern("k", std::move(declaration).str());
   }
 
-  /// The page-box geometry (dimensions, the page `to_box` transform and the
-  /// `.p x# y#` class string) shared by both modes' page setup. `add_class`
+  /// The page-box geometry shared by both modes' page setup; `add_class`
   /// interns the width/height declarations.
   struct PageBox {
     double width;
@@ -2452,10 +2279,9 @@ public:
     return {width, height, to_box, std::move(classes)};
   }
 
-  /// Returns the 1-based font family index for `font`, or 0 when it is unusable
-  /// (or already rejected). On the first acceptance of a usable font runs
-  /// `on_accept(index)` so the caller can grow its parallel per-font arrays.
-  /// Shared accept/reject bookkeeping for both modes' `font_family` lambdas.
+  /// The 1-based font family index for `font`, or 0 when it is unusable. Runs
+  /// `on_accept(index)` on first acceptance so the caller can grow its parallel
+  /// per-font arrays.
   template <typename OnAccept>
   static std::uint32_t intern_font(
       std::unordered_map<const pdf::Font *, std::uint32_t> &family_index,
@@ -2474,10 +2300,8 @@ public:
     return index;
   }
 
-  /// Writes a page's `<defs>` clips and its paint-order body — an SVG
-  /// open/close dance around a `variant<LineT, PathT>` item list — via
-  /// `write_line`. The structure is identical in both modes; only the line and
-  /// path types and the line writer differ.
+  /// A page's `<defs>` and its paint-order body: an SVG open/close dance around
+  /// the item list, identical in both modes bar the line and path types.
   template <typename LineT, typename PathT, typename WriteLine>
   static void
   write_page_items(HtmlWriter &out, const std::string &clip_defs,
@@ -2515,10 +2339,8 @@ public:
     close_svg();
   }
 
-  /// Writes the document/head prologue shared by both modes: the constant
-  /// `body`/`.p`/`.t` rules, then `write_mode_css()` for the mode-specific
-  /// rules, then the constant `.s` rule, the font faces/styles and the interned
-  /// atomic rules. Leaves the writer positioned after `</head>`.
+  /// The document/head prologue shared by both modes, with `write_mode_css()`
+  /// slotted between the constant rules. Leaves the writer after `</head>`.
   template <typename WriteModeCss>
   void write_header_common(HtmlWriter &out, const std::string &font_faces,
                            const std::string &font_styles,
@@ -2533,9 +2355,8 @@ public:
     out.write_header_style_begin();
     out.out() << "body{margin:0;background:#525659}";
     // `.d`: the page column, sized to the widest page so pages of differing
-    // width centre against each other, not against the viewport. The page's
-    // side margin is part of that width, so fitting the document to a phone
-    // screen leaves a gutter instead of going edge to edge.
+    // width centre against each other rather than against the viewport. Their
+    // side margin is part of that width, so a phone screen keeps a gutter.
     out.out() << ".d{display:flex;flex-direction:column;align-items:center;"
                  "gap:16px;padding:16px 0;width:max-content;min-width:100%}";
     out.out() << ".p{position:relative;margin:0 16px;background:#fff;"
@@ -2557,14 +2378,9 @@ public:
     out.write_header_end();
   }
 
-  /// Appends a text run's line-block placement classes via `add_class(classes,
-  /// prefix, declaration)`: `l`/`t` (left/top, in pt) for an axis-aligned run,
-  /// or `m` (a CSS `translate(...)` + `matrix(...)` transform, re-anchored to
-  /// the run's baseline by `ascent_pt`) for a rotated/skewed one. A CSS
-  /// `matrix()` translation is intrinsically px, so the (pt) translation is
-  /// carried by a leading `translate(...pt)` — keeping the whole text layer in
-  /// pt. Shared by the visual, selection and single-layer line blocks, which
-  /// all position runs the same way.
+  /// Appends a line block's placement classes: `l`/`t` (left/top in pt) for an
+  /// axis-aligned run, `m` (a transform re-anchored to the baseline by
+  /// `ascent_pt`) for a rotated or skewed one. Shared by all three layers.
   template <typename AddClass>
   static void add_position_classes(std::string &classes, AddClass &&add_class,
                                    const util::math::Transform2D &m,
@@ -2577,9 +2393,8 @@ public:
                 pt_decl("top", round2(baseline - ascent_pt * m.a)));
       return;
     }
-    // `translate()` accepts pt and is applied after (outside) the `matrix()`,
-    // so `translate(tx,ty) matrix(a,b,c,d,0,0)` reproduces the full affine with
-    // the translation authored in pt instead of matrix()'s implicit px.
+    // A CSS `matrix()` translation is intrinsically px; `translate()` takes pt
+    // and applies outside it, so the whole text layer stays in pt.
     const double tx = m.e - m.c * ascent_pt;
     const double ty = m.f - m.d * ascent_pt;
     std::ostringstream t;
@@ -2589,10 +2404,9 @@ public:
     add_class(classes, "m", std::move(t).str());
   }
 
-  /// Whether `font`'s embedded program can be re-encoded (SFNT PUA re-cmap or
-  /// CFF->OTF wrap) without throwing; probes the real encode path so failures
-  /// surface here rather than in the post-pass. Restores the SFNT's original
-  /// cmap after probing (the CFF probe is stateless).
+  /// Whether `font`'s embedded program re-encodes without throwing. Probes the
+  /// real encode path so failures surface here, not in the post-pass, and
+  /// restores the SFNT cmap it mutates.
   static bool font_is_usable(const pdf::Font &font) {
     if (const auto sfnt = std::dynamic_pointer_cast<font::sfnt::SfntFont>(
             font.embedded_font)) {
@@ -2629,10 +2443,9 @@ public:
     return (inv ? "fn" : "fv") + std::to_string(font);
   }
 
-  /// Re-encodes `font`'s embedded program (SFNT PUA re-cmap or CFF->OTF wrap,
-  /// folding in `extra_unicode`'s real-Unicode cmap entries alongside the PUA
-  /// range) and appends its `@font-face` and `.fvN`/`.fnN` rules.
-  /// `class_used[0]`/`[1]` gate whether the visible/invisible rule is needed.
+  /// Re-encodes `font`'s embedded program, folding `extra_unicode`'s cmap
+  /// entries in alongside the PUA range, and appends its `@font-face` plus the
+  /// `.fvN`/`.fnN` rules `class_used` says are needed.
   static void
   write_font_face(const pdf::Font &font, const std::uint32_t index,
                   const std::map<char32_t, std::uint16_t> &extra_unicode,
@@ -2697,11 +2510,9 @@ public:
     return s;
   }
 
-  /// Escapes only the three markup-significant characters for the selection /
-  /// unicode text. Deliberately *not* `html::escape_text`: that substitutes
-  /// spaces with `&nbsp;`, which browsers treat as a distinct character from
-  /// U+0020 and so breaks find-in-page word matching and double-click word
-  /// selection across the very text these layers exist to make selectable.
+  /// Escapes only the three markup-significant characters. Deliberately *not*
+  /// `html::escape_text`: its `&nbsp;` substitution is a distinct character
+  /// from U+0020 and breaks the find and word selection these layers exist for.
   static std::string escape_markup(std::string s) {
     util::string::replace_all(s, "&", "&amp;");
     util::string::replace_all(s, "<", "&lt;");
@@ -2709,10 +2520,8 @@ public:
     return s;
   }
 
-  /// Handles path/shading/image elements common to both rendering modes.
-  /// Calls close_line() and push_fragment(svg_string) when a non-empty
-  /// fragment is produced. Returns true when the element was a graphic
-  /// (caller should `continue`), false when it is a text element.
+  /// Handles the non-text elements common to both modes, calling `close_line`
+  /// and `push_svg` for a non-empty fragment. Returns false for a text element.
   template <typename CloseLine, typename PushSvg>
   static bool
   handle_graphic_element(const pdf::PageElement &element,

--- a/src/odr/internal/html/text_file.cpp
+++ b/src/odr/internal/html/text_file.cpp
@@ -30,11 +30,7 @@ public:
   [[nodiscard]] const HtmlViews &list_views() const override { return m_views; }
 
   [[nodiscard]] bool exists(const std::string &path) const override {
-    if (path == "text.html") {
-      return true;
-    }
-
-    return false;
+    return path == "text.html";
   }
 
   [[nodiscard]] std::string mimetype(const std::string &path) const override {
@@ -112,11 +108,11 @@ public:
 
       std::ostringstream ss_out;
       util::stream::pipe_line(*in, ss_out, false);
-      if (const std::string &line = ss_out.str(); line.empty()) {
+      if (std::string line = ss_out.str(); line.empty()) {
         out.write_element_begin(
             "br", HtmlElementOptions().set_close_type(HtmlCloseType::trailing));
       } else {
-        out.out() << escape_text(ss_out.str());
+        out.out() << escape_text(std::move(line));
       }
 
       out.write_element_end("div");

--- a/src/odr/internal/magic.cpp
+++ b/src/odr/internal/magic.cpp
@@ -18,8 +18,7 @@ namespace odr::internal {
 
 namespace {
 
-/// At most @p size bytes, cut back to what was actually read - a file shorter
-/// than the longest signature must never be matched against what sat behind it.
+/// At most @p size bytes, cut back to what was actually read.
 std::string read_head(std::istream &in, const std::size_t size) {
   std::string result(size, '\0');
   in.read(result.data(), static_cast<std::streamsize>(size));
@@ -65,12 +64,8 @@ FileType riff_file_type(const std::string &head) {
   return FileType::unknown;
 }
 
-/// Which format an ISO base media container holds, from its major brand.
-///
-/// The brands are open ended and every writer adds its own, so this names the
-/// ones that mean something other than video and lets the rest - `isom`,
-/// `mp41`, `mp42`, `avc1`, `dash` and whatever comes next - fall through to
-/// what the container almost always is.
+/// Which format an ISO base media container holds, from its major brand. Only
+/// the brands that are not video are named; the open ended rest falls through.
 FileType iso_base_media_file_type(const std::string &head) {
   const std::string_view brand = tag_at(head, 8);
   if (brand == "qt  ") {
@@ -189,8 +184,8 @@ FileType magic::file_type(const std::string &magic) {
       match_magic(magic, "02 00 09 00 00 03")) { // disk metafile header
     return FileType::windows_metafile;
   }
-  // the leading record type alone is far too weak, so the header signature at
-  // offset 40 has to agree
+  // the leading record type alone is too weak, the signature at offset 40 has
+  // to agree
   if (match_magic(magic, "01 00 00 00") && tag_at(magic, 40) == " EMF") {
     return FileType::enhanced_metafile;
   }
@@ -203,8 +198,7 @@ FileType magic::file_type(const std::string &magic) {
 }
 
 FileType magic::file_type(std::istream &in) {
-  // every signature is a prefix but one: an enhanced metafile names itself at
-  // offset 40, so the head has to reach 44
+  // an enhanced metafile names itself at offset 40, so the head has to reach 44
   static constexpr std::size_t head_size = 64;
 
   return file_type(read_head(in, head_size));
@@ -220,10 +214,8 @@ FileType magic::file_type(const File &file) {
 
 std::string_view magic::mimetype(const std::string &path,
                                  const Logger &logger) {
-  // the signature table above is not enough on its own: a zip and a compound
-  // file binary say nothing about which document they hold, and the answer for
-  // those only comes out of opening them. that is what `list_file_types` does,
-  // and it reports the container first and what was decoded from it after
+  // a zip or compound file binary only names its document once opened;
+  // `list_file_types` reports the container first and the decoded type after
   const std::vector<FileType> file_types =
       open_strategy::list_file_types(std::make_shared<DiskFile>(path), logger);
   if (file_types.empty()) {

--- a/src/odr/internal/odf/odf_document.cpp
+++ b/src/odr/internal/odf/odf_document.cpp
@@ -127,8 +127,7 @@ void Document::save(const Path & /*path*/, const char * /*password*/) const {
 
 namespace {
 
-/// Parses a `svg:*` length attribute. An absent or unparsable value yields
-/// nullopt rather than throwing — geometry is presentational.
+/// Absent or unparsable geometry yields nullopt rather than throwing.
 std::optional<Measure> read_measure(const pugi::xml_attribute attribute) {
   if (!attribute) {
     return std::nullopt;
@@ -140,8 +139,7 @@ std::optional<Measure> read_measure(const pugi::xml_attribute attribute) {
   }
 }
 
-/// Same, for the attributes the API reports unconditionally; a missing value
-/// degrades to a bare zero.
+/// Same, for attributes the API reports unconditionally.
 Measure read_measure_or_zero(const pugi::xml_attribute attribute) {
   return read_measure(attribute).value_or(Measure(0, DynamicUnit()));
 }
@@ -212,13 +210,11 @@ public:
   element_is_editable(const ElementIdentifier element_id) const override {
     const ElementRegistry::Element &element =
         m_registry->element_at(element_id);
+    if (element.type == ElementType::sheet_cell) {
+      return !m_registry->sheet_cell_element_at(element_id).is_repeated;
+    }
     if (element.parent_id != null_element_id) {
       return element_is_editable(element.parent_id);
-    }
-    if (element.type == ElementType::sheet_cell) {
-      const ElementRegistry::SheetCell &sheet_cell =
-          m_registry->sheet_cell_element_at(element_id);
-      return !sheet_cell.is_repeated;
     }
     return true;
   }
@@ -423,10 +419,10 @@ public:
         cursor.add_cell(colspan, rowspan, columns_repeated);
 
         const std::uint32_t new_rows = cursor.row();
-        if (const std::uint32_t new_cols =
-                std::max(result.columns, cursor.column());
-            cell.first_child() && range && new_rows < range->rows &&
-            new_cols < range->columns) {
+        const std::uint32_t new_cols =
+            std::max(result.columns, cursor.column());
+        if (cell.first_child() &&
+            (!range || (new_rows < range->rows && new_cols < range->columns))) {
           result.rows = new_rows;
           result.columns = new_cols;
         }
@@ -476,9 +472,9 @@ public:
                   const std::uint32_t row) const override {
     const ElementRegistry::Sheet &sheet_registry =
         m_registry->sheet_element_at(element_id);
-    const pugi::xml_node column_node = sheet_registry.row_node(row);
+    const pugi::xml_node row_node = sheet_registry.row_node(row);
     if (const pugi::xml_attribute attr =
-            column_node.attribute("table:style-name")) {
+            row_node.attribute("table:style-name")) {
       if (const Style *style = m_document->style_registry().style(attr.value());
           style != nullptr) {
         return style->resolved().table_row_style;
@@ -556,11 +552,10 @@ public:
         m_registry->text_element_at(element_id);
 
     const pugi::xml_node first = get_node(element_id);
-    const pugi::xml_node last = text_element.last;
+    const pugi::xml_node end = text_element.last.next_sibling();
 
     std::string result;
-    for (pugi::xml_node node = first; node != last.next_sibling();
-         node = node.next_sibling()) {
+    for (pugi::xml_node node = first; node != end; node = node.next_sibling()) {
       result += get_text(node);
     }
     return result;
@@ -571,32 +566,27 @@ public:
     ElementRegistry::Text &text_element =
         m_registry->text_element_at(element_id);
 
-    const pugi::xml_node first = get_node(element_id);
-    const pugi::xml_node last = text_element.last;
-
-    pugi::xml_node parent = first.parent();
-    const pugi::xml_node old_first = first;
-    const pugi::xml_node old_last = last;
+    pugi::xml_node parent = get_node(element_id).parent();
+    const pugi::xml_node old_first = get_node(element_id);
+    const pugi::xml_node old_last = text_element.last;
+    // the removal loop below invalidates `old_last`
+    const pugi::xml_node old_end = old_last.next_sibling();
     pugi::xml_node new_first = old_first;
-    pugi::xml_node new_last = last;
+    pugi::xml_node new_last = old_last;
 
-    const auto insert_pcdata = [&] {
-      const pugi::xml_node new_node = parent.insert_child_before(
-          pugi::xml_node_type::node_pcdata, old_first);
+    const auto track = [&](const pugi::xml_node new_node) {
       if (new_first == old_first) {
         new_first = new_node;
       }
       new_last = new_node;
       return new_node;
     };
+    const auto insert_pcdata = [&] {
+      return track(parent.insert_child_before(pugi::xml_node_type::node_pcdata,
+                                              old_first));
+    };
     const auto insert_node = [&](const char *node) {
-      const pugi::xml_node new_node =
-          parent.insert_child_before(node, old_first);
-      if (new_first == old_first) {
-        new_first = new_node;
-      }
-      new_last = new_node;
-      return new_node;
+      return track(parent.insert_child_before(node, old_first));
     };
 
     for (const util::xml::StringToken &token : util::xml::tokenize_text(text)) {
@@ -619,10 +609,16 @@ public:
       }
     }
 
+    if (new_first == old_first) {
+      // empty text still needs a live node to anchor the element to, or the
+      // removal below would leave the registry pointing at freed nodes
+      insert_pcdata();
+    }
+
     element.node = new_first;
     text_element.last = new_last;
 
-    for (pugi::xml_node node = old_first; node != old_last.next_sibling();) {
+    for (pugi::xml_node node = old_first; node != old_end;) {
       const pugi::xml_node next = node.next_sibling();
       parent.remove_child(node);
       node = next;

--- a/src/odr/internal/odf/odf_element_registry.cpp
+++ b/src/odr/internal/odf/odf_element_registry.cpp
@@ -22,7 +22,7 @@ std::tuple<ElementIdentifier, ElementRegistry::Element &>
 ElementRegistry::create_element(const ElementType type,
                                 const pugi::xml_node node) {
   Element &element = m_elements.emplace_back();
-  ElementIdentifier element_id = m_elements.size();
+  const ElementIdentifier element_id = m_elements.size();
   element.type = type;
   element.node = node;
   return {element_id, element};
@@ -34,36 +34,39 @@ ElementRegistry::create_text_element(const pugi::xml_node first_node,
                                      const pugi::xml_node last_node) {
   const auto &[element_id, element] =
       create_element(ElementType::text, first_node);
-  auto [it, success] = m_texts.emplace(element_id, Text{last_node});
-  return {element_id, element, it->second};
+  Text &text = m_texts.emplace(element_id, Text{last_node}).first->second;
+  return {element_id, element, text};
 }
 
 std::tuple<ElementIdentifier, ElementRegistry::Element &,
            ElementRegistry::Table &>
 ElementRegistry::create_table_element(const pugi::xml_node node) {
   const auto &[element_id, element] = create_element(ElementType::table, node);
-  auto [it, success] = m_tables.emplace(element_id, Table{});
-  return {element_id, element, it->second};
+  Table &table = m_tables.emplace(element_id, Table{}).first->second;
+  return {element_id, element, table};
 }
 
 std::tuple<ElementIdentifier, ElementRegistry::Element &,
            ElementRegistry::Sheet &>
 ElementRegistry::create_sheet_element(const pugi::xml_node node) {
   const auto &[element_id, element] = create_element(ElementType::sheet, node);
-  auto [it, success] = m_sheets.emplace(element_id, Sheet{});
-  return {element_id, element, it->second};
+  Sheet &sheet = m_sheets.emplace(element_id, Sheet{}).first->second;
+  return {element_id, element, sheet};
 }
 
 std::tuple<ElementIdentifier, ElementRegistry::Element &,
            ElementRegistry::SheetCell &>
 ElementRegistry::create_sheet_cell_element(const pugi::xml_node node,
                                            const TablePosition &position,
-                                           bool is_repeated) {
+                                           const bool is_repeated) {
   const auto &[element_id, element] =
       create_element(ElementType::sheet_cell, node);
-  auto [it, success] = m_sheet_cells.emplace(
-      element_id, SheetCell{.position = position, .is_repeated = is_repeated});
-  return {element_id, element, it->second};
+  SheetCell &sheet_cell =
+      m_sheet_cells
+          .emplace(element_id,
+                   SheetCell{.position = position, .is_repeated = is_repeated})
+          .first->second;
+  return {element_id, element, sheet_cell};
 }
 
 ElementRegistry::Element &
@@ -128,6 +131,22 @@ ElementRegistry::sheet_cell_element(const ElementIdentifier id) const {
   return nullptr;
 }
 
+void ElementRegistry::link_child(const ElementIdentifier parent_id,
+                                 const ElementIdentifier child_id,
+                                 ElementIdentifier &first_id,
+                                 ElementIdentifier &last_id) {
+  Element &child = element_at(child_id);
+  child.parent_id = parent_id;
+  child.previous_sibling_id = last_id;
+
+  if (first_id == null_element_id) {
+    first_id = child_id;
+  } else {
+    element_at(last_id).next_sibling_id = child_id;
+  }
+  last_id = child_id;
+}
+
 void ElementRegistry::append_child(const ElementIdentifier parent_id,
                                    const ElementIdentifier child_id) {
   check_element_id(parent_id);
@@ -137,18 +156,8 @@ void ElementRegistry::append_child(const ElementIdentifier parent_id,
         "DocumentElementRegistry::append_child: child already has a parent");
   }
 
-  const ElementIdentifier previous_sibling_id =
-      element_at(parent_id).last_child_id;
-
-  element_at(child_id).parent_id = parent_id;
-  element_at(child_id).previous_sibling_id = previous_sibling_id;
-
-  if (element_at(parent_id).first_child_id == null_element_id) {
-    element_at(parent_id).first_child_id = child_id;
-  } else {
-    element_at(previous_sibling_id).next_sibling_id = child_id;
-  }
-  element_at(parent_id).last_child_id = child_id;
+  Element &parent = element_at(parent_id);
+  link_child(parent_id, child_id, parent.first_child_id, parent.last_child_id);
 }
 
 void ElementRegistry::append_column(const ElementIdentifier table_id,
@@ -160,18 +169,8 @@ void ElementRegistry::append_column(const ElementIdentifier table_id,
         "DocumentElementRegistry::append_column: child already has a parent");
   }
 
-  const ElementIdentifier previous_sibling_id =
-      table_element_at(table_id).last_column_id;
-
-  element_at(column_id).parent_id = table_id;
-  element_at(column_id).previous_sibling_id = previous_sibling_id;
-
-  if (table_element_at(table_id).first_column_id == null_element_id) {
-    table_element_at(table_id).first_column_id = column_id;
-  } else {
-    element_at(previous_sibling_id).next_sibling_id = column_id;
-  }
-  table_element_at(table_id).last_column_id = column_id;
+  Table &table = table_element_at(table_id);
+  link_child(table_id, column_id, table.first_column_id, table.last_column_id);
 }
 
 void ElementRegistry::append_shape(const ElementIdentifier sheet_id,
@@ -183,18 +182,8 @@ void ElementRegistry::append_shape(const ElementIdentifier sheet_id,
         "DocumentElementRegistry::append_shape: child already has a parent");
   }
 
-  const ElementIdentifier previous_sibling_id =
-      sheet_element_at(sheet_id).last_shape_id;
-
-  element_at(shape_id).parent_id = sheet_id;
-  element_at(shape_id).previous_sibling_id = previous_sibling_id;
-
-  if (sheet_element_at(sheet_id).first_shape_id == null_element_id) {
-    sheet_element_at(sheet_id).first_shape_id = shape_id;
-  } else {
-    element_at(previous_sibling_id).next_sibling_id = shape_id;
-  }
-  sheet_element_at(sheet_id).last_shape_id = shape_id;
+  Sheet &sheet = sheet_element_at(sheet_id);
+  link_child(sheet_id, shape_id, sheet.first_shape_id, sheet.last_shape_id);
 }
 
 void ElementRegistry::append_sheet_cell(const ElementIdentifier sheet_id,

--- a/src/odr/internal/odf/odf_element_registry.hpp
+++ b/src/odr/internal/odf/odf_element_registry.hpp
@@ -124,6 +124,10 @@ private:
   std::unordered_map<ElementIdentifier, Sheet> m_sheets;
   std::unordered_map<ElementIdentifier, SheetCell> m_sheet_cells;
 
+  /// Links `child_id` as the last child of the chain `first_id`/`last_id`.
+  void link_child(ElementIdentifier parent_id, ElementIdentifier child_id,
+                  ElementIdentifier &first_id, ElementIdentifier &last_id);
+
   void check_element_id(ElementIdentifier id) const;
   void check_text_id(ElementIdentifier id) const;
   void check_table_id(ElementIdentifier id) const;

--- a/src/odr/internal/odf/odf_manifest.hpp
+++ b/src/odr/internal/odf/odf_manifest.hpp
@@ -40,8 +40,8 @@ struct Manifest {
       std::string salt;
 
       // argon2 specific
-      std::uint64_t argon2_memory;
-      std::uint64_t argon2_lanes;
+      std::uint64_t argon2_memory{0};
+      std::uint64_t argon2_lanes{0};
     };
     struct StartKeyGeneration {
       ChecksumType type{ChecksumType::UNKNOWN};

--- a/src/odr/internal/odf/odf_meta.cpp
+++ b/src/odr/internal/odf/odf_meta.cpp
@@ -17,7 +17,7 @@ namespace odr::internal::odf {
 
 namespace {
 
-bool lookup_file_type(const std::string &mimetype_in, FileType &file_type,
+void lookup_file_type(const std::string &mimetype_in, FileType &file_type,
                       std::string_view &mimetype_out) {
   // https://www.openoffice.org/framework/documentation/mimetypes/mimetypes.html
   static const std::unordered_map<std::string, FileType> MIME_TYPES = {
@@ -60,7 +60,6 @@ bool lookup_file_type(const std::string &mimetype_in, FileType &file_type,
     file_type = FileType::unknown;
     mimetype_out = "application/octet-stream";
   }
-  return false;
 }
 
 } // namespace

--- a/src/odr/internal/odf/odf_parser.cpp
+++ b/src/odr/internal/odf/odf_parser.cpp
@@ -3,6 +3,7 @@
 #include <odr/internal/common/table_cursor.hpp>
 #include <odr/internal/odf/odf_element_registry.hpp>
 
+#include <algorithm>
 #include <unordered_map>
 
 #include <pugixml.hpp>
@@ -97,8 +98,10 @@ parse_table_row(ElementRegistry &registry, const pugi::xml_node node) {
 
   for (const pugi::xml_node cell_node : node.children()) {
     // TODO log warning if repeated
-    auto [cell, _] = parse_any_element_tree(registry, cell_node);
-    registry.append_child(element_id, cell);
+    if (auto [cell_id, _] = parse_any_element_tree(registry, cell_node);
+        cell_id != null_element_id) {
+      registry.append_child(element_id, cell_id);
+    }
   }
 
   return {element_id, node.next_sibling()};
@@ -133,6 +136,13 @@ parse_table(ElementRegistry &registry, const pugi::xml_node node) {
   return {element_id, node.next_sibling()};
 }
 
+/// Empty: no content and no span beyond the one cell.
+bool is_cell_empty(const pugi::xml_node cell_node) {
+  return !cell_node.first_child() &&
+         cell_node.attribute("table:number-columns-spanned").as_uint(1) <= 1 &&
+         cell_node.attribute("table:number-rows-spanned").as_uint(1) <= 1;
+}
+
 std::tuple<ElementIdentifier, pugi::xml_node>
 parse_sheet(ElementRegistry &registry, const pugi::xml_node node) {
   if (!node) {
@@ -162,31 +172,10 @@ parse_sheet(ElementRegistry &registry, const pugi::xml_node node) {
     sheet.register_row(cursor.row(), rows_repeated, row_node);
 
     // TODO covered cells
-    bool row_empty = true;
-    for (const pugi::xml_node cell_node :
-         row_node.children("table:table-cell")) {
-      const std::uint32_t colspan =
-          cell_node.attribute("table:number-columns-spanned").as_uint(1);
-      const std::uint32_t rowspan =
-          cell_node.attribute("table:number-rows-spanned").as_uint(1);
-
-      bool cell_empty = true;
-      if (cell_node.first_child()) {
-        cell_empty = false;
-      }
-      if (colspan > 1 || rowspan > 1) {
-        cell_empty = false;
-      }
-
-      if (!cell_empty) {
-        row_empty = false;
-        break;
-      }
-    }
+    const bool row_empty = std::ranges::all_of(
+        row_node.children("table:table-cell"), is_cell_empty);
 
     if (row_empty) {
-      sheet.register_row(cursor.row(), rows_repeated, row_node);
-
       // TODO covered cells
       for (const pugi::xml_node cell_node :
            row_node.children("table:table-cell")) {
@@ -222,15 +211,7 @@ parse_sheet(ElementRegistry &registry, const pugi::xml_node node) {
             cell_node.attribute("table:number-rows-spanned").as_uint(1);
         const bool is_repeated = columns_repeated > 1 || rows_repeated > 1;
 
-        bool cell_empty = true;
-        if (cell_node.first_child()) {
-          cell_empty = false;
-        }
-        if (colspan > 1 || rowspan > 1) {
-          cell_empty = false;
-        }
-
-        if (cell_empty) {
+        if (is_cell_empty(cell_node)) {
           sheet.register_cell(cursor.column(), cursor.row(), columns_repeated,
                               1, cell_node, null_element_id);
 

--- a/src/odr/internal/odf/odf_style.cpp
+++ b/src/odr/internal/odf/odf_style.cpp
@@ -24,7 +24,6 @@ std::optional<Measure> read_measure(const pugi::xml_attribute attribute) {
     try {
       return Measure(attribute.value());
     } catch (...) { // NOLINT(bugprone-empty-catch)
-      // an unparsable measure yields nullopt
       // TODO log
     }
   }
@@ -168,7 +167,7 @@ std::optional<Color> read_color(const pugi::xml_attribute attribute) {
     return {};
   }
   const char *value = attribute.value();
-  if (std::strcmp("transparent", attribute.value()) == 0) {
+  if (std::strcmp("transparent", value) == 0) {
     return {}; // TODO use alpha
   }
   if (value[0] == '#') {
@@ -239,29 +238,29 @@ Style::Style() = default;
 
 Style::Style(const StyleRegistry *registry, std::string family,
              const pugi::xml_node node)
-    : m_registry{registry}, m_name{std::move(family)}, m_node{node} {
-  resolve_style_();
+    : m_name{std::move(family)}, m_node{node} {
+  resolve_style_(registry);
 }
 
 Style::Style(const StyleRegistry *registry, std::string name,
-             const pugi::xml_node node, Style *parent, Style *family)
-    : m_registry{registry}, m_name{std::move(name)}, m_node{node},
-      m_parent{parent}, m_family{family} {
-  if (const Style *copy_from = m_parent != nullptr ? m_parent : m_family;
+             const pugi::xml_node node, const Style *parent,
+             const Style *family)
+    : m_name{std::move(name)}, m_node{node} {
+  if (const Style *copy_from = parent != nullptr ? parent : family;
       copy_from != nullptr) {
     m_resolved = copy_from->m_resolved;
   }
 
-  resolve_style_();
+  resolve_style_(registry);
 }
 
 std::string Style::name() const { return m_name; }
 
 const ResolvedStyle &Style::resolved() const { return m_resolved; }
 
-void Style::resolve_style_() {
+void Style::resolve_style_(const StyleRegistry *registry) {
   // TODO use override?
-  resolve_text_style_(m_registry, m_node, m_resolved.text_style);
+  resolve_text_style_(registry, m_node, m_resolved.text_style);
   resolve_paragraph_style_(m_node, m_resolved.paragraph_style);
   resolve_table_style_(m_node, m_resolved.table_style);
   resolve_table_column_style_(m_node, m_resolved.table_column_style);
@@ -581,8 +580,11 @@ Style *StyleRegistry::generate_default_style_(const std::string &name,
 
 Style *StyleRegistry::generate_style_(const std::string &name,
                                       const pugi::xml_node node) {
-  auto &&style = m_styles[name];
-  if (style != nullptr) {
+  // a null entry means the style is still resolving, i.e. the parent chain is
+  // cyclic; break it rather than recurse forever
+  const auto [style_it, inserted] = m_styles.try_emplace(name);
+  std::unique_ptr<Style> &style = style_it->second;
+  if (!inserted) {
     return style.get();
   }
 
@@ -590,8 +592,9 @@ Style *StyleRegistry::generate_style_(const std::string &name,
   if (const pugi::xml_attribute parent_attr =
           node.attribute("style:parent-style-name");
       parent_attr) {
-    if (const pugi::xml_node parent_node = m_index_style[parent_attr.value()]) {
-      parent = generate_style_(parent_attr.value(), parent_node);
+    if (const auto parent_it = m_index_style.find(parent_attr.value());
+        parent_it != std::end(m_index_style)) {
+      parent = generate_style_(parent_attr.value(), parent_it->second);
     }
   }
 

--- a/src/odr/internal/odf/odf_style.hpp
+++ b/src/odr/internal/odf/odf_style.hpp
@@ -31,24 +31,22 @@ class Style final {
 public:
   Style();
   Style(const StyleRegistry *registry, std::string family, pugi::xml_node node);
+  /// `parent`/`family` are the already resolved bases to copy from; neither is
+  /// retained.
   Style(const StyleRegistry *registry, std::string name, pugi::xml_node node,
-        Style *parent, Style *family);
+        const Style *parent, const Style *family);
 
   [[nodiscard]] std::string name() const;
 
   [[nodiscard]] const ResolvedStyle &resolved() const;
 
 private:
-  const StyleRegistry *m_registry{nullptr};
-
   std::string m_name;
   pugi::xml_node m_node;
-  Style *m_parent{nullptr};
-  Style *m_family{nullptr};
 
   ResolvedStyle m_resolved;
 
-  void resolve_style_();
+  void resolve_style_(const StyleRegistry *registry);
 
   static void resolve_text_style_(const StyleRegistry *registry,
                                   pugi::xml_node node, TextStyle &result);

--- a/src/odr/internal/oldms/presentation/ppt_io.cpp
+++ b/src/odr/internal/oldms/presentation/ppt_io.cpp
@@ -33,32 +33,6 @@ std::uint32_t presentation::read_u32(std::istream &in) {
   return util::byte_stream::read<std::uint32_t>(in);
 }
 
-std::string presentation::read_text_chars(std::istream &in,
-                                          const std::uint32_t rec_len) {
-  const std::size_t count = rec_len / 2;
-  std::u16string buffer;
-  buffer.resize(count);
-  in.read(reinterpret_cast<char *>(buffer.data()),
-          static_cast<std::streamsize>(count * sizeof(char16_t)));
-  return util::string::u16string_to_string(buffer);
-}
-
-std::string presentation::read_text_bytes(std::istream &in,
-                                          const std::uint32_t rec_len) {
-  static constexpr auto eof = std::istream::traits_type::eof();
-
-  std::u16string buffer;
-  buffer.reserve(rec_len);
-  for (std::uint32_t i = 0; i < rec_len; ++i) {
-    const auto c = in.get();
-    if (c == eof) {
-      break;
-    }
-    buffer.push_back(static_cast<std::uint8_t>(c));
-  }
-  return util::string::u16string_to_string(buffer);
-}
-
 presentation::Anchor
 presentation::read_client_anchor(std::istream &in,
                                  const std::uint32_t rec_len) {
@@ -83,10 +57,15 @@ presentation::read_client_anchor(std::istream &in,
 
 std::u16string presentation::read_raw_text_chars(std::istream &in,
                                                  const std::uint32_t rec_len) {
+  // recLen MUST be even ([MS-PPT] 2.9.42); an odd one would leave the caller's
+  // record cursor one byte behind the stream.
+  if (rec_len % 2 != 0) {
+    throw std::runtime_error("ppt: odd TextCharsAtom length " +
+                             std::to_string(rec_len));
+  }
   std::u16string buffer;
   buffer.resize(rec_len / 2);
-  in.read(reinterpret_cast<char *>(buffer.data()),
-          static_cast<std::streamsize>(buffer.size() * sizeof(char16_t)));
+  util::byte_stream::read(in, reinterpret_cast<char *>(buffer.data()), rec_len);
   return buffer;
 }
 

--- a/src/odr/internal/oldms/presentation/ppt_io.hpp
+++ b/src/odr/internal/oldms/presentation/ppt_io.hpp
@@ -9,30 +9,22 @@
 
 namespace odr::internal::oldms::presentation {
 
-// NOTE: these helpers read multi-byte values in host byte order, so they are
-// correct only on little-endian hosts. Handling big-endian is a future task.
+// These helpers read multi-byte values in host byte order — little-endian
+// hosts only, see oldms/AGENTS.md.
 
 RecordHeader read_record_header(std::istream &in);
 CurrentUserAtomHead read_current_user_atom_head(std::istream &in);
 UserEditAtomBody read_user_edit_atom_body(std::istream &in);
 
-/// Reads a raw unsigned 32-bit integer (an offset/identifier). See the
-/// byte-order note above.
+/// Reads a raw unsigned 32-bit integer (an offset/identifier).
 std::uint32_t read_u32(std::istream &in);
-
-/// Decodes a TextCharsAtom body (rec_len bytes, two per UTF-16 code unit) to
-/// UTF-8. See the byte-order note above.
-std::string read_text_chars(std::istream &in, std::uint32_t rec_len);
-
-/// Decodes a TextBytesAtom body (rec_len bytes, one byte per character, each in
-/// the range 0x00-0xFF) to UTF-8.
-std::string read_text_bytes(std::istream &in, std::uint32_t rec_len);
 
 /// Reads an OfficeArtClientAnchor into {top, left, right, bottom}: rec_len 8 →
 /// SmallRectStruct (int16), 16 → RectStruct (int32). Throws on any other.
 Anchor read_client_anchor(std::istream &in, std::uint32_t rec_len);
 
-/// Reads a TextCharsAtom body without decoding (rec_len / 2 UTF-16 units).
+/// Reads a TextCharsAtom body without decoding (rec_len / 2 UTF-16 units);
+/// throws unless rec_len is even ([MS-PPT] 2.9.42).
 std::u16string read_raw_text_chars(std::istream &in, std::uint32_t rec_len);
 
 /// Reads a TextBytesAtom body without decoding (rec_len characters).

--- a/src/odr/internal/oldms/presentation/ppt_parser.cpp
+++ b/src/odr/internal/oldms/presentation/ppt_parser.cpp
@@ -33,10 +33,9 @@ constexpr char line_break_mark = '\x0B';
 /// The control characters `build_paragraphs` splits on.
 constexpr std::array<char, 2> control_marks = {paragraph_mark, line_break_mark};
 
-/// Sequentially walks a container's child records — no tellg/absolute offsets.
-/// Construct with the stream at the container body. next() returns the next
-/// child header with the stream at its body; read up to recLen bytes and report
-/// them via consume(), the rest is skipped. Advances exactly container.recLen.
+/// Sequentially walks a container's child records; the stream must be at the
+/// container body. next() leaves the stream at the child's body — read up to
+/// recLen bytes and report them via consume(), the rest is skipped.
 class ChildCursor {
 public:
   ChildCursor(std::istream &in, const RecordHeader &container)
@@ -73,15 +72,6 @@ public:
       m_in->ignore(m_body);
       m_remaining -= static_cast<std::int64_t>(m_body);
       m_body = 0;
-    }
-  }
-
-  /// Skips any trailing bytes so the cursor advances by exactly
-  /// container.recLen.
-  void finish() {
-    if (m_remaining > 0) {
-      m_in->ignore(m_remaining);
-      m_remaining = 0;
     }
   }
 
@@ -137,8 +127,6 @@ std::string clean_text(const std::string &in) {
   out.reserve(in.size());
   for (const char c : in) {
     const auto uc = static_cast<std::uint8_t>(c);
-    // Keep tab and any non-control byte (>= 0x20, including UTF-8 lead and
-    // continuation bytes); drop the remaining control characters.
     if (uc < 0x20 && c != '\x09') {
       continue;
     }
@@ -250,9 +238,8 @@ struct Shape final {
 };
 
 /// Builds the paragraph/span/text subtree of one shape's text under
-/// `parent_id`. Paragraphs open lazily (the trailing paragraph mark adds no
-/// empty paragraph); each span and paragraph stores its style so empty
-/// paragraphs keep their height.
+/// `parent_id`; paragraphs open lazily, so the trailing paragraph mark adds no
+/// empty one.
 void build_paragraphs(ElementRegistry &registry,
                       const ElementIdentifier parent_id,
                       const StyledText &shape_text) {
@@ -441,10 +428,8 @@ std::vector<Shape>
 read_slide_shapes(std::istream &in, const RecordHeader &slide,
                   const std::vector<StyledText> &outline_texts,
                   StyleContext &context) {
-  // SlideContainer → DrawingContainer → OfficeArtDgContainer (mandatory).
   // The drawing holds a mandatory OfficeArtSpgrContainer plus optionally a
-  // direct shape not in any group ([MS-ODRAW] 2.2.13); both are read in
-  // stream (z) order.
+  // shape not in any group ([MS-ODRAW] 2.2.13), read in stream (z) order.
   const RecordHeader drawing = require_child(in, slide, RT_Drawing);
   const RecordHeader dg = require_child(in, drawing, RT_OfficeArtDgContainer);
 
@@ -526,9 +511,8 @@ SlideListText read_slide_list_text(std::istream &in,
   constexpr std::uint32_t persist_ref_size = sizeof(std::uint32_t);
 
   SlideListText result;
-  // Outline texts of the slide currently being read; valid until reassigned at
-  // the next SlidePersistAtom (unordered_map keeps references stable on
-  // insert).
+  // Outline texts of the slide being read; unordered_map keeps the pointer
+  // valid across inserts.
   std::vector<StyledText> *current = nullptr;
   PendingText pending;
   const auto flush = [&](const std::vector<TextCFRun> &runs) {
@@ -655,9 +639,9 @@ std::vector<BlipSlot> read_blip_store(std::istream &in,
       }
     } else if (child->recType == RT_OfficeArtBlipJPEG ||
                child->recType == RT_OfficeArtBlipPNG) {
-      // A BLIP directly in the store occupies a slot of its own; rewind is
-      // impossible on this stream, so re-parse from the header we just read.
-      // The header was already consumed by the cursor; read body inline.
+      // A BLIP directly in the store occupies a slot of its own; its header is
+      // already consumed, so the body is read here rather than via
+      // read_blip_record.
       const std::uint32_t prefix = blip_prefix_size(*child);
       if (child->recLen < prefix) {
         throw std::runtime_error("ppt: truncated BLIP record");
@@ -712,13 +696,10 @@ std::vector<std::string> read_font_collection(std::istream &in,
   return fonts;
 }
 
-/// Resolves the presentation slides via the [MS-PPT] reading algorithm (the
-/// only spec-defined path): the "Current User" stream points at the newest
-/// UserEditAtom, whose chain builds the persist directory, which resolves the
-/// live DocumentContainer and each SlideContainer — so slides come out in order
-/// from the live records, ignoring stale copies left by incremental saves.
-/// Malformed records throw. Returns each slide's shapes in z order; the
-/// shapes' styles accumulate in `context`.
+/// Resolves the presentation's slides via the [MS-PPT] 2.1.2 reading
+/// algorithm: "Current User" → UserEditAtom chain → persist directory → the
+/// live DocumentContainer and each SlideContainer. Returns each slide's shapes
+/// in z order; their styles accumulate in `context`.
 std::vector<std::vector<Shape>>
 collect_slides(std::istream &current_user, std::istream &document,
                const abstract::ReadableFilesystem &files,
@@ -752,8 +733,8 @@ collect_slides(std::istream &current_user, std::istream &document,
         read_header(document, RT_PersistDirectoryAtom);
     read_persist_directory(document, dir_header, directory);
 
-    // offsetLastEdit MUST strictly decrease (0 ends the chain); a
-    // non-decreasing value is a malformed/looping chain.
+    // offsetLastEdit MUST strictly decrease (0 ends the chain), so this also
+    // breaks a looping chain.
     if (edit.offsetLastEdit != 0 && edit.offsetLastEdit >= edit_offset) {
       throw std::runtime_error("ppt: non-decreasing UserEditAtom chain");
     }

--- a/src/odr/internal/oldms/presentation/ppt_structs.hpp
+++ b/src/odr/internal/oldms/presentation/ppt_structs.hpp
@@ -5,10 +5,8 @@
 
 namespace odr::internal::oldms::presentation {
 
-// Filled by copying file bytes straight in (see ppt_io), so multi-byte fields
-// use host byte order — correct only on little-endian hosts (see ppt_io.hpp).
-// Bit-fields additionally assume LSB-first allocation, which all supported
-// compilers use on little-endian targets (shared oldms/ assumption).
+// Filled by copying file bytes straight in (see ppt_io): little-endian,
+// LSB-first hosts only — see oldms/AGENTS.md.
 
 /// Record types relevant to text extraction. See [MS-PPT] 2.13.24 RecordType.
 enum RecordType : std::uint16_t {

--- a/src/odr/internal/oldms/spreadsheet/xls_io.cpp
+++ b/src/odr/internal/oldms/spreadsheet/xls_io.cpp
@@ -5,7 +5,9 @@
 #include <odr/internal/util/string_util.hpp>
 
 #include <algorithm>
+#include <array>
 #include <cmath>
+#include <cstdio>
 #include <istream>
 #include <stdexcept>
 
@@ -174,9 +176,9 @@ std::string spreadsheet::format_number(const double value) {
     return "NaN";
   }
 
-  char buffer[32];
-  std::snprintf(buffer, sizeof(buffer), "%.15g", value);
-  return buffer;
+  std::array<char, 32> buffer{};
+  std::snprintf(buffer.data(), buffer.size(), "%.15g", value);
+  return buffer.data();
 }
 
 std::string spreadsheet::error_code_string(const std::uint8_t error) {

--- a/src/odr/internal/oldms/spreadsheet/xls_io.hpp
+++ b/src/odr/internal/oldms/spreadsheet/xls_io.hpp
@@ -8,17 +8,13 @@
 
 namespace odr::internal::oldms::spreadsheet {
 
-// NOTE: like the sibling .doc/.ppt modules, multi-byte values are read in host
-// byte order, so this is correct only on little-endian hosts.
+// Multi-byte values are read in host byte order — little-endian hosts only,
+// see oldms/AGENTS.md.
 
-/// Sequential reader over the flat BIFF8 record stream ([MS-XLS] 2.1.4).
-///
-/// `next_record` advances to the next record header (skipping any unread body
-/// bytes). The `read_*` body accessors hop transparently into a following
-/// CONTINUE record when the current body is exhausted — required for the SST
-/// and String records, whose payload may be split across CONTINUE records —
-/// and throw if more bytes are requested but the next record is not a
-/// CONTINUE.
+/// Sequential reader over the flat BIFF8 record stream ([MS-XLS] 2.1.4). The
+/// `read_*` body accessors hop transparently into a following CONTINUE record
+/// when the current body is exhausted (the SST and String payloads may split
+/// across them), and throw if that next record is not a CONTINUE.
 class BiffReader final {
 public:
   explicit BiffReader(std::istream &in);

--- a/src/odr/internal/oldms/spreadsheet/xls_structs.hpp
+++ b/src/odr/internal/oldms/spreadsheet/xls_structs.hpp
@@ -7,10 +7,8 @@
 
 namespace odr::internal::oldms::spreadsheet {
 
-// Filled by copying file bytes straight in (see xls_io), so multi-byte fields
-// use host byte order — correct only on little-endian hosts (see xls_io.hpp).
-// Bit-fields additionally assume LSB-first allocation, which all supported
-// compilers use on little-endian targets (shared oldms/ assumption).
+// Filled by copying file bytes straight in (see xls_io): little-endian,
+// LSB-first hosts only — see oldms/AGENTS.md.
 
 /// BIFF8 record type values handled here ([MS-XLS] 2.3 Record Enumeration).
 enum BiffRecordType : std::uint16_t {

--- a/src/odr/internal/oldms/text/doc_helper.cpp
+++ b/src/odr/internal/oldms/text/doc_helper.cpp
@@ -65,11 +65,16 @@ text::CharacterIndex text::read_character_index(std::istream &in) {
     std::string plcPcd = util::stream::read(in, lcb);
     const PlcPcdMap plc_pcd_map(plcPcd.data(), plcPcd.size());
 
-    for (std::uint32_t i = 0; i < plc_pcd_map.n(); ++i) {
-      const bool is_compressed = plc_pcd_map.aData(i).fc.fCompressed != 0;
-      const std::size_t data_offset = is_compressed
-                                          ? plc_pcd_map.aData(i).fc.fc / 2
-                                          : plc_pcd_map.aData(i).fc.fc;
+    const std::uint32_t count = plc_pcd_map.n();
+    for (std::uint32_t i = 0; i < count; ++i) {
+      // aCp is strictly ascending ([MS-DOC] 2.8.35); otherwise the piece
+      // length below would wrap around.
+      if (plc_pcd_map.aCP(i + 1) <= plc_pcd_map.aCP(i)) {
+        throw std::runtime_error("doc: PlcPcd CPs must be ascending");
+      }
+      const FcCompressed fc = plc_pcd_map.aData(i).fc;
+      const bool is_compressed = fc.fCompressed != 0;
+      const std::size_t data_offset = is_compressed ? fc.fc / 2 : fc.fc;
       const std::size_t length_cp = plc_pcd_map.aCP(i + 1) - plc_pcd_map.aCP(i);
       result.append(plc_pcd_map.aCP(i), length_cp, data_offset, is_compressed);
     }
@@ -110,10 +115,10 @@ text::read_character_runs(std::istream &document_stream,
     return it->second;
   };
 
-  for (std::uint32_t i = 0; i < plc.n(); ++i) {
-    // A 512-byte ChpxFkp page ([MS-DOC] 2.9.33) at pn * 512: crun in the last
-    // byte, crun+1 rgfc offsets, crun rgb bytes; rgb[j] * 2 locates the Chpx
-    // within the page, 0 means default properties.
+  // A ChpxFkp page ([MS-DOC] 2.9.33) is 512 bytes at pn * 512; rgb[j] * 2
+  // locates the run's Chpx within it, 0 meaning default properties.
+  const std::uint32_t page_count = plc.n();
+  for (std::uint32_t i = 0; i < page_count; ++i) {
     std::array<char, 512> page;
     document_stream.seekg(static_cast<std::streamoff>(plc.aData(i).pn) * 512);
     document_stream.read(page.data(), page.size());

--- a/src/odr/internal/oldms/text/doc_io.cpp
+++ b/src/odr/internal/oldms/text/doc_io.cpp
@@ -35,9 +35,7 @@ auto type_dispatch_FibRgFcLcb(const std::uint16_t nFib, const F &f) {
     return f(TypeTag<FibRgFcLcb2007>{});
   }
   default:
-    // Newer-than-2007 FIBs only append entries; the fcClx we read lives in the
-    // FibRgFcLcb97 base, so reuse the newest modelled layout. Older/unknown
-    // fail.
+    // Newer FIBs only append entries, so the newest modelled layout fits.
     if (nFib > nFib2007) {
       return f(TypeTag<FibRgFcLcb2007>{});
     }
@@ -53,52 +51,6 @@ namespace odr::internal::oldms {
 
 void text::read(std::istream &in, FibBase &out) {
   util::byte_stream::read(in, out);
-}
-
-void text::read(std::istream &in, FibRgFcLcb97 &out) {
-  util::byte_stream::read(in, out);
-}
-
-void text::read(std::istream &in, FibRgFcLcb2000 &out) {
-  util::byte_stream::read(in, out);
-}
-
-void text::read(std::istream &in, FibRgFcLcb2002 &out) {
-  util::byte_stream::read(in, out);
-}
-
-void text::read(std::istream &in, FibRgFcLcb2003 &out) {
-  util::byte_stream::read(in, out);
-}
-
-void text::read(std::istream &in, FibRgFcLcb2007 &out) {
-  util::byte_stream::read(in, out);
-}
-
-std::size_t text::determine_size_Fib(std::istream &in) {
-  std::size_t result = 0;
-
-  const auto read_uint16_t = [&] {
-    const auto value = util::byte_stream::read<std::uint16_t>(in);
-    result += sizeof(std::uint16_t);
-    return value;
-  };
-  const auto ignore = [&](const std::size_t count) {
-    in.ignore(static_cast<std::streamsize>(count));
-    result += count;
-  };
-
-  ignore(sizeof(FibBase));
-  const std::uint16_t csw = read_uint16_t();
-  ignore(static_cast<std::size_t>(csw) * 2);
-  const std::uint16_t cslw = read_uint16_t();
-  ignore(static_cast<std::size_t>(cslw) * 4);
-  const std::uint16_t cbRgFcLcb = read_uint16_t();
-  ignore(static_cast<std::size_t>(cbRgFcLcb) * 8);
-  const std::uint16_t cswNew = read_uint16_t();
-  ignore(static_cast<std::size_t>(cswNew) * 2);
-
-  return result;
 }
 
 void text::read(std::istream &in, ParsedFib &out) {
@@ -122,8 +74,7 @@ void text::read(std::istream &in, ParsedFib &out) {
   in.ignore(static_cast<std::streamsize>(
       static_cast<std::size_t>(out.cslw) * 4 - sizeof(out.fibRgLw)));
 
-  // ccpText ([MS-DOC] 2.5.5) MUST be >= 0; reject a negative value as
-  // malformed.
+  // ccpText MUST be >= 0 ([MS-DOC] 2.5.5).
   if (out.ccpText() < 0) {
     throw std::runtime_error("Unexpected negative Fib.ccpText: " +
                              std::to_string(out.ccpText()));
@@ -146,9 +97,7 @@ void text::read(std::istream &in, ParsedFib &out) {
       nFib, [&]<typename T>(const T) -> std::unique_ptr<FibRgFcLcb97> {
         using FibRgFcLcbType = T::type;
         auto result = std::make_unique<FibRgFcLcbType>();
-        // Copy only what fits: surplus entries of a newer FIB are ignored, a
-        // shorter one leaves the rest zero-initialised. fcClx is always
-        // covered.
+        // Clamped: surplus entries are dropped, a short block stays zeroed.
         const std::size_t copy =
             std::min<std::size_t>(sizeof(FibRgFcLcbType),
                                   static_cast<std::size_t>(out.cbRgFcLcb) * 8);
@@ -179,17 +128,6 @@ void text::read(std::istream &in, ParsedFibRgCswNew &out) {
     throw std::runtime_error("Unsupported nFibNew value: " +
                              std::to_string(out.nFibNew));
   }
-}
-
-std::unique_ptr<text::FibRgFcLcb97>
-text::read_FibRgFcLcb(std::istream &in, const std::uint16_t nFib) {
-  return type_dispatch_FibRgFcLcb(
-      nFib, [&in]<typename T>(const T) -> std::unique_ptr<FibRgFcLcb97> {
-        using FibRgFcLcbType = T::type;
-        auto result = std::make_unique<FibRgFcLcbType>();
-        read(in, *result);
-        return result;
-      });
 }
 
 void text::read_Clx(std::istream &in, const HandlePrc &handle_Prc,
@@ -246,8 +184,7 @@ std::string text::read_string_compressed(std::istream &in,
         uncompressed.has_value()) {
       util::string::append_c32(*uncompressed, result);
     } else {
-      // Unmapped byte ([MS-DOC] 2.4.1 step 6): denotes code point U+00XX, so
-      // UTF-8-encode it (emitting the raw byte would be invalid UTF-8 >= 0xA0).
+      // An unmapped byte denotes code point U+00XX ([MS-DOC] 2.4.1 step 6).
       util::string::append_c32(static_cast<char32_t>(ci), result);
     }
   }
@@ -260,8 +197,8 @@ std::u16string text::read_string_uncompressed(std::istream &in,
   std::u16string result;
   result.resize(length_cp);
 
-  in.read(reinterpret_cast<char *>(result.data()),
-          static_cast<std::streamsize>(length_cp * sizeof(char16_t)));
+  util::byte_stream::read(in, reinterpret_cast<char *>(result.data()),
+                          length_cp * sizeof(char16_t));
 
   return result;
 }

--- a/src/odr/internal/oldms/text/doc_io.hpp
+++ b/src/odr/internal/oldms/text/doc_io.hpp
@@ -11,16 +11,6 @@
 namespace odr::internal::oldms::text {
 
 void read(std::istream &in, FibBase &out);
-void read(std::istream &in, FibRgFcLcb97 &out);
-void read(std::istream &in, FibRgFcLcb2000 &out);
-void read(std::istream &in, FibRgFcLcb2002 &out);
-void read(std::istream &in, FibRgFcLcb2003 &out);
-void read(std::istream &in, FibRgFcLcb2007 &out);
-
-std::size_t determine_size_Fib(std::istream &in);
-
-std::unique_ptr<FibRgFcLcb97> read_FibRgFcLcb(std::istream &in,
-                                              std::uint16_t nFib);
 void read(std::istream &in, ParsedFibRgCswNew &out);
 void read(std::istream &in, ParsedFib &out);
 

--- a/src/odr/internal/oldms/text/doc_parser.cpp
+++ b/src/odr/internal/oldms/text/doc_parser.cpp
@@ -14,6 +14,7 @@
 #include <cstdint>
 #include <istream>
 #include <limits>
+#include <stdexcept>
 #include <string>
 #include <string_view>
 #include <vector>
@@ -29,12 +30,9 @@ constexpr char line_break_mark = '\x0B';
 // End-of-section / manual page break ([MS-DOC] 2.8.26); surfaced as page_break.
 constexpr char page_break_mark = '\x0C';
 
-// Drops anchor/control characters and resolves field codes, keeping only the
-// visible text. A field is 0x13 begin ... [0x14 separator] ... 0x15 end
-// ([MS-DOC] 2.8.25): the instruction (begin..separator) is hidden, the result
-// (separator..end) shown. A separator-less field is hidden entirely.
-// Stateful: a field can span style runs and paragraphs, so one cleaner
-// processes the whole body in order.
+/// Drops control/anchor characters and hides field instructions ([MS-DOC]
+/// 2.8.25). Stateful — a field can span style runs and paragraphs, so one
+/// cleaner must process the whole body in order.
 class TextCleaner {
 public:
   std::string clean(const std::string_view in) {
@@ -81,7 +79,6 @@ public:
       case '\x1F': // optional hyphen: drop
         break;
       default:
-        // Drop remaining control/anchor characters (< 0x20); keep the rest.
         if (static_cast<std::uint8_t>(c) >= 0x20) {
           out.push_back(c);
         }
@@ -165,17 +162,20 @@ ElementIdentifier text::parse_tree(ElementRegistry &registry,
   ParsedFib fib;
   read(*document_stream, fib);
 
-  const std::string tableStreamPath =
-      fib.base.fWhichTblStm == 1 ? "/1Table" : "/0Table";
-  const auto table_stream = files.open(AbsPath(tableStreamPath))->stream();
+  // The table stream ([MS-DOC] 1.4) is required; which one is in fWhichTblStm.
+  const auto table_file =
+      files.open(AbsPath(fib.base.fWhichTblStm == 1 ? "/1Table" : "/0Table"));
+  if (table_file == nullptr) {
+    throw std::runtime_error("doc: missing table stream");
+  }
+  const auto table_stream = table_file->stream();
 
-  // Font table; TextStyle::font_name points into the strings, which keep
-  // their buffers when the vector is moved into the registry below.
+  // TextStyle::font_name points into these strings, which keep their buffers
+  // when the vector is moved into the registry below.
   std::vector<std::string> font_names =
       read_font_names(*table_stream, fib.fibRgFcLcb->sttbfFfn);
 
-  // Direct character formatting ([MS-DOC] 2.4.6.2); Pcd.Prm modifications are
-  // not modelled.
+  // Direct character formatting only ([MS-DOC] 2.4.6.2).
   std::vector<TextStyle> styles{default_character_style()}; // index 0
   const CharacterRuns character_runs =
       read_character_runs(*document_stream, *table_stream,
@@ -189,10 +189,7 @@ ElementIdentifier text::parse_tree(ElementRegistry &registry,
   const std::vector<StyledRun> runs = decode_styled_runs(
       *document_stream, character_index, character_runs, ccp_text);
 
-  // Build the tree: paragraphs are opened lazily so the trailing guard
-  // paragraph mark does not produce an extra empty paragraph. Each paragraph
-  // and span stores its style index; empty paragraphs keep their height
-  // through the paragraph style.
+  // Paragraphs open lazily, so the trailing paragraph mark adds no empty one.
   TextCleaner cleaner;
   ElementIdentifier paragraph_id = null_element_id;
 

--- a/src/odr/internal/oldms/text/doc_structs.hpp
+++ b/src/odr/internal/oldms/text/doc_structs.hpp
@@ -9,10 +9,8 @@
 
 namespace odr::internal::oldms::text {
 
-// Filled by copying file bytes straight in (see doc_io), so multi-byte fields
-// use host byte order — correct only on little-endian hosts. Bit-fields
-// additionally assume LSB-first allocation, which all supported compilers use
-// on little-endian targets (shared oldms/ assumption).
+// Filled by copying file bytes straight in (see doc_io): little-endian,
+// LSB-first hosts only — see oldms/AGENTS.md.
 
 enum NFibValues : std::uint16_t {
   nFib97 = 0x00C1,
@@ -385,77 +383,49 @@ struct ParsedFib {
   std::uint16_t cswNew;
   std::optional<ParsedFibRgCswNew> fibRgCswNew;
 
-  // FibRgLw97.ccpText: count of CPs in the main document. It is the 4th 32-bit
-  // field (cbMac, reserved1, reserved2, ccpText), i.e. uint16 indices 6-7.
-  // Stored little-endian, consistent with the rest of this parser.
+  /// FibRgLw97.ccpText ([MS-DOC] 2.5.5), the 4th 32-bit field of fibRgLw.
   [[nodiscard]] std::int32_t ccpText() const {
-    // Assemble unsigned to avoid signed-shift overflow (UB) when the high word
-    // has the sign bit set; the caller validates the resulting sign.
+    // Assembled unsigned: a signed shift would be UB with the sign bit set.
     const std::uint32_t value = static_cast<std::uint32_t>(fibRgLw[6]) |
                                 (static_cast<std::uint32_t>(fibRgLw[7]) << 16);
     return static_cast<std::int32_t>(value);
   }
 };
 
-template <typename Derived, typename Data> class PlcBase {
+/// Zero-copy view over a PLC ([MS-DOC] 2.2.2): n+1 CPs followed by n data
+/// elements, over a buffer that must outlive the view.
+template <typename Data> class PlcMap {
 public:
-  static constexpr std::uint32_t cbData() { return sizeof(Data); }
+  PlcMap(const char *data, const std::size_t cbPlc)
+      : m_data(data), m_cbPlc(cbPlc) {}
 
+  /// Number of data elements; throws unless cbPlc yields a whole number.
   [[nodiscard]] std::uint32_t n() const {
-    return (self().cbPlc() - 4) / (4 + sizeof(Data));
-  }
-
-  [[nodiscard]] const std::uint32_t *aCP_ptr() const {
-    return reinterpret_cast<const std::uint32_t *>(self().data());
-  }
-
-  [[nodiscard]] const Data *aData_ptr() const {
-    return reinterpret_cast<const Data *>(self().data() + (n() + 1) * 4);
+    constexpr std::size_t stride = 4 + sizeof(Data);
+    if (m_cbPlc < 4 || (m_cbPlc - 4) % stride != 0) {
+      throw std::runtime_error("doc: malformed Plc size");
+    }
+    return static_cast<std::uint32_t>((m_cbPlc - 4) / stride);
   }
 
   [[nodiscard]] std::uint32_t aCP(const std::uint32_t i) const {
-    return aCP_ptr()[i];
+    return reinterpret_cast<const std::uint32_t *>(m_data)[i];
   }
 
   [[nodiscard]] Data aData(const std::uint32_t i) const {
-    return aData_ptr()[i];
+    return reinterpret_cast<const Data *>(m_data + (n() + 1) * 4)[i];
   }
 
 private:
-  [[nodiscard]] Derived &self() { return *static_cast<Derived *>(this); }
-  [[nodiscard]] const Derived &self() const {
-    return *static_cast<const Derived *>(this);
-  }
-};
-
-template <typename Derived> class PlcPcdBase : public PlcBase<Derived, Pcd> {};
-
-class PlcPcdMap : public PlcPcdBase<PlcPcdMap> {
-public:
-  PlcPcdMap(char *data, const std::size_t cbPlc)
-      : m_data(data), m_cbPlc(cbPlc) {}
-
-  [[nodiscard]] char *data() const { return m_data; }
-  [[nodiscard]] std::size_t cbPlc() const { return m_cbPlc; }
-
-private:
-  char *m_data{nullptr};
+  const char *m_data{nullptr};
   std::size_t m_cbPlc{0};
 };
 
-/// PlcBteChpx ([MS-DOC] 2.8.5): a PLC keyed by WordDocument-stream offsets
-/// (fc, not CP) whose data elements locate the ChpxFkp pages.
-class PlcBteChpxMap : public PlcBase<PlcBteChpxMap, PnFkpChpx> {
-public:
-  PlcBteChpxMap(char *data, const std::size_t cbPlc)
-      : m_data(data), m_cbPlc(cbPlc) {}
+/// PlcPcd ([MS-DOC] 2.8.35): the piece table, keyed by CP.
+using PlcPcdMap = PlcMap<Pcd>;
 
-  [[nodiscard]] char *data() const { return m_data; }
-  [[nodiscard]] std::size_t cbPlc() const { return m_cbPlc; }
-
-private:
-  char *m_data{nullptr};
-  std::size_t m_cbPlc{0};
-};
+/// PlcBteChpx ([MS-DOC] 2.8.5): keyed by WordDocument-stream offsets (fc, not
+/// CP); its data elements locate the ChpxFkp pages.
+using PlcBteChpxMap = PlcMap<PnFkpChpx>;
 
 } // namespace odr::internal::oldms::text

--- a/src/odr/internal/oldms/text/doc_style.cpp
+++ b/src/odr/internal/oldms/text/doc_style.cpp
@@ -82,9 +82,8 @@ text::apply_character_sprms(TextStyle style, const std::string_view grpprl,
     if (const std::int32_t fixed_size = sprm.operand_size(); fixed_size >= 0) {
       operand_size = static_cast<std::size_t>(fixed_size);
     } else {
-      // spra == 6: the first operand byte is the size of the remainder. The
-      // two SPRMs encoded differently (sprmTDefTable, sprmPChgTabs with
-      // cb == 0xFF) are not character properties and must not appear here.
+      // spra == 6: the first operand byte sizes the remainder. The two SPRMs
+      // encoded otherwise are not character properties ([MS-DOC] 2.2.7).
       if (at >= grpprl.size()) {
         throw std::runtime_error("doc: Prl operand overruns grpprl");
       }
@@ -133,8 +132,8 @@ text::apply_character_sprms(TextStyle style, const std::string_view grpprl,
       style.font_size = Measure(half_points / 2.0, DynamicUnit("pt"));
     } break;
     case sprmCRgFtc0: {
-      // SttbfFfn index ([MS-DOC] 2.6.1); with 0 entries the value MUST be 0
-      // and the (unmodelled) style-sheet default font applies — leave unset.
+      // SttbfFfn index ([MS-DOC] 2.6.1); with 0 entries it MUST be 0 and the
+      // unmodelled style-sheet default font applies.
       const auto ftc = static_cast<std::int16_t>(
           util::byte::from_little_endian<std::uint16_t>(operand));
       if (ftc < 0 || (font_names.empty() ? ftc != 0
@@ -192,8 +191,7 @@ std::vector<std::string> text::read_font_names(std::istream &table_stream,
     const auto ffn = util::byte_stream::read<FfnFixed>(table_stream);
     (void)ffn;
 
-    // xszFfn: null-terminated UTF-16 within the remaining bytes; an
-    // alternative name (xszAlt) may follow the terminator.
+    // xszFfn: null-terminated UTF-16; an alternative name may follow it.
     const std::size_t name_units = (cch_data - sizeof(FfnFixed)) / 2;
     std::u16string name = read_string_uncompressed(table_stream, name_units);
     if ((cch_data - sizeof(FfnFixed)) % 2 != 0) {

--- a/src/odr/internal/ooxml/ooxml_crypto.cpp
+++ b/src/odr/internal/ooxml/ooxml_crypto.cpp
@@ -10,8 +10,6 @@
 #include <stdexcept>
 #include <utility>
 
-namespace {} // namespace
-
 namespace odr::internal::ooxml::crypto {
 
 ECMA376Standard::ECMA376Standard(const EncryptionHeader &encryption_header,
@@ -29,11 +27,7 @@ ECMA376Standard::ECMA376Standard(const std::string &encryption_info) {
   offset += sizeof(standard_header);
 
   std::memcpy(&m_encryption_header, offset, sizeof(m_encryption_header));
-  const std::u16string csp_name_u16(
-      reinterpret_cast<const char16_t *>(offset + sizeof(m_encryption_header)));
-  // the CSP name field is parsed but currently unused
-  [[maybe_unused]] const std::string csp_name =
-      util::string::u16string_to_string(csp_name_u16);
+  // the trailing CSP name is skipped; it is not needed to derive the key
   offset += standard_header.encryption_header_size;
 
   std::memcpy(&m_encryption_verifier, offset, sizeof(m_encryption_verifier));
@@ -131,8 +125,7 @@ Util::Util(const std::string &encryption_info) {
       version_info.minor == 2) {
     impl = std::make_unique<ECMA376Standard>(encryption_info);
   } else {
-    // everything else (agile 4.4, extensible 3.3/4.3, and unknown variants) is
-    // unsupported
+    // agile (4.4), extensible (3.3/4.3) and unknown variants
     throw MsUnsupportedCryptoAlgorithm();
   }
 }

--- a/src/odr/internal/ooxml/ooxml_util.cpp
+++ b/src/odr/internal/ooxml/ooxml_util.cpp
@@ -10,6 +10,31 @@
 
 namespace odr::internal {
 
+namespace {
+
+// value readers shared by the `w:val`-node and the bare-attribute overloads
+
+bool line_from_value(const char *value) {
+  return std::strcmp("none", value) != 0 && std::strcmp("false", value) != 0 &&
+         std::strcmp("noStrike", value) != 0;
+}
+
+std::optional<FontWeight> font_weight_from_value(const char *value) {
+  if (std::strcmp("false", value) == 0 || std::strcmp("0", value) == 0) {
+    return FontWeight::normal;
+  }
+  return FontWeight::bold;
+}
+
+std::optional<FontStyle> font_style_from_value(const char *value) {
+  if (std::strcmp("false", value) == 0) {
+    return {};
+  }
+  return FontStyle::italic;
+}
+
+} // namespace
+
 std::optional<std::string>
 ooxml::read_string_attribute(const pugi::xml_attribute attribute) {
   if (!attribute) {
@@ -89,10 +114,8 @@ ooxml::read_pct_attribute(const pugi::xml_attribute attribute) {
     return {};
   }
 
-  // handle percentage which is not always a percentage for tables
-  // http://officeopenxml.com/WPtableWidth.php
-  // potentially this should be moved to a table parser
-
+  // a table width in "pct" is in fiftieths of a percent unless it carries a
+  // literal `%` — http://officeopenxml.com/WPtableWidth.php
   std::string val = attribute.value();
   util::string::trim_inplace(val);
 
@@ -128,24 +151,14 @@ bool ooxml::read_line_attribute(const pugi::xml_node node) {
   if (!node) {
     return false;
   }
-  if (const char *val = node.attribute("w:val").value();
-      std::strcmp("none", val) == 0 || std::strcmp("false", val) == 0 ||
-      std::strcmp("noStrike", val) == 0) {
-    return false;
-  }
-  return true;
+  return line_from_value(node.attribute("w:val").value());
 }
 
 bool ooxml::read_line_attribute(const pugi::xml_attribute attribute) {
   if (!attribute) {
     return false;
   }
-  if (const char *val = attribute.value(); std::strcmp("none", val) == 0 ||
-                                           std::strcmp("false", val) == 0 ||
-                                           std::strcmp("noStrike", val) == 0) {
-    return false;
-  }
-  return true;
+  return line_from_value(attribute.value());
 }
 
 std::optional<std::string>
@@ -169,11 +182,7 @@ ooxml::read_font_weight_attribute(const pugi::xml_node node) {
   if (!node) {
     return {};
   }
-  if (const char *val = node.attribute("w:val").value();
-      std::strcmp("false", val) == 0 || std::strcmp("0", val) == 0) {
-    return FontWeight::normal;
-  }
-  return FontWeight::bold;
+  return font_weight_from_value(node.attribute("w:val").value());
 }
 
 std::optional<FontWeight>
@@ -181,11 +190,7 @@ ooxml::read_font_weight_attribute(const pugi::xml_attribute attribute) {
   if (!attribute) {
     return {};
   }
-  if (const char *val = attribute.value();
-      std::strcmp("false", val) == 0 || std::strcmp("0", val) == 0) {
-    return FontWeight::normal;
-  }
-  return FontWeight::bold;
+  return font_weight_from_value(attribute.value());
 }
 
 std::optional<FontStyle>
@@ -193,11 +198,7 @@ ooxml::read_font_style_attribute(const pugi::xml_node node) {
   if (!node) {
     return {};
   }
-  if (const char *val = node.attribute("w:val").value();
-      std::strcmp("false", val) == 0) {
-    return {};
-  }
-  return FontStyle::italic;
+  return font_style_from_value(node.attribute("w:val").value());
 }
 
 std::optional<FontStyle>
@@ -205,10 +206,7 @@ ooxml::read_font_style_attribute(const pugi::xml_attribute attribute) {
   if (!attribute) {
     return {};
   }
-  if (const char *val = attribute.value(); std::strcmp("false", val) == 0) {
-    return {};
-  }
-  return FontStyle::italic;
+  return font_style_from_value(attribute.value());
 }
 
 std::optional<TextAlign>
@@ -259,11 +257,7 @@ std::optional<std::string> ooxml::read_border_node(const pugi::xml_node node) {
   }
   std::string result;
   result.append(size->to_string()).append(" ");
-  if (std::strcmp("none", val) == 0) {
-    result.append(node.attribute("w:val").value()).append(" ");
-  } else {
-    result.append("solid ");
-  }
+  result.append(std::strcmp("none", val) == 0 ? "none " : "solid ");
   if (const std::optional<Color> color =
           read_color_attribute(node.attribute("w:color"))) {
     result.append(html::color(*color));

--- a/src/odr/internal/ooxml/ooxml_util.hpp
+++ b/src/odr/internal/ooxml/ooxml_util.hpp
@@ -45,8 +45,6 @@ std::optional<TextAlign> read_text_align_attribute(pugi::xml_attribute);
 std::optional<VerticalAlign> read_vertical_align_attribute(pugi::xml_attribute);
 std::optional<std::string> read_border_node(pugi::xml_node);
 
-std::string read_text_property(pugi::xml_node);
-
 using Relations = std::unordered_map<std::string, std::string>;
 using XmlDocumentsAndRelations =
     std::unordered_map<AbsPath, std::pair<pugi::xml_document, Relations>>;

--- a/src/odr/internal/ooxml/presentation/ooxml_presentation_document.cpp
+++ b/src/odr/internal/ooxml/presentation/ooxml_presentation_document.cpp
@@ -199,9 +199,7 @@ public:
   }
   [[nodiscard]] bool element_is_editable(
       [[maybe_unused]] const ElementIdentifier element_id) const override {
-    // The presentation document is read-only (is_editable/is_savable are
-    // false), so no element is editable. The text_set_content machinery
-    // exists but stays dormant until pptx editing + save are wired up.
+    // read-only; text_set_content below stays dormant until save is wired up
     return false;
   }
   [[nodiscard]]
@@ -370,6 +368,12 @@ public:
       }
     }
 
+    if (new_first == old_first) {
+      // empty text still needs a live node to anchor the element to, or the
+      // removal below would leave the registry pointing at freed nodes
+      insert_node("a:t");
+    }
+
     element.node = new_first;
     text_element.last = new_last;
 
@@ -488,12 +492,12 @@ public:
     return read_emus_attribute(
         get_frame_xfrm(element_id).child("a:ext").attribute("cy"));
   }
-  [[nodiscard]] std::optional<std::int32_t>
-  frame_z_index(const ElementIdentifier) const override {
+  [[nodiscard]] std::optional<std::int32_t> frame_z_index(
+      [[maybe_unused]] const ElementIdentifier element_id) const override {
     return std::nullopt;
   }
-  [[nodiscard]] GraphicStyle
-  frame_style(const ElementIdentifier) const override {
+  [[nodiscard]] GraphicStyle frame_style(
+      [[maybe_unused]] const ElementIdentifier element_id) const override {
     return {};
   }
 

--- a/src/odr/internal/ooxml/presentation/ooxml_presentation_element_registry.cpp
+++ b/src/odr/internal/ooxml/presentation/ooxml_presentation_element_registry.cpp
@@ -18,7 +18,7 @@ std::tuple<ElementIdentifier, ElementRegistry::Element &>
 ElementRegistry::create_element(const ElementType type,
                                 const pugi::xml_node node) {
   Element &element = m_elements.emplace_back();
-  ElementIdentifier element_id = m_elements.size();
+  const ElementIdentifier element_id = m_elements.size();
   element.type = type;
   element.node = node;
   return {element_id, element};

--- a/src/odr/internal/ooxml/spreadsheet/ooxml_spreadsheet_document.cpp
+++ b/src/odr/internal/ooxml/spreadsheet/ooxml_spreadsheet_document.cpp
@@ -16,8 +16,7 @@ namespace odr::internal::ooxml::spreadsheet {
 
 namespace {
 std::unique_ptr<abstract::ElementAdapter>
-create_element_adapter(const Document &document, ElementRegistry &registry,
-                       StyleRegistry &style_registry);
+create_element_adapter(const Document &document, ElementRegistry &registry);
 }
 
 Document::Document(std::shared_ptr<abstract::ReadableFilesystem> files)
@@ -59,8 +58,7 @@ Document::Document(std::shared_ptr<abstract::ReadableFilesystem> files)
   m_root_element = parse_tree(m_element_registry, parse_context,
                               workbook_xml.document_element());
 
-  m_element_adapter =
-      create_element_adapter(*this, m_element_registry, m_style_registry);
+  m_element_adapter = create_element_adapter(*this, m_element_registry);
 }
 
 const ElementRegistry &Document::element_registry() const {
@@ -108,10 +106,8 @@ class ElementAdapter final : public abstract::ElementAdapter,
                              public abstract::FrameAdapter,
                              public abstract::ImageAdapter {
 public:
-  ElementAdapter(const Document &document, ElementRegistry &registry,
-                 StyleRegistry &style_registry)
-      : m_document(&document), m_registry(&registry),
-        m_style_registry(&style_registry) {}
+  ElementAdapter(const Document &document, ElementRegistry &registry)
+      : m_document(&document), m_registry(&registry) {}
 
   [[nodiscard]] ElementType
   element_type(const ElementIdentifier element_id) const override {
@@ -268,10 +264,9 @@ public:
     const pugi::xml_node cell_node = sheet_element.cell_node(column, row);
 
     TableCellStyle result;
-    if (const pugi::xml_attribute style_attribute = cell_node.attribute("s");
-        style_attribute) {
-      const std::uint32_t style_id = style_attribute.as_uint();
-      const ResolvedStyle style = m_style_registry->cell_style(style_id);
+    if (const pugi::xml_attribute style_attribute = cell_node.attribute("s")) {
+      const ResolvedStyle style =
+          m_document->style_registry().cell_style(style_attribute.as_uint());
       result.override(style.table_cell_style);
     }
     return result;
@@ -435,7 +430,6 @@ public:
 private:
   const Document *m_document{nullptr};
   ElementRegistry *m_registry{nullptr};
-  StyleRegistry *m_style_registry{nullptr};
 
   [[nodiscard]] pugi::xml_node
   get_node(const ElementIdentifier element_id) const {
@@ -495,9 +489,8 @@ private:
 };
 
 std::unique_ptr<abstract::ElementAdapter>
-create_element_adapter(const Document &document, ElementRegistry &registry,
-                       StyleRegistry &style_registry) {
-  return std::make_unique<ElementAdapter>(document, registry, style_registry);
+create_element_adapter(const Document &document, ElementRegistry &registry) {
+  return std::make_unique<ElementAdapter>(document, registry);
 }
 
 } // namespace

--- a/src/odr/internal/ooxml/spreadsheet/ooxml_spreadsheet_element_registry.cpp
+++ b/src/odr/internal/ooxml/spreadsheet/ooxml_spreadsheet_element_registry.cpp
@@ -8,8 +8,10 @@ namespace odr::internal::ooxml::spreadsheet {
 
 void ElementRegistry::clear() noexcept {
   m_elements.clear();
+  m_element_relations.clear();
   m_texts.clear();
   m_sheets.clear();
+  m_sheet_cells.clear();
 }
 
 [[nodiscard]] std::size_t ElementRegistry::size() const noexcept {
@@ -20,7 +22,7 @@ std::tuple<ElementIdentifier, ElementRegistry::Element &>
 ElementRegistry::create_element(const ElementType type,
                                 const pugi::xml_node node) {
   Element &element = m_elements.emplace_back();
-  ElementIdentifier element_id = m_elements.size();
+  const ElementIdentifier element_id = m_elements.size();
   element.type = type;
   element.node = node;
   return {element_id, element};

--- a/src/odr/internal/ooxml/spreadsheet/ooxml_spreadsheet_parser.cpp
+++ b/src/odr/internal/ooxml/spreadsheet/ooxml_spreadsheet_parser.cpp
@@ -5,6 +5,7 @@
 #include <odr/internal/common/table_range.hpp>
 #include <odr/internal/ooxml/spreadsheet/ooxml_spreadsheet_element_registry.hpp>
 
+#include <algorithm>
 #include <unordered_map>
 
 #include <pugixml.hpp>
@@ -61,15 +62,15 @@ void parse_root_children(ElementRegistry &registry, const ParseContext &context,
                          const pugi::xml_node node) {
   for (pugi::xml_node child_node : node.child("sheets").children("sheet")) {
     const char *id = child_node.attribute("r:id").value();
-    AbsPath sheet_path = context.document_path().parent().join(
+    const AbsPath sheet_path = context.document_path().parent().join(
         RelPath(context.document_relations().at(id)));
     const auto &[sheet_xml, sheet_relations] =
         context.documents_and_relations().at(sheet_path);
-    ParseContext newContext(sheet_path, sheet_relations,
-                            context.documents_and_relations(),
-                            context.shared_strings());
+    const ParseContext sheet_context(sheet_path, sheet_relations,
+                                     context.documents_and_relations(),
+                                     context.shared_strings());
     const auto &[sheet, _] = parse_any_element_tree(
-        registry, newContext, sheet_xml.document_element());
+        registry, sheet_context, sheet_xml.document_element());
     registry.append_child(parent_id, sheet);
   }
 }
@@ -107,6 +108,7 @@ parse_sheet_element(ElementRegistry &registry, const ParseContext &context,
     sheet.register_column(min, max, col_node);
   }
 
+  TableDimensions used;
   for (const pugi::xml_node row_node :
        node.child("sheetData").children("row")) {
     const std::uint32_t row = row_node.attribute("r").as_uint() - 1;
@@ -120,6 +122,9 @@ parse_sheet_element(ElementRegistry &registry, const ParseContext &context,
       registry.append_sheet_cell(element_id, cell_id);
       sheet.register_cell(position.column, position.row, cell_node, cell_id);
       parse_sheet_cell_children(registry, context, cell_id, cell_node);
+
+      used.rows = std::max(used.rows, position.row + 1);
+      used.columns = std::max(used.columns, position.column + 1);
     }
   }
 
@@ -131,9 +136,8 @@ parse_sheet_element(ElementRegistry &registry, const ParseContext &context,
     }
     const TableRange range(ref);
 
-    // The renderer's cursor learns covered positions only from the anchor's
-    // span, so a range whose anchor cell is absent from sheetData must be
-    // dropped entirely — stray covered flags would starve the cursor.
+    // covered flags are only meaningful next to the anchor's span, so a range
+    // whose anchor is absent from sheetData must be dropped entirely
     const ElementRegistry::Sheet::Cell *anchor =
         sheet.cell(range.from().column, range.from().row);
     if (anchor == nullptr) {
@@ -157,15 +161,16 @@ parse_sheet_element(ElementRegistry &registry, const ParseContext &context,
     }
   }
 
-  {
-    const std::string dimension_ref =
-        node.child("dimension").attribute("ref").value();
-    TablePosition position_to;
-    if (dimension_ref.find(':') == std::string::npos) {
-      position_to = TablePosition(dimension_ref);
-    } else {
-      position_to = TableRange(dimension_ref).to();
-    }
+  // `dimension` is optional; fall back to the range the cells actually span
+  if (const std::string dimension_ref =
+          node.child("dimension").attribute("ref").value();
+      dimension_ref.empty()) {
+    sheet.dimensions = used;
+  } else {
+    const TablePosition position_to =
+        dimension_ref.find(':') == std::string::npos
+            ? TablePosition(dimension_ref)
+            : TableRange(dimension_ref).to();
     sheet.dimensions =
         TableDimensions(position_to.row + 1, position_to.column + 1);
   }

--- a/src/odr/internal/ooxml/text/ooxml_text_document.cpp
+++ b/src/odr/internal/ooxml/text/ooxml_text_document.cpp
@@ -22,8 +22,7 @@ namespace odr::internal::ooxml::text {
 
 namespace {
 std::unique_ptr<abstract::ElementAdapter>
-create_element_adapter(const Document &document, ElementRegistry &registry,
-                       const Relations &document_relations);
+create_element_adapter(const Document &document, ElementRegistry &registry);
 }
 
 Document::Document(std::shared_ptr<abstract::ReadableFilesystem> files)
@@ -40,8 +39,7 @@ Document::Document(std::shared_ptr<abstract::ReadableFilesystem> files)
 
   m_style_registry = StyleRegistry(m_styles_xml.document_element());
 
-  m_element_adapter =
-      create_element_adapter(*this, m_element_registry, m_document_relations);
+  m_element_adapter = create_element_adapter(*this, m_element_registry);
 }
 
 ElementRegistry &Document::element_registry() { return m_element_registry; }
@@ -115,10 +113,8 @@ class ElementAdapter final : public abstract::ElementAdapter,
                              public abstract::FrameAdapter,
                              public abstract::ImageAdapter {
 public:
-  ElementAdapter(const Document &document, ElementRegistry &registry,
-                 const Relations &document_relations)
-      : m_document(&document), m_registry(&registry),
-        m_document_relations(&document_relations) {}
+  ElementAdapter(const Document &document, ElementRegistry &registry)
+      : m_document(&document), m_registry(&registry) {}
 
   [[nodiscard]] ElementType
   element_type(const ElementIdentifier element_id) const override {
@@ -320,6 +316,12 @@ public:
       }
     }
 
+    if (new_first == old_first) {
+      // empty text still needs a live node to anchor the element to, or the
+      // removal below would leave the registry pointing at freed nodes
+      insert_node("w:t");
+    }
+
     element.node = new_first;
     text_element.last = new_last;
 
@@ -341,7 +343,7 @@ public:
       return std::string("#") + anchor.value();
     }
     if (const pugi::xml_attribute ref = node.attribute("r:id"); ref) {
-      const auto relations = get_document_relations();
+      const Relations &relations = m_document->document_relations();
       if (const auto rel = relations.find(ref.value());
           rel != std::end(relations)) {
         return rel->second;
@@ -406,8 +408,6 @@ public:
 
   [[nodiscard]] bool
   table_cell_is_covered(const ElementIdentifier element_id) const override {
-    // A cell continues a vertical merge when `w:vMerge` is present without
-    // `w:val` or with `w:val="continue"`.
     return is_merge_continuation(
         get_node(element_id).child("w:tcPr").child("w:vMerge"));
   }
@@ -449,13 +449,10 @@ public:
         .table_cell_style;
   }
 
-  [[nodiscard]] AnchorType
-  frame_anchor_type(const ElementIdentifier element_id) const override {
-    if (const pugi::xml_node node = get_node(element_id);
-        node.child("wp:inline")) {
-      return AnchorType::as_char;
-    }
-    return AnchorType::as_char; // TODO default?
+  [[nodiscard]] AnchorType frame_anchor_type(
+      [[maybe_unused]] const ElementIdentifier element_id) const override {
+    // TODO `wp:anchor` is floating, not as_char
+    return AnchorType::as_char;
   }
   [[nodiscard]] std::optional<Measure>
   frame_x([[maybe_unused]] const ElementIdentifier element_id) const override {
@@ -505,8 +502,9 @@ public:
                                             .child("pic:blipFill")
                                             .child("a:blip")
                                             .attribute("r:embed")) {
-      if (const auto rel = m_document_relations->find(ref.value());
-          rel != std::end(*m_document_relations)) {
+      const Relations &relations = m_document->document_relations();
+      if (const auto rel = relations.find(ref.value());
+          rel != std::end(relations)) {
         return AbsPath("/word").join(RelPath(rel->second)).string();
       }
     }
@@ -516,7 +514,6 @@ public:
 private:
   const Document *m_document{nullptr};
   ElementRegistry *m_registry{nullptr};
-  const Relations *m_document_relations{nullptr};
 
   [[nodiscard]] pugi::xml_node
   get_node(const ElementIdentifier element_id) const {
@@ -535,6 +532,7 @@ private:
     return {};
   }
 
+  /// A `w:vMerge` continues the merge above unless it says `w:val="restart"`.
   [[nodiscard]] static bool is_merge_continuation(const pugi::xml_node merge) {
     if (!merge) {
       return false;
@@ -574,10 +572,6 @@ private:
                     .as_uint(1);
     }
     return {};
-  }
-
-  [[nodiscard]] const Relations &get_document_relations() const {
-    return m_document->document_relations();
   }
 
   [[nodiscard]] static std::string get_text(const pugi::xml_node node) {
@@ -621,10 +615,8 @@ private:
 };
 
 std::unique_ptr<abstract::ElementAdapter>
-create_element_adapter(const Document &document, ElementRegistry &registry,
-                       const Relations &document_relations) {
-  return std::make_unique<ElementAdapter>(document, registry,
-                                          document_relations);
+create_element_adapter(const Document &document, ElementRegistry &registry) {
+  return std::make_unique<ElementAdapter>(document, registry);
 }
 
 } // namespace

--- a/src/odr/internal/ooxml/text/ooxml_text_element_registry.cpp
+++ b/src/odr/internal/ooxml/text/ooxml_text_element_registry.cpp
@@ -18,7 +18,7 @@ std::tuple<ElementIdentifier, ElementRegistry::Element &>
 ElementRegistry::create_element(const ElementType type,
                                 const pugi::xml_node node) {
   Element &element = m_elements.emplace_back();
-  ElementIdentifier element_id = m_elements.size();
+  const ElementIdentifier element_id = m_elements.size();
   element.type = type;
   element.node = node;
   return {element_id, element};

--- a/src/odr/internal/ooxml/text/ooxml_text_parser.cpp
+++ b/src/odr/internal/ooxml/text/ooxml_text_parser.cpp
@@ -111,14 +111,7 @@ parse_list_element(ElementRegistry &registry, pugi::xml_node node) {
     const std::int32_t level = list_level(node);
 
     for (std::int32_t i = 0; i < level; ++i) {
-      /* TODO fix lists
-      auto list_item_unique = std::make_unique<ListItem>(node);
-      auto list_item = list_item_unique.get();
-      store.push_back(std::move(list_item_unique));
-
-      base->init_append_child(list_item);
-       */
-
+      // TODO a nested level should be a list_item wrapping the list
       const auto &[nested_id, _] =
           registry.create_element(ElementType::list, node);
 

--- a/src/odr/internal/ooxml/text/ooxml_text_style.cpp
+++ b/src/odr/internal/ooxml/text/ooxml_text_style.cpp
@@ -252,18 +252,24 @@ void StyleRegistry::generate_styles_(const pugi::xml_node styles_root) {
 
 Style *StyleRegistry::generate_style_(const std::string &name,
                                       const pugi::xml_node node) {
-  std::unique_ptr<Style> &style = m_styles[name];
-  if (style) {
-    return style.get();
+  // an entry present but still null means we are inside its own resolution;
+  // returning it breaks a cyclic `w:basedOn` chain
+  if (const auto styles_it = m_styles.find(name);
+      styles_it != std::end(m_styles)) {
+    return styles_it->second.get();
   }
+  std::unique_ptr<Style> &style = m_styles[name];
 
   Style *parent{nullptr};
 
   if (const pugi::xml_attribute parent_attr =
           node.child("w:basedOn").attribute("w:val");
       parent_attr) {
-    if (const pugi::xml_node parent_node = m_index[parent_attr.value()]) {
-      parent = generate_style_(parent_attr.value(), parent_node);
+    // `find`, not `operator[]`: an unknown parent id must not grow m_index
+    // while generate_styles_ iterates it
+    if (const auto index_it = m_index.find(parent_attr.value());
+        index_it != std::end(m_index)) {
+      parent = generate_style_(index_it->first, index_it->second);
     }
   }
 

--- a/src/odr/internal/open_strategy.cpp
+++ b/src/odr/internal/open_strategy.cpp
@@ -29,23 +29,19 @@ namespace odr::internal {
 
 namespace {
 
+/// Orders by position in @p priority; anything not listed sorts last.
 template <typename T> auto priority_comparator(const std::vector<T> &priority) {
   return [&priority](const T &a, const T &b) {
-    auto a_it = std::find(std::begin(priority), std::end(priority), a);
-    auto b_it = std::find(std::begin(priority), std::end(priority), b);
+    const auto a_it = std::ranges::find(priority, a);
+    const auto b_it = std::ranges::find(priority, b);
 
-    if (a_it == std::end(priority) && b_it == std::end(priority)) {
+    if (b_it == std::ranges::end(priority)) {
+      return a_it != std::ranges::end(priority);
+    }
+    if (a_it == std::ranges::end(priority)) {
       return false;
     }
-    if (a_it == std::end(priority)) {
-      return false;
-    }
-    if (b_it == std::end(priority)) {
-      return true;
-    }
-
-    return std::distance(std::begin(priority), a_it) <
-           std::distance(std::begin(priority), b_it);
+    return a_it < b_it;
   };
 }
 
@@ -125,9 +121,8 @@ open_file_as(const std::shared_ptr<abstract::File> &file, const FileType as,
     throw NoSvmFile();
   }
 
-  // Everything below has no decoder: the bytes go to the browser as they are,
-  // so the category is all that has to be right. Every image but the starview
-  // metafile above lands here, and so does all audio and video.
+  // no decoder below: the bytes go to the browser as they are, so only the
+  // category has to be right
   const FileCategory category = file_category_by_file_type(as);
   if (category == FileCategory::image) {
     ODR_VERBOSE(logger, "open as image");
@@ -285,8 +280,8 @@ open_strategy::list_file_types(const std::shared_ptr<abstract::File> &file,
         ODR_VERBOSE(logger, "failed to open as json");
       }
 
-      // an svg has no signature to find it by - it is xml, and only the root
-      // element tells the two apart, so both are reported
+      // an svg has no signature; only the xml root element tells it from plain
+      // xml, so both are reported
       try {
         ODR_VERBOSE(logger, "try open as xml");
         util::xml::check_xml_file(*file->stream());
@@ -374,8 +369,7 @@ open_strategy::open_file(const std::shared_ptr<abstract::File> &file,
     ODR_VERBOSE(logger, "open as svm");
     return std::make_unique<svm::SvmFile>(file);
   }
-  // see `open_file_as` — no decoder, so the category is all that has to be
-  // right
+  // see `open_file_as` — no decoder, only the category has to be right
   const FileCategory file_category = file_category_by_file_type(file_type);
   if (file_category == FileCategory::image) {
     ODR_VERBOSE(logger, "open as image");
@@ -413,8 +407,8 @@ open_strategy::open_file(const std::shared_ptr<abstract::File> &file,
         ODR_VERBOSE(logger, "failed to open as json");
       }
 
-      // see `list_file_types` - an svg is only recognised by parsing it, and
-      // a plain xml file has no decoder of its own, so it stays text
+      // an svg is only recognised by parsing it; plain xml has no decoder of
+      // its own and stays text
       try {
         ODR_VERBOSE(logger, "try open as svg");
         svg::check_svg_file(*file->stream());

--- a/src/odr/internal/pdf/pdf_cmap.hpp
+++ b/src/odr/internal/pdf/pdf_cmap.hpp
@@ -10,22 +10,18 @@
 
 namespace odr::internal::pdf {
 
-/// Maps PDF character codes to Unicode, as described by a `ToUnicode` CMap.
-///
-/// A code is a sequence of bytes (1 or more, big-endian) whose width is defined
-/// by the codespace ranges; a destination is a sequence of UTF-16 units (more
-/// than one for ligatures). `translate_string` splits an input string into
-/// codes of the right width and concatenates their destinations.
+/// A parsed CMap: character codes (1+ big-endian bytes, width from the
+/// codespace ranges) to Unicode (several UTF-16 units for a ligature) and/or to
+/// CIDs. `translate_string` splits an input string and concatenates the
+/// destinations.
 class CMap {
 public:
   void add_codespace_range(std::string low_code, std::string high_code);
   void map_single(std::string code, std::u16string unicode);
 
-  /// CID mapping (a composite font's `/Encoding` CMap stream, ISO 32000-1
-  /// 9.7.5.3): `cidchar` maps a single code, `cidrange` maps a contiguous block
-  /// (`base_cid + (code - low)`). Codes are keyed by their raw big-endian bytes
-  /// / width so a 1-byte and a 2-byte code with the same numeric value stay
-  /// distinct (`<20>` -> CID 229 vs `<0020>` -> CID 32), the mixed-width case.
+  /// CID mapping from a composite font's `/Encoding` CMap stream (ISO 32000-1
+  /// 9.7.5.3); a range maps `base_cid + (code - low)`. Codes are keyed by their
+  /// raw bytes *and* width, so `<20>` and `<0020>` stay distinct.
   void map_cid_char(std::string code, std::uint32_t cid);
   void add_cid_range(std::uint32_t low, std::uint32_t high,
                      std::uint32_t base_cid, std::size_t width);
@@ -45,24 +41,19 @@ public:
     return m_inherits_external_cmap;
   }
 
-  /// True when this CMap declares an authoritative codespace: at least one
-  /// range, and it does not inherit an unresolved base CMap via `usecmap`. When
-  /// true, the code widths this CMap implies are authoritative for splitting a
-  /// code string (see `code_width`); when false, callers fall back to another
-  /// CMap's codespace or a fixed width. An inherited (`usecmap`) codespace is
-  /// deliberately excluded — its local ranges may cover only an override
-  /// subset, so trusting them would mis-split the inherited (e.g. 2-byte)
-  /// codes.
+  /// True when this CMap's `code_width` may be trusted to split a code string:
+  /// it declares at least one range and inherits no unresolved base CMap. A
+  /// `usecmap` stream is excluded because its local ranges may cover only an
+  /// override subset. False sends callers to another codespace or a fixed
+  /// width.
   [[nodiscard]] bool has_codespace() const {
     return !m_codespace_ranges.empty() && !m_inherits_external_cmap;
   }
 
-  /// Byte width of a code whose first byte is `first`, decided by the codespace
-  /// ranges (matched on the first byte, ISO 32000-1 9.7.6.2). Falls back to a
-  /// single byte when no range declares/matches it. This is the variable-width
-  /// split that `translate_string` uses; exposing it lets the glyph/advance
-  /// paths split codes identically, so a mixed 1-/2-byte codespace (e.g. a
-  /// 1-byte space among 2-byte CIDs) stays aligned across both.
+  /// Byte width of a code starting with `first`, from the codespace ranges
+  /// (matched on the first byte, ISO 32000-1 9.7.6.2); 1 when none matches.
+  /// Public so the glyph/advance paths split exactly as `translate_string`
+  /// does, keeping a mixed 1-/2-byte codespace aligned across both.
   [[nodiscard]] std::size_t code_width(std::uint8_t first) const;
 
   [[nodiscard]] std::string translate_string(const std::string &codes) const;

--- a/src/odr/internal/pdf/pdf_cmap_parser.cpp
+++ b/src/odr/internal/pdf/pdf_cmap_parser.cpp
@@ -15,11 +15,9 @@ static constexpr int_type eof = std::streambuf::traits_type::eof();
 
 namespace {
 
-// PDF character codes are 1–4 bytes wide (PDF 32000-1 §9.7.6.2); that bound is
-// what lets a code be packed losslessly into a `std::uint32_t`. The call sites
-// validate widths and skip out-of-spec entries, so in practice the guards in
-// the helpers below never fire — they enforce the invariant defensively so a
-// stray caller fails loudly rather than silently corrupting the mapping.
+// Character codes are 1-4 bytes wide (ISO 32000-1 9.7.6.2), which is what lets
+// one pack losslessly into a `std::uint32_t`. Call sites already skip
+// out-of-spec entries, so the guards below only catch a stray new caller.
 constexpr std::size_t max_code_width = 4;
 
 // A conforming `bfrange`'s low/high codes differ only in their last byte
@@ -310,12 +308,10 @@ CMap CMapParser::parse_cmap() {
       } else if (command == "begincidrange") {
         read_cidrange(last_int, cmap);
       } else if (command == "usecmap") {
-        // `/BaseCMap usecmap`: this stream inherits another CMap's codespace
-        // and mappings (ISO 32000-1 9.7.5.3). We do not resolve the base, so
-        // any codespace declared locally is (potentially) an override-only
-        // subset; flag it so it is no longer treated as authoritative and
-        // callers fall back to the ToUnicode codespace / fixed width instead of
-        // mis-splitting the inherited (e.g. 2-byte) codes.
+        // `/BaseCMap usecmap` inherits another CMap (ISO 32000-1 9.7.5.3).
+        // We do not resolve the base, so what is declared locally may be an
+        // override-only subset; flagging it stops callers from splitting the
+        // inherited (e.g. 2-byte) codes by an incomplete codespace.
         cmap.mark_inherits_external_cmap();
         ODR_WARNING(m_logger,
                     "pdf: unresolved 'usecmap'; local codespace not treated as "

--- a/src/odr/internal/pdf/pdf_color.cpp
+++ b/src/odr/internal/pdf/pdf_color.cpp
@@ -125,9 +125,11 @@ ColorSpaceDef::to_rgb(const std::vector<double> &c) const {
     }
     const std::int32_t n = base->components;
     const auto index = static_cast<std::int32_t>(std::lround(at(0)));
-    const auto offset =
-        static_cast<std::size_t>(std::clamp<std::int32_t>(index, 0, hival)) *
-        static_cast<std::size_t>(n);
+    // `std::clamp` is undefined for hi < lo, so a negative `/HiVal` (malformed)
+    // must not reach it.
+    const auto offset = static_cast<std::size_t>(std::clamp<std::int32_t>(
+                            index, 0, std::max(hival, 0))) *
+                        static_cast<std::size_t>(n);
     std::vector<double> base_components(static_cast<std::size_t>(n), 0.0);
     for (std::int32_t j = 0; j < n; ++j) {
       const std::size_t k = offset + static_cast<std::size_t>(j);
@@ -188,7 +190,7 @@ pdf::parse_color_space(const Object &object, const ColorSpaceContext &context) {
   if (resolved.is_name()) {
     return space_from_name(resolved.as_name(), context);
   }
-  if (!resolved.is_array() || resolved.as_array().size() == 0) {
+  if (!resolved.is_array() || resolved.as_array().empty()) {
     return nullptr;
   }
 

--- a/src/odr/internal/pdf/pdf_document.cpp
+++ b/src/odr/internal/pdf/pdf_document.cpp
@@ -40,17 +40,17 @@ double Font::advance_width(const std::uint32_t code) const {
     }
     return cid_default_width / 1000.0;
   }
-  const long index = static_cast<long>(code) - first_char;
+  const std::int64_t index = static_cast<std::int64_t>(code) - first_char;
   if (type3) {
     // Type3 widths are in glyph space, mapped to text space by `/FontMatrix`
     // (ISO 32000-1 9.6.5) — not the fixed 1/1000 em of other fonts. The
     // horizontal advance is the x-component of `(w, 0)` through the matrix.
-    if (index >= 0 && index < static_cast<long>(widths.size())) {
+    if (index >= 0 && index < static_cast<std::int64_t>(widths.size())) {
       return widths[static_cast<std::size_t>(index)] * type3->font_matrix.a;
     }
     return 0;
   }
-  if (index >= 0 && index < static_cast<long>(widths.size())) {
+  if (index >= 0 && index < static_cast<std::int64_t>(widths.size())) {
     return widths[static_cast<std::size_t>(index)] / 1000.0;
   }
   // Non-embedded standard-14 fonts usually ship no `/Widths`: fall back to the

--- a/src/odr/internal/pdf/pdf_document_element.hpp
+++ b/src/odr/internal/pdf/pdf_document_element.hpp
@@ -40,9 +40,8 @@ struct Element {
   ObjectReference object_reference;
   Object object;
 
-  /// Value-semantic discrimination over the element hierarchy, backed by RTTI;
-  /// mirrors `Object`'s `is_*`/`as_*` surface. `T` must be a complete-derived
-  /// type at the call site.
+  /// RTTI-backed discrimination mirroring `Object`'s `is_*`/`as_*` surface.
+  /// `T` must be complete at the call site.
   template <typename T>
     requires std::derived_from<T, Element>
   [[nodiscard]] bool is() const {
@@ -86,52 +85,36 @@ struct Page final : Element {
 
 struct Annotation final : Element {};
 
+/// A resource dictionary (ISO 32000-1 7.8.3). Every subdictionary is resolved
+/// eagerly at parse time so extraction needs no parser handle. Element pointers
+/// are non-owning (the `Document` arena owns them); the plain value types
+/// (`ColorSpaceDef`, `Shading`, `SoftMaskDef`) are shared because a single one
+/// may be reached from several resources.
 struct Resources final : Element {
   std::unordered_map<std::string, Font *> font;
   std::unordered_map<std::string, XObject *> x_object;
-  /// The `/ColorSpace` subdictionary (ISO 32000-1 8.6.3): named colour spaces
-  /// referenced by `cs`/`CS`. Resolved eagerly (ICC alternates, Separation tint
-  /// transforms, …) so extraction can convert `sc`/`scn` colours to RGB without
-  /// a parser handle. The device spaces (`/DeviceRGB`, …) are not stored here —
-  /// they resolve by name at use time.
+  /// `/ColorSpace` (8.6.3), for `cs`/`CS`. Device spaces are not stored — they
+  /// resolve by name at use time.
   std::unordered_map<std::string, std::shared_ptr<ColorSpaceDef>> color_space;
-  /// The `/Properties` subdictionary (ISO 32000-1 7.8.3): named property lists
-  /// referenced by `BDC`. Each value is the resolved property-list dictionary
-  /// `Object`; used to recover `/ActualText` for a `BDC /Tag /Name` sequence.
+  /// `/Properties` (7.8.3): the property lists `BDC` names, for `/ActualText`.
   std::unordered_map<std::string, Object> properties;
-  /// The `/Shading` subdictionary (ISO 32000-1 8.7.4.3): named shadings painted
-  /// by the `sh` operator. Resolved eagerly (the tint function sampled into
-  /// colour stops) so extraction needs no parser handle. Held by `shared_ptr`
-  /// because `Shading` is a plain value type, not a document `Element` (a
-  /// shading pattern shares ownership of the same `Shading`).
+  /// `/Shading` (8.7.4.3), for `sh`; the tint function already sampled.
   std::unordered_map<std::string, std::shared_ptr<Shading>> shading;
-  /// The `/Pattern` subdictionary (ISO 32000-1 8.7.3.3): named tiling/shading
-  /// patterns selected as a colour by `scn`/`SCN` in a `/Pattern` colour space.
-  /// A non-owning pointer: `Pattern` is a document `Element`, owned by the
-  /// `Document` graph like the other resource elements (`Font`, `XObject`).
+  /// `/Pattern` (8.7.3.3), for `scn`/`SCN` in a `/Pattern` colour space.
   std::unordered_map<std::string, Pattern *> pattern;
-  /// The `/ExtGState` subdictionary (ISO 32000-1 8.4.5): named graphics-state
-  /// parameter dictionaries selected by the `gs` operator. Resolved dicts are
-  /// stored verbatim (like `/Properties`) and interpreted at `gs` time — the
-  /// extractor reads `ca`/`CA` (constant alpha) and `/BM` (blend mode).
+  /// `/ExtGState` (8.4.5), for `gs`; kept verbatim and interpreted at `gs`
+  /// time (the extractor reads `ca`/`CA` and `/BM`).
   std::unordered_map<std::string, Object> ext_g_state;
-  /// The soft mask (`/SMask`) of each `/ExtGState` that carries one, resolved
-  /// at parse time (its `/G` transparency group parsed as a form `XObject`),
-  /// keyed by the same name as `ext_g_state`. Absent when the state has no
-  /// `/SMask` or sets `/SMask /None`; the `gs` handler reads the dict's
-  /// `/SMask` to tell the two apart. Held by `shared_ptr` so a mask shared
-  /// across states is parsed once and outlives the `Resources` if a `SoftMask`
-  /// still references it.
+  /// The `/SMask` of each `/ExtGState` that carries one, keyed alike. Absent
+  /// for `/SMask /None` too, so the `gs` handler consults `ext_g_state` to tell
+  /// "no mask" from "clear the mask" apart.
   std::unordered_map<std::string, std::shared_ptr<SoftMaskDef>>
       ext_g_state_soft_mask;
 };
 
-/// A soft mask (`/SMask` in an `/ExtGState`, ISO 32000-1 11.6.5.2), resolved at
-/// parse time. The mask is derived from a transparency group XObject `/G`: for
-/// `/S /Luminosity` the group's luminosity is the alpha; for `/S /Alpha` its
-/// alpha is. `/BC` is the group's backdrop colour, in the group's own colour
-/// space (raw components; empty = the default, black). Consumed by the page
-/// extractor, which renders `/G` into a `SoftMask` (`pdf_page_element.hpp`).
+/// An unrendered soft mask (`/ExtGState` `/SMask`, ISO 32000-1 11.6.5.2): the
+/// page extractor runs `/G` to produce the `SoftMask` in
+/// `pdf_page_element.hpp`.
 struct SoftMaskDef {
   enum class Type { luminosity, alpha };
   Type type{Type::luminosity};
@@ -141,23 +124,18 @@ struct SoftMaskDef {
   std::vector<double> backdrop;
 };
 
-/// Type3 font glyph data (ISO 32000-1 9.6.5). A Type3 glyph is a small content
-/// stream (`/CharProcs`, keyed by glyph name) drawn in glyph space, mapped to
-/// text space by `/FontMatrix` (unlike other fonts, glyph space is not fixed at
-/// 1/1000 em). The char procs draw against their own `/Resources`.
+/// Type3 font glyph data (ISO 32000-1 9.6.5): glyphs are content streams, and
+/// glyph space is whatever `/FontMatrix` says, not the fixed 1/1000 em.
 struct Type3Data {
-  /// `/FontMatrix`: glyph space -> text space (e.g. `[0.001 0 0 0.001 0 0]`).
-  util::math::Transform2D font_matrix;
-  /// `/CharProcs`: glyph name -> the decoded char-proc content stream.
+  util::math::Transform2D font_matrix; ///< glyph space -> text space
+  /// `/CharProcs`: glyph name -> decoded char-proc content stream.
   std::unordered_map<std::string, std::string> char_procs;
-  /// `/Resources` the char procs draw against, or `nullptr` (then the enclosing
-  /// page's resources apply). Owned by the `Document` graph.
+  /// `/Resources`, or null to inherit the invoking page's.
   Resources *resources{nullptr};
 };
 
-/// An external object referenced by `Do` and listed in a resource dictionary's
-/// `/XObject` subdictionary (ISO 32000-1 7.8.3, 8.8). Form XObjects carry a
-/// reusable content stream; image XObjects carry decoded raster/JPEG data.
+/// An external object invoked by `Do` (ISO 32000-1 8.8): a reusable content
+/// stream (form) or raster data (image).
 struct XObject final : Element {
   enum class Subtype {
     unknown, ///< neither `/Form` nor `/Image`
@@ -167,51 +145,39 @@ struct XObject final : Element {
 
   Subtype subtype{Subtype::unknown};
 
-  /// Form XObject only: the `/Matrix` (default identity), concatenated onto the
-  /// CTM when the form is invoked (8.10.1).
-  util::math::Transform2D matrix;
-  /// Form XObject only: the `/BBox` `[x0 y0 x1 y1]` in form space, clipping the
-  /// form's content (8.10.2). `nullopt` when the form declares none (lenient;
-  /// the spec requires it).
+  // --- form (`/Subtype /Form`) ---
+  util::math::Transform2D matrix; ///< `/Matrix`, concatenated at `Do` (8.10.1)
+  /// `/BBox` in form space, clipping the content (8.10.2). The spec requires
+  /// it; `nullopt` is a lenience for files that omit it.
   std::optional<std::array<double, 4>> bbox;
-  /// Form XObject only: the form's own `/Resources`, or `nullptr` to inherit
-  /// the invoking scope's resources (7.8.3).
+  /// `/Resources`, or null to inherit the invoking scope's (7.8.3).
   Resources *resources{nullptr};
-  /// Form XObject only: true when the form is a transparency group
-  /// (`/Group` with `/S /Transparency`, ISO 32000-1 11.6.6). Such a group is
-  /// composited in isolation, so a soft mask / constant alpha active when it is
-  /// invoked applies to the group's result as a whole rather than to each
-  /// interior painting — even when the group's own content resets the mask.
+  /// `/Group` with `/S /Transparency` (11.6.6). Such a group composites in
+  /// isolation, so the alpha/mask in force at `Do` applies to its result as a
+  /// whole — even when its own content resets them.
   bool transparency_group{false};
-  /// Form XObject only: the decoded (filter-applied) content stream, read
-  /// eagerly at parse time so text extraction needs no parser handle.
-  std::string content;
+  std::string content; ///< decoded content stream, read eagerly
 
-  /// Image XObject only: the encoded image bytes for the browser — a JPEG
-  /// passed through (`DCTDecode`) or a raster re-encoded as PNG (Flate/LZW/raw
-  /// samples assembled through the colour space, with a `/SMask`/`/Mask`
-  /// composited into RGBA) — with `image_mime` naming the format. Empty for a
-  /// codec not yet handled (JPX/CCITT/JBIG2), a stencil mask (see below) and
-  /// non-image XObjects, so `Do` skips it.
+  // --- image (`/Subtype /Image`) ---
+  /// Browser-ready bytes: a `DCTDecode` JPEG passed through, or a raster
+  /// re-encoded as PNG (with any `/SMask`/`/Mask` composited into RGBA). Empty
+  /// for an undecodable codec (JPX/CCITT/JBIG2) and for a stencil, so `Do`
+  /// skips it.
   std::string image_data;
   std::string image_mime;
 
-  /// Image XObject `/ImageMask true` (ISO 32000-1 8.9.6.2): a 1-bpc stencil
-  /// painted in the *current fill colour*, which is known only at `Do` time. So
-  /// the decoded bitmap and its geometry are carried here for the page
-  /// extractor to recolour (`encode_stencil_png`); `image_data` stays empty.
-  /// `false` for a normal image.
+  /// `/ImageMask true` (8.9.6.2): a 1-bpc stencil painted in the current fill
+  /// colour, which is known only at `Do` time — so the bitmap is carried raw
+  /// for the extractor to recolour and `image_data` stays empty.
   bool stencil_mask{false};
-  std::string stencil_samples;    ///< decoded 1-bpc bitmap, rows byte-aligned
-  std::int32_t stencil_width{0};  ///< `/Width`
-  std::int32_t stencil_height{0}; ///< `/Height`
+  std::string stencil_samples;        ///< 1-bpc bitmap, rows byte-aligned
+  std::int32_t stencil_width{0};      ///< `/Width`
+  std::int32_t stencil_height{0};     ///< `/Height`
   std::vector<double> stencil_decode; ///< `/Decode`, empty = default `[0 1]`
 };
 
-/// A pattern listed in a resource dictionary's `/Pattern` subdictionary
-/// (ISO 32000-1 8.7.3), selected as a colour by `scn`/`SCN` in a `/Pattern`
-/// colour space. Shading patterns (`/PatternType 2`) paint a gradient through
-/// the path; tiling patterns (`/PatternType 1`) repeat a content-stream cell.
+/// A `/Pattern` resource (ISO 32000-1 8.7.3), selected as a colour by
+/// `scn`/`SCN` in a `/Pattern` colour space.
 struct Pattern final : Element {
   enum class Type {
     unknown,
@@ -220,20 +186,15 @@ struct Pattern final : Element {
   };
   Type type{Type::unknown};
 
-  /// `/Matrix` mapping pattern space to the default coordinate system of the
-  /// pattern's parent content stream (8.7.3.1); default identity.
+  /// `/Matrix`: pattern space -> the parent content stream's default space
+  /// (8.7.3.1) — *not* the CTM at use time.
   util::math::Transform2D matrix;
 
-  /// Shading pattern (`/PatternType 2`): the shading painted through the path,
-  /// pre-resolved (its tint function sampled into stops). Null otherwise.
+  /// Shading pattern: the gradient painted through the path, pre-resolved.
   std::shared_ptr<Shading> shading;
 
-  /// Tiling pattern (`/PatternType 1`, ISO 32000-1 8.7.3.1): a content-stream
-  /// cell tiled across the filled region. `/PaintType` 1 (coloured) carries its
-  /// own colours; `/PaintType` 2 (uncoloured) is painted entirely in the
-  /// current fill colour at use time. The cell is `/BBox` in pattern space,
-  /// repeated every `/XStep`/`/YStep`. Fields are zero/empty for a non-tiling
-  /// pattern.
+  /// Tiling pattern: a `/BBox` cell repeated every `/XStep`/`/YStep`. An
+  /// uncoloured cell (`/PaintType 2`) takes the fill colour at use time.
   std::int32_t paint_type{0};    ///< `/PaintType`: 1 coloured, 2 uncoloured
   std::array<double, 4> bbox{};  ///< `/BBox` `[x0 y0 x1 y1]`, pattern space
   double x_step{0};              ///< `/XStep`, pattern space
@@ -243,17 +204,13 @@ struct Pattern final : Element {
 };
 
 /// A non-owning view over a string of PDF character codes, splitting it into
-/// big-endian codes on iteration. Holds only a `string_view`, so it must not
-/// outlive the underlying bytes; iterate it directly
-/// (`for (std::uint32_t code : font.codes(...))`). Trailing bytes shorter than
-/// a full code are dropped, matching the PDF text-showing operators.
+/// big-endian codes on iteration; must not outlive the bytes. A trailing
+/// partial code is dropped, as the text-showing operators do.
 ///
-/// Code width is variable when a `codespace` CMap is supplied (its codespace
-/// ranges pick each code's width from its first byte, ISO 32000-1 9.7.6.2) — so
-/// a mixed 1-/2-byte encoding (a 1-byte space among 2-byte CIDs, as PDFClown
-/// and other producers emit) stays aligned. Without a codespace (or when the
-/// CMap declares none) it falls back to a fixed `Font::code_byte_width()`,
-/// splitting the same way the fixed-width iterator historically did.
+/// A `codespace` CMap picks each code's width from its first byte (ISO 32000-1
+/// 9.7.6.2), so a mixed 1-/2-byte encoding (a 1-byte space among 2-byte CIDs,
+/// which PDFClown et al. emit) stays aligned; without one the width is a fixed
+/// `Font::code_byte_width()`.
 class CodeRange {
 public:
   class Iterator {
@@ -273,9 +230,8 @@ public:
     }
 
     std::uint32_t operator*() const {
-      // A composite font's embedded CID `/Encoding` CMap maps the code to its
-      // CID (which is what the glyph/advance paths expect); without one the CID
-      // is the code itself (`Identity-H/V`), as it is for simple fonts.
+      // Yields the CID, which is what the glyph/advance paths expect; without a
+      // CID map it is the code itself (`Identity-H/V`, and simple fonts).
       if (m_cid_map != nullptr) {
         if (const std::optional<std::uint32_t> cid =
                 m_cid_map->cid_for_code(m_range.substr(0, m_width));
@@ -306,9 +262,9 @@ public:
     }
 
   private:
-    /// Fix the width of the code at the front of `m_range`, dropping a trailing
-    /// partial code (fewer bytes than its declared width) by consuming the rest
-    /// of the range so the iterator lands exactly on the end sentinel.
+    /// Fix the width of the code at the front of `m_range`. A trailing partial
+    /// code is dropped by consuming the rest of the range, so the iterator
+    /// lands exactly on the end sentinel.
     void settle() {
       if (m_range.empty()) {
         m_width = 0;
@@ -343,9 +299,8 @@ public:
     return {m_codes, m_width, m_codespace, m_cid_map};
   }
   [[nodiscard]] Iterator end() const {
-    // An empty view positioned at the end of the codes: the exhausted `begin()`
-    // iterator consumes down to this same one-past-the-end pointer, so the two
-    // compare equal (`operator==` matches on `data()`).
+    // An exhausted `begin()` consumes down to this same one-past-the-end
+    // pointer, and `operator==` matches on `data()`.
     return {m_codes.substr(m_codes.size()), m_width, m_codespace, m_cid_map};
   }
 
@@ -363,71 +318,46 @@ struct Font final : Element {
   /// fallback used when no `ToUnicode` CMap is present.
   std::optional<Encoding> encoding;
 
-  /// True for composite (Type0) fonts. Their character codes are
-  /// multi-byte and select CIDs via the Type0 `/Encoding` CMap; `/ToUnicode` is
-  /// the primary code -> Unicode path. Failing that, the predefined CJK CMaps
-  /// map code -> CID -> Unicode (via `pdf_cid`), or the `/CIDSystemInfo`
-  /// collection maps identity CIDs -> Unicode, or an embedded TrueType font's
-  /// reverse map recovers it (see `glyph_for_code` / `to_unicode`).
+  /// Composite (Type0): multi-byte codes selecting CIDs through the Type0
+  /// `/Encoding` CMap. See `to_unicode` for the extraction fallback chain.
   bool composite{false};
-  /// The descendant CIDFont's `/CIDSystemInfo` `/Registry` and `/Ordering`
-  /// (e.g. `Adobe` / `Identity` or `Adobe` / `Japan1`). Recorded for the
-  /// predefined CID -> Unicode table selection; empty for
-  /// simple fonts.
+  /// The descendant CIDFont's `/CIDSystemInfo` (e.g. `Adobe`/`Japan1`), which
+  /// picks the predefined CID -> Unicode table. Empty for simple fonts.
   std::string cid_registry;
   std::string cid_ordering;
-  /// The composite font's `/Encoding` when it is a *predefined* CMap name (e.g.
-  /// `Identity-H`, `UniGB-UCS2-H`, `90ms-RKSJ-H`); empty for an embedded CMap
-  /// stream. Drives the predefined-CMap extraction path (Unicode CMaps decoded
-  /// directly, legacy CJK CMaps mapped code -> CID -> Unicode).
+  /// The Type0 `/Encoding` when it is a *predefined* CMap name (`Identity-H`,
+  /// `UniGB-UCS2-H`, `90ms-RKSJ-H`, …); empty for an embedded CMap stream.
   std::string cid_encoding_name;
-  /// The composite font's `/Encoding` when it is an *embedded* CMap stream
-  /// (code -> CID plus codespace, ISO 32000-1 9.7.5.3); empty for a predefined
-  /// name (above) or a simple font. When it declares a CID map, `codes()`
-  /// yields CIDs through it — so a producer that mixes a 1-byte code (e.g. a
-  /// space) among 2-byte CIDs selects the right glyph and advance; when it
-  /// declares a codespace, that codespace (authoritative over `/ToUnicode`'s)
-  /// splits the code string.
+  /// The Type0 `/Encoding` when it is an *embedded* CMap stream (code -> CID
+  /// plus codespace, ISO 32000-1 9.7.5.3). Its codespace outranks
+  /// `/ToUnicode`'s when splitting a code string (see `codes`).
   CMap cid_encoding;
 
-  /// Simple-font glyph metrics (ISO 32000-1 9.2.4): `/Widths`, in glyph space
-  /// (1/1000 text-space units), indexed by `code - first_char`; codes outside
-  /// the range fall back to `missing_width` (`/MissingWidth`).
+  /// Simple-font metrics (ISO 32000-1 9.2.4): `/Widths` in glyph space (1/1000
+  /// em) indexed by `code - first_char`, else `/MissingWidth`.
   int first_char{0};
   std::vector<double> widths;
   double missing_width{0};
 
-  /// Composite-font glyph metrics (9.7.4.3): the `/DW` default width and the
-  /// `/W` map CID -> width, both glyph-space units. Codes are interpreted as
-  /// CIDs (identity), the common `Identity-H/V` case.
+  /// Composite-font metrics (9.7.4.3): `/DW` and the `/W` CID -> width map,
+  /// glyph space.
   double cid_default_width{1000};
   std::unordered_map<std::uint32_t, double> cid_widths;
 
-  /// FontDescriptor `/Ascent` in em units (the raw `/Ascent`, glyph space,
-  /// divided by 1000), when the descriptor declares it. The baseline-to-top
-  /// distance of the font's glyphs; used to place a run by its baseline (PDF's
-  /// text origin) rather than its CSS box top. Absent for fonts with no
-  /// descriptor `/Ascent` (the HTML layer then falls back to the embedded
-  /// font's bounding box, then a constant).
+  /// FontDescriptor `/Ascent` in em (i.e. /1000). The HTML layer raises each
+  /// run by it, since PDF's text origin is the baseline but a CSS box anchors
+  /// its top. Absent -> the layer falls back to the embedded bbox, then 0.8.
   std::optional<double> descriptor_ascent;
 
-  /// Bytes per character code: 2 for composite (Type0) fonts (the
-  /// `Identity-H/V` and common CID case), 1 for simple fonts.
+  /// Bytes per character code, absent a codespace saying otherwise.
   [[nodiscard]] int code_byte_width() const { return composite ? 2 : 1; }
 
-  /// View `codes` as a sequence of character codes, each yielded as the *CID*
-  /// it selects (identity when there is no CID map — the common case, and what
-  /// the glyph/advance paths expect). The result borrows `codes`; do not
-  /// outlive it.
+  /// View `codes` as character codes, each yielded as the CID it selects. The
+  /// result borrows `codes`.
   ///
-  /// A composite font splits (and maps) by its embedded CID `/Encoding` CMap
-  /// when present — that CMap declares both the codespace and the code -> CID
-  /// map, so a producer mixing a 1-byte code among 2-byte CIDs (PDFClown et
-  /// al.) stays aligned and selects the right glyph. Failing that it splits by
-  /// the `ToUnicode` codespace (CIDs identity — the same split `to_unicode`
-  /// uses, keeping glyph/advance/Unicode consistent), and failing that by a
-  /// fixed 2 bytes (the common `Identity-H` case). Simple fonts split by a
-  /// fixed 1 byte with identity CIDs.
+  /// The split is by the embedded CID `/Encoding` CMap's codespace if there is
+  /// one, else the `/ToUnicode` codespace (which keeps the split identical to
+  /// `to_unicode`'s), else the fixed `code_byte_width`.
   [[nodiscard]] CodeRange codes(std::string_view codes) const {
     const auto width = static_cast<std::size_t>(code_byte_width());
     if (!composite) {
@@ -440,52 +370,36 @@ struct Font final : Element {
     return {codes, width, codespace, cid_map};
   }
 
-  /// Embedded font: the SFNT parsed from `/FontFile2` (a simple TrueType font,
-  /// or a composite `CIDFontType2`), or `nullptr` when nothing is embedded or
-  /// the font is an unsupported flavor (`/FontFile3` CFF, `/FontFile` Type1 —
-  /// both not yet read). When present, the HTML layer re-encodes it to the PUA
-  /// and renders the actual glyphs via `@font-face`, and `to_unicode` reads the
-  /// embedded reverse map.
+  /// The embedded font program (`/FontFile`/`2`/`3`, all flavors), or null.
+  /// When present the HTML layer re-encodes it to the PUA and renders its real
+  /// glyphs via `@font-face`, and `to_unicode` can use its reverse map.
   std::shared_ptr<abstract::Font> embedded_font;
 
-  /// Substitution for a non-embedded font (`embedded_font == nullptr`): the CSS
-  /// `font-family` the HTML layer renders it in, plus the standard-14 AFM font
-  /// whose advance widths back `advance_width` when the font carries no
-  /// `/Widths`. Resolved once at parse time; `nullopt` for embedded fonts (they
-  /// render their real glyphs), Type3 fonts (their glyphs are drawn), and
-  /// composite fonts.
+  /// Substitution for a non-embedded simple font: the CSS `font-family` to
+  /// render in, plus the standard-14 AFM metrics backing `advance_width` when
+  /// the font ships no `/Widths`.
   std::optional<FontSubstitute> substitute;
 
-  /// Type3 font data (ISO 32000-1 9.6.5): set only for `/Subtype /Type3`, whose
-  /// glyphs are content streams rather than a font program. The executor runs
-  /// each shown code's char proc through the page machinery at the glyph
-  /// transform, so the glyphs paint as ordinary path/image elements; the text
-  /// stays selectable through the usual code -> Unicode chain (`/Encoding`).
+  /// Set only for `/Subtype /Type3` (ISO 32000-1 9.6.5).
   std::optional<Type3Data> type3;
 
-  /// Composite-font `/CIDToGIDMap` (ISO 32000-1 9.7.4.3) when given as an
-  /// explicit stream: `GID = cid_to_gid[CID]`. Empty means `Identity`
-  /// (`GID = CID`, the common case).
+  /// `/CIDToGIDMap` (9.7.4.3) as an explicit stream: `GID = cid_to_gid[CID]`.
+  /// Empty means `Identity`.
   std::vector<std::uint16_t> cid_to_gid;
 
-  /// Map a single character code (as split by `code_byte_width`) to a glyph id
-  /// in the `embedded_font`. For a composite font the code is the CID
-  /// (`Identity-H/V`), mapped to a GID via `/CIDToGIDMap`; for a simple
-  /// TrueType font the embedded `cmap` (or, failing that, the code's Unicode)
-  /// selects the glyph (ISO 32000-1 9.6.6.4). Returns 0 (`.notdef`) when there
-  /// is no embedded font or no mapping.
+  /// Glyph id of `code` in `embedded_font`; 0 (`.notdef`) when there is none.
+  /// Composite: CID through `/CIDToGIDMap`. Simple TrueType: the embedded
+  /// `cmap` keyed on the byte, then on the code's Unicode (9.6.6.4).
   [[nodiscard]] std::uint16_t glyph_for_code(std::uint32_t code) const;
 
-  /// Glyph advance width of a single character code, in text-space units
-  /// (glyph-space / 1000; multiply by the font size for user space). Falls back
-  /// to `/MissingWidth` (simple) or `/DW` (composite) for absent codes.
+  /// Advance of one code in text-space units (glyph space / 1000); multiply by
+  /// the font size for user space.
   [[nodiscard]] double advance_width(std::uint32_t code) const;
 
-  /// Translate a string of character codes to Unicode: the `ToUnicode` CMap
-  /// when present (authoritative); else, for a composite font, the predefined
-  /// `/Encoding` CMap (Unicode or legacy CJK), the `/CIDSystemInfo`
-  /// collection's CID -> Unicode, or the embedded reverse map — "no Unicode" if
-  /// all fail; else the simple-font `/Encoding`, else identity bytes.
+  /// Codes -> Unicode, first hit wins: `/ToUnicode`; then for a composite font
+  /// the predefined `/Encoding` CMap, the `/CIDSystemInfo` collection, the
+  /// embedded reverse map, else nothing; for a simple font the `/Encoding`,
+  /// the embedded reverse map, else identity bytes.
   [[nodiscard]] std::string to_unicode(const std::string &codes) const;
 };
 

--- a/src/odr/internal/pdf/pdf_document_parser.cpp
+++ b/src/odr/internal/pdf/pdf_document_parser.cpp
@@ -62,32 +62,58 @@ struct State {
     m_patterns[reference] = pattern;
   }
 
+  /// The `Pages` nodes on the current `/Kids` path. The page tree is required
+  /// to be acyclic (ISO 32000-1 7.7.3.2); without this a `/Kids` cycle recurses
+  /// until the stack overflows. `enter_pages` returns false on re-entry.
+  [[nodiscard]] bool enter_pages(const ObjectReference &reference) {
+    return m_active_pages.insert(reference).second;
+  }
+  void leave_pages(const ObjectReference &reference) {
+    m_active_pages.erase(reference);
+  }
+
 private:
   DocumentParser *m_parser{};
   Document *m_document{};
 
-  /// Memoized XObject elements by pointer. A shared form/image XObject (e.g.
-  /// a header reused on every page) is parsed once, and a cyclic form reference
-  /// resolves to the existing — possibly still-being-built — element instead of
-  /// recursing forever, so the in-memory graph mirrors the file (cycles
-  /// included). `find_x_object` returns `nullptr` when not yet parsed;
-  /// `cache_x_object` must register the element *before* its `/Resources` are
-  /// parsed. The drawing side guards against the resulting cycles.
+  /// Memoized XObject elements. Registering one *before* parsing its
+  /// `/Resources` is what makes a cyclic form reference resolve to the
+  /// (still-being-built) element instead of recursing forever; the drawing side
+  /// then guards the cycle at render time.
   std::map<ObjectReference, XObject *> m_x_objects;
 
-  /// Memoized Font elements by reference. Fonts are shared by indirect
-  /// reference across every page that uses them, so without this each page's
-  /// `/Resources` would parse a fresh `Font` element. The HTML writer dedups
-  /// embedded `@font-face` rules by `Font` pointer, so duplicate elements would
-  /// re-inline the (base64) font program once per page — a multi-page document
-  /// reusing one font would balloon to gigabytes.
+  /// Memoized Font elements. The HTML writer dedups `@font-face` rules by
+  /// `Font` pointer, so a duplicate element would re-inline the base64 font
+  /// program once per page.
   std::map<ObjectReference, Font *> m_fonts;
 
-  /// Memoized Pattern elements by reference, mirroring `m_x_objects`. A tiling
-  /// pattern's own `/Resources` may name patterns (including, in a malformed
-  /// file, itself); registering the element before its resources are parsed
-  /// breaks the cycle and shares a pattern reused across pages.
+  /// Memoized Pattern elements; register-before-parse as for `m_x_objects`,
+  /// since a tiling pattern's `/Resources` may name patterns (even itself).
   std::map<ObjectReference, Pattern *> m_patterns;
+
+  std::set<ObjectReference> m_active_pages;
+};
+
+/// RAII counterpart of `State::enter_pages` / `State::leave_pages`.
+class PagesScope {
+public:
+  PagesScope(State &state, const ObjectReference &reference)
+      : m_state{&state}, m_reference{reference},
+        m_entered{state.enter_pages(reference)} {}
+  ~PagesScope() {
+    if (m_entered) {
+      m_state->leave_pages(m_reference);
+    }
+  }
+  PagesScope(const PagesScope &) = delete;
+  PagesScope &operator=(const PagesScope &) = delete;
+
+  [[nodiscard]] bool entered() const { return m_entered; }
+
+private:
+  State *m_state;
+  ObjectReference m_reference;
+  bool m_entered;
 };
 
 /// Normalize /Rotate to {0, 90, 180, 270}: the spec requires a multiple of 90,
@@ -97,17 +123,13 @@ Integer normalize_rotate(Integer rotate) {
   return (rotate / 90) * 90;
 }
 
-/// The page attributes that are inherited through the `Pages` tree
-/// (ISO 32000-1 7.7.3.3, Table 30: exactly `Resources`, `MediaBox`,
-/// `CropBox`, `Rotate`). Threaded down the tree instead of walking `Parent`
-/// pointers — no cycle risk, no re-reads. Each slot holds the value set by the
-/// nearest ancestor that carried it (possibly an indirect reference, resolved
-/// lazily at the leaf); a null slot means no ancestor set it.
+/// The attributes inherited through the `Pages` tree (ISO 32000-1 7.7.3.3,
+/// Table 30). Threaded down the recursion rather than walked back up through
+/// `/Parent` — no cycle risk, no re-reads. Each slot holds the nearest
+/// ancestor's value, possibly still an indirect reference; null = unset.
 struct PageAttributes {
-  /// Default page size used when no `MediaBox` is present anywhere in the
-  /// page tree (US Letter, 612 × 792 pt). The spec requires `MediaBox`, so
-  /// this is a lenience for malformed files. (`Object` is not a literal type,
-  /// hence `static const` rather than `constexpr`.)
+  /// US Letter, the lenience for a page tree that declares no `MediaBox` at
+  /// all. (`Object` is not a literal type, hence not `constexpr`.)
   static const Object &default_media_box() {
     static const auto value =
         Object(Array({Object(Integer(0)), Object(Integer(0)),
@@ -120,9 +142,8 @@ struct PageAttributes {
   Object crop_box;
   Object rotate;
 
-  /// Overlay this node's own inheritable entries from `dictionary`. A
-  /// present-but-null entry counts as absent (7.3.9: null is equivalent to
-  /// omitting the entry) and leaves the inherited value untouched.
+  /// Overlay this node's own inheritable entries. A present-but-null entry
+  /// counts as absent (7.3.9).
   void overlay(const Dictionary &dictionary) {
     const auto take = [&](Object &slot, const std::string &key) {
       if (dictionary.has_value(key)) {
@@ -135,11 +156,8 @@ struct PageAttributes {
     take(rotate, "Rotate");
   }
 
-  /// Resolve the accumulated attributes into final values (7.7.3.4): write the
-  /// resolved `media_box`/`crop_box`/`rotate` onto `page` (references
-  /// resolved, missing `MediaBox` → US Letter, `CropBox` → `MediaBox`,
-  /// `Rotate` normalized) and return the `Resources` object (resolved, or an
-  /// empty dictionary if absent) for the caller to parse.
+  /// Write the resolved box/rotation onto `page` and return its `/Resources`
+  /// object for the caller to parse (7.7.3.4). Applies the Table-30 defaults.
   Object resolve_into(Page &page, DocumentParser &parser,
                       const ObjectReference &reference) const {
     page.media_box = parser.resolve_object_copy(media_box);
@@ -171,11 +189,9 @@ struct PageAttributes {
   }
 };
 
-/// Parse a simple-font `/Encoding`: either a base-encoding name, or a
-/// dictionary with an optional `/BaseEncoding` name overlaid with a
-/// `/Differences` array (`code name name … code name …`). Returns `nullopt` for
-/// an encoding that cannot be represented (e.g. an unsupported base name with
-/// no differences).
+/// Parse a simple-font `/Encoding` (ISO 32000-1 9.6.6): a base-encoding name,
+/// or a dictionary overlaying `/Differences` onto `/BaseEncoding`. `nullopt`
+/// for an encoding we cannot represent.
 std::optional<Encoding> parse_encoding(DocumentParser &parser,
                                        const Object &encoding_object) {
   const Object resolved = parser.resolve_object_copy(encoding_object);
@@ -290,19 +306,15 @@ util::math::Transform2D parse_matrix(DocumentParser &parser, Object object) {
           array[3].as_real(), array[4].as_real(), array[5].as_real()};
 }
 
-/// Load the embedded font from a `/FontDescriptor` through the `abstract::Font`
-/// interface: `/FontFile2` (TrueType / `CIDFontType2`) -> `SfntFont`, and
-/// `/FontFile3` (CFF / `Type1C` / `CIDFontType0C`, or OpenType-CFF) -> either
-/// an `SfntFont` (when the program is already a full SFNT, `/Subtype
-/// /OpenType`) or a bare `CffFont`. `/FontFile` (Type1) is translated to a CFF
-/// (`type1::to_cff`) and read as a `CffFont`, so it reuses the whole CFF path.
-/// A malformed font is logged and leaves `font.embedded_font` null, so such
-/// fonts keep rendering through the fallback path.
+/// Load a `/FontDescriptor`'s embedded program as an `abstract::Font`:
+/// `/FontFile2` -> `SfntFont`, `/FontFile3` -> `SfntFont` or bare `CffFont` by
+/// its magic, `/FontFile` (Type1) -> CFF via `type1::to_cff` so it reuses the
+/// CFF path. A malformed program is logged and leaves `embedded_font` null, so
+/// the font still renders through the substitute path.
 void load_embedded_font(DocumentParser &parser, const Dictionary &descriptor,
                         Font &font) {
-  // Capture `/Ascent` (glyph space, /1000) for baseline placement. Both the
-  // simple- and composite-font paths route their descriptor through here, so
-  // this is the one place that sees every descriptor.
+  // Both the simple- and composite-font paths route their descriptor through
+  // here, so this is the one place that sees every `/Ascent`.
   if (descriptor.has_key("Ascent")) {
     const Object ascent = parser.resolve_object_copy(descriptor["Ascent"]);
     if (ascent.is_real()) {
@@ -450,20 +462,15 @@ void parse_cid_to_gid_map(DocumentParser &parser, const Object &map,
   }
 }
 
-/// Parse a composite (Type0) font's descendant CIDFont (`/DescendantFonts` is a
-/// one-element array of the CIDFont): records the `/CIDSystemInfo`
-/// `/Registry`/`/Ordering` used to pick a predefined CID -> Unicode table.
-/// The Type0 `/Encoding` (code -> CID) is `Identity-H/V` or a predefined CJK
-/// CMap; only `/ToUnicode` is used for extraction.
+/// Parse a composite (Type0) font: its `/Encoding` and the widths, embedded
+/// program and `/CIDSystemInfo` of its one descendant CIDFont.
 void parse_composite_font(DocumentParser &parser, const Dictionary &dictionary,
                           Font &font) {
   font.composite = true;
 
-  // The Type0 `/Encoding`: a predefined CMap name (`Identity-H`,
-  // `UniGB-UCS2-H`, …) or an embedded CMap stream. A name drives the predefined
-  // Unicode-CMap path in `Font::to_unicode`; a stream is parsed into a
-  // code -> CID CMap (`Font::cid_encoding`) so `codes()` yields the right CIDs
-  // for a mixed-width encoding (ISO 32000-1 9.7.5.3).
+  // A predefined CMap name drives `Font::to_unicode`; an embedded stream is
+  // parsed into a code -> CID CMap so `codes()` yields the right CIDs for a
+  // mixed-width encoding (ISO 32000-1 9.7.5.3).
   if (dictionary.has_key("Encoding")) {
     const Object encoding = parser.resolve_object_copy(dictionary["Encoding"]);
     if (encoding.is_name()) {
@@ -488,7 +495,7 @@ void parse_composite_font(DocumentParser &parser, const Dictionary &dictionary,
   }
   const Object descendants =
       parser.resolve_object_copy(dictionary["DescendantFonts"]);
-  if (!descendants.is_array() || descendants.as_array().size() == 0) {
+  if (!descendants.is_array() || descendants.as_array().empty()) {
     return;
   }
 
@@ -544,11 +551,9 @@ void parse_composite_font(DocumentParser &parser, const Dictionary &dictionary,
 
 Resources *parse_resources(State &state, const Object &object);
 
-/// Parse a Type3 font (ISO 32000-1 9.6.5): `/FontMatrix` (glyph -> text space),
-/// the `/CharProcs` glyph content streams (decoded and kept by glyph name), and
-/// the `/Resources` those procs draw against. `/FirstChar`/`/Widths` (glyph
-/// space) and `/Encoding` (code -> glyph name) are parsed by the caller, as for
-/// any simple font.
+/// Parse the Type3-specific parts of a font (ISO 32000-1 9.6.5): `/FontMatrix`,
+/// the `/CharProcs` streams and their `/Resources`. `/FirstChar`, `/Widths` and
+/// `/Encoding` are parsed by the caller, as for any simple font.
 void parse_type3_font(State &state, const Dictionary &dictionary, Font &font) {
   DocumentParser &parser = state.parser();
   Type3Data type3;
@@ -693,12 +698,9 @@ void bind_parser_io(Context &context, DocumentParser &parser) {
   };
 }
 
-/// Resolve a `/SMask` (soft mask) or stencil `/Mask` sub-image referenced by
-/// `mask` into a base-sized alpha plane (ISO 32000-1 11.6.5.2 / 8.9.6.3). The
-/// sub-image is a single-component raster: decode its `/Filter` chain, then map
-/// its samples to coverage (`decode_mask_alpha`). Returns empty when `mask` is
-/// not a stream reference or its codec is not decodable (CCITT/JBIG2/JPX), so
-/// the base image stays opaque.
+/// Resolve a `/SMask` or stencil `/Mask` sub-image into a base-sized alpha
+/// plane (ISO 32000-1 11.6.5.2 / 8.9.6.3). Empty when `mask` is not a stream
+/// reference or its codec is undecodable, leaving the base image opaque.
 std::vector<std::uint8_t> resolve_mask_alpha(DocumentParser &parser,
                                              const Object &mask,
                                              const std::int32_t base_width,
@@ -732,11 +734,9 @@ std::vector<std::uint8_t> resolve_mask_alpha(DocumentParser &parser,
       image_decode(parser, dictionary), stencil, base_width, base_height);
 }
 
-/// Carry an `/ImageMask true` stencil's decoded bitmap and geometry onto
-/// `x_object` (ISO 32000-1 8.9.6.2). The stencil is painted in the current fill
-/// colour, known only at `Do` time, so the page extractor recolours it; here we
-/// only decode and stash. An undecodable codec leaves `stencil_mask` false so
-/// `Do` skips it.
+/// Decode an `/ImageMask true` stencil onto `x_object` (ISO 32000-1 8.9.6.2).
+/// Only decoded, not coloured: the fill colour is known only at `Do` time. An
+/// undecodable codec leaves `stencil_mask` false, so `Do` skips it.
 void parse_stencil_mask(DocumentParser &parser, const Dictionary &dictionary,
                         const IndirectObject &object, XObject &x_object) {
   Object filter;
@@ -764,16 +764,12 @@ void parse_stencil_mask(DocumentParser &parser, const Dictionary &dictionary,
   x_object.stencil_decode = image_decode(parser, dictionary);
 }
 
-/// Build the browser-ready bytes of an image XObject (ISO 32000-1 8.9). A JPEG
-/// (`DCTDecode`) passes through undecoded; a fully decodable raster
-/// (Flate/LZW/RunLength/ASCII/raw) is decoded, its samples assembled through
-/// the image's colour space and re-encoded as a PNG — RGBA when a `/SMask`,
-/// stencil `/Mask` or colour-key `/Mask` supplies transparency. Codecs we
-/// cannot yet hand off (JPXDecode, CCITTFaxDecode, JBIG2Decode) and unresolved
-/// colour spaces leave the bytes empty, so `Do` skips the image. A `/SMask` or
-/// `/Mask` on a JPEG base is ignored (decoding the JPEG to composite is out of
-/// scope). `resources` supplies the enclosing `/ColorSpace` table so a `/CS…`
-/// named colour space resolves.
+/// Build the browser-ready bytes of an image XObject (ISO 32000-1 8.9): a JPEG
+/// passes through, any other decodable raster is assembled through its colour
+/// space and re-encoded as PNG (RGBA when masked). An undecodable codec or
+/// colour space leaves the bytes empty, so `Do` skips the image. Transparency
+/// on a JPEG base is ignored — compositing it would mean decoding the JPEG.
+/// `resources` resolves a named `/CS…` colour space.
 void parse_image_data(DocumentParser &parser, const Dictionary &dictionary,
                       const IndirectObject &object, XObject &x_object,
                       const Resources *resources) {
@@ -1005,12 +1001,9 @@ Pattern *parse_pattern(State &state, const ObjectReference &reference,
   return pattern;
 }
 
-/// Resolve a `/SMask` soft-mask dictionary from an `/ExtGState` (ISO 32000-1
-/// 11.6.5.2) into a `SoftMaskDef`: parse its `/G` transparency group as a form
-/// XObject, read `/S` (`/Luminosity` default, `/Alpha`) and the `/BC` backdrop.
-/// Returns null when `/G` is missing or not a form (then `gs` treats the state
-/// as having no mask). `/SMask /None` never reaches here — the caller filters
-/// non-dictionaries out first.
+/// Resolve an `/ExtGState` `/SMask` dictionary into a `SoftMaskDef` (ISO
+/// 32000-1 11.6.5.2). Null when `/G` is missing or not a form, which `gs` reads
+/// as "no mask". `/SMask /None` never reaches here — it is not a dictionary.
 std::shared_ptr<SoftMaskDef> parse_soft_mask(State &state,
                                              const Dictionary &dictionary) {
   DocumentParser &parser = state.parser();
@@ -1191,11 +1184,9 @@ Page *parse_page(State &state, const ObjectReference &reference, Pages *parent,
   const Object resources = attributes.resolve_into(*page, parser, reference);
   page->resources = parse_resources(state, resources);
 
-  // /Contents is a content stream or an array of them, supplied directly or
-  // through an indirect reference (7.7.3.3). It is optional — a page may have
-  // none (e.g. a blank page carrying only annotations). Resolve a reference
-  // first so that a reference to an array is expanded into its stream
-  // references rather than mistaken for a single stream.
+  // `/Contents` is optional, and is one stream or an array of them (7.7.3.3).
+  // Resolve first, so a reference *to an array* expands rather than being
+  // mistaken for a single stream.
   if (dictionary.has_key("Contents")) {
     const Object &contents = dictionary["Contents"];
     const Object resolved_contents = parser.resolve_object_copy(contents);
@@ -1230,6 +1221,12 @@ Page *parse_page(State &state, const ObjectReference &reference, Pages *parent,
 
 Pages *parse_pages(State &state, const ObjectReference &reference,
                    PageAttributes attributes) {
+  const PagesScope scope(state, reference);
+  if (!scope.entered()) {
+    throw std::runtime_error("cyclic PDF page tree at " +
+                             reference.to_string());
+  }
+
   DocumentParser &parser = state.parser();
   Document &document = state.document();
 
@@ -1320,11 +1317,9 @@ DocumentParser::DocumentParser(std::unique_ptr<std::istream> in,
     // Build an `Authenticator` from the trailer `/Encrypt` and `/ID`
     // (ISO 32000-1 7.6).
 
-    // The `/Encrypt` dictionary's own `/O`,`/U`,… strings are never encrypted
-    // (7.6.2), and need no explicit self-skip guard: it is resolved here while
-    // `m_decryptor` is still empty (installed only after this block), so
-    // `read_object` leaves its strings raw and caches that copy — every later
-    // lookup hits the cache and never re-decrypts it.
+    // The `/Encrypt` dictionary's own strings are never encrypted (7.6.2), and
+    // need no self-skip guard: resolving it here, before any decryptor exists,
+    // caches the raw strings that every later lookup then serves.
     Object encrypt = m_trailer["Encrypt"];
     resolve_object(encrypt);
     if (!encrypt.is_dictionary()) {
@@ -1340,11 +1335,10 @@ DocumentParser::DocumentParser(std::unique_ptr<std::istream> in,
       }
     }
 
-    // Set only after resolving `/Encrypt` above: `read_object` throws on an
-    // encrypted-but-unauthenticated read, and that resolution runs before any
-    // decryptor exists. `m_is_encrypted` records that the file declares
-    // encryption regardless of whether we can authenticate it, so an
-    // unsupported handler still reports as encrypted.
+    // Set only now: `read_object` throws on an encrypted-but-unauthenticated
+    // read, and the resolution above runs before any decryptor exists. This
+    // records that the file *declares* encryption, so an unsupported handler
+    // still reports as encrypted.
     m_is_encrypted = true;
     m_authenticator = Authenticator::create(encrypt.as_dictionary(), id0);
   }
@@ -1470,7 +1464,7 @@ DocumentParser::read_object_stream(const ObjectReference &reference) {
 }
 
 std::string DocumentParser::read_object_stream(const IndirectObject &object) {
-  Object length = object.object.as_dictionary()["Length"];
+  Object length = object.object.as_dictionary().get("Length");
   resolve_object(length);
 
   // a stream object always carries a stream position

--- a/src/odr/internal/pdf/pdf_document_parser.hpp
+++ b/src/odr/internal/pdf/pdf_document_parser.hpp
@@ -23,21 +23,15 @@ namespace odr::internal::pdf {
 struct Document;
 
 /// Resolution/memoization layer on top of the sequential `FileParser`: maps
-/// `ObjectReference`s to file positions via the cross-reference table and
-/// hands out resolved objects by reference.
+/// `ObjectReference`s to file positions via the cross-reference table and hands
+/// out resolved objects by reference.
 ///
-/// Reads are memoized in `m_objects` / `m_object_streams`. This is intrinsic,
-/// not a convenience: a compressed object can only be read by inflating and
-/// parsing the whole object stream that holds it, and only this class knows
-/// (from the xref) which objects share a stream — so the caller cannot dedupe
-/// that work. `read_object` is also reentrant (length resolution, object-stream
-/// loading, deep resolution), and the object graph has heavy sharing, so the
-/// cache must live here.
-///
-/// Both caches grow monotonically and are never evicted, which is safe only
-/// because a `DocumentParser` is a transient per-render object: build one,
-/// produce a `Document`, read its lazy streams, then discard it. Do not hold it
-/// long-lived or share it across documents.
+/// The caches are intrinsic, not a convenience: reading one compressed object
+/// means inflating and parsing the whole object stream holding it, and only
+/// this class knows from the xref which objects share one. They grow
+/// monotonically and are never evicted, which is safe only because a
+/// `DocumentParser` is transient per render — build one, produce a `Document`,
+/// read its lazy streams, discard it. Never share one across documents.
 class DocumentParser {
 public:
   /// Takes ownership of the input stream (move-only: the parser is the

--- a/src/odr/internal/pdf/pdf_encryption.cpp
+++ b/src/odr/internal/pdf/pdf_encryption.cpp
@@ -43,8 +43,7 @@ std::string xor_key(std::string key, const std::uint8_t x) {
 /// Pad/truncate a password to 32 bytes with the padding constant (Algorithm 2,
 /// step a).
 std::string pad_password(const std::string &password) {
-  std::string pw =
-      password.substr(0, std::min<std::size_t>(password.size(), 32));
+  std::string pw = password.substr(0, 32);
   pw += padding.substr(0, 32 - pw.size());
   return pw;
 }
@@ -237,6 +236,12 @@ Authenticator::create(const Dictionary &encrypt, const std::string &file_id0) {
 
   if (d.m_v >= 5) {
     if (!encrypt.has_key("OE") || !encrypt.has_key("UE")) {
+      return std::nullopt;
+    }
+    // `/O` and `/U` are 48 bytes: 32-byte hash + 8-byte validation salt +
+    // 8-byte key salt (ISO 32000-2 7.6.4.3). `authenticate` slices them
+    // unconditionally, so refuse a truncated pair here.
+    if (d.m_o.size() < 48 || d.m_u.size() < 48) {
       return std::nullopt;
     }
     d.m_oe = encrypt["OE"].as_string();

--- a/src/odr/internal/pdf/pdf_encryption.hpp
+++ b/src/odr/internal/pdf/pdf_encryption.hpp
@@ -17,11 +17,9 @@ enum class EncryptionMethod {
   aes_v3, ///< AES-256-CBC, file key used directly (V 5).
 };
 
-/// The decrypting half of the PDF standard security handler (ISO 32000-1 7.6):
-/// holds the derived file encryption key and the stream/string methods, and
-/// decrypts the strings and streams of indirect objects. Obtained from
-/// `Authenticator::authenticate`; immutable and always usable — there is no
-/// un-authenticated state. Read-only: permission bits are not enforced.
+/// The decrypting half of the PDF standard security handler (ISO 32000-1 7.6),
+/// holding the derived file key. Produced by `Authenticator::authenticate`, so
+/// its mere existence means the file is unlocked.
 class Decryptor {
 public:
   /// Wrap an already-derived file key and the resolved stream/string methods.
@@ -53,10 +51,9 @@ private:
 };
 
 /// The authenticating half of the PDF standard security handler (ISO 32000-1
-/// 7.6; AES-256 / R 6 per ISO 32000-2 7.6.4): parses the `/Encrypt` dictionary
-/// and validates a password, producing a `Decryptor` on success. Permission
-/// bits (`/P`) are recorded but not enforced — same stance as the rest of the
-/// engine.
+/// 7.6; AES-256 / R 6 per ISO 32000-2 7.6.4): validates a password against the
+/// `/Encrypt` dictionary, producing a `Decryptor`. Permission bits are recorded
+/// but not enforced.
 ///
 /// Supported configurations (anything else → `create` returns `nullopt`):
 ///   - `V 1/2`, `R 2/3` — RC4, 40-128 bit.
@@ -74,13 +71,9 @@ public:
   /// The raw `/P` permission bitfield (recorded, not enforced).
   [[nodiscard]] std::int64_t permissions() const { return m_p; }
 
-  /// Try `password` (UTF-8/PDFDocEncoded bytes) as the user password, then as
-  /// the owner password. Returns a ready-to-use `Decryptor` on success, or
-  /// `nullopt` if neither matches. The empty password is the usual case
-  /// (owner-locked-only files). The derived key lives only inside the returned
-  /// `Decryptor` — callers carry the `Decryptor` forward (e.g. to re-open the
-  /// file for rendering) rather than the bare key, so the password is never
-  /// retained.
+  /// Try `password` as the user password, then as the owner password;
+  /// `nullopt` if neither matches. The derived key lives only inside the
+  /// returned `Decryptor`, which callers carry forward instead of the key.
   [[nodiscard]] std::optional<Decryptor>
   authenticate(const std::string &password) const;
 

--- a/src/odr/internal/pdf/pdf_file_parser.cpp
+++ b/src/odr/internal/pdf/pdf_file_parser.cpp
@@ -133,12 +133,10 @@ std::string FileParser::read_stream(const std::uint32_t size) {
 }
 
 std::string FileParser::read_stream() {
-  // Length unknown (recovery path): the stream terminator is the `endstream`
-  // keyword followed by the object's `endobj` (7.3.8.1). `endstream` can occur
-  // inside binary/compressed payload, so scan for the whole `endstream <ws>
-  // endobj` sequence rather than stopping at the first `endstream` — which
-  // would truncate such streams. Bytes consumed while probing a false match are
-  // folded back into the data, so no rewind is needed.
+  // Length unknown (recovery path), so scan for the terminator (7.3.8.1). It
+  // must be the whole `endstream <ws> endobj` sequence: a bare `endstream` also
+  // occurs inside binary payload, and stopping there would truncate the stream.
+  // Bytes consumed probing a false match are folded back into the data.
   static const std::string end_stream = "endstream";
   static const std::string end_obj = "endobj";
 
@@ -224,7 +222,7 @@ void FileParser::read_header() {
 }
 
 Entry FileParser::read_entry() {
-  std::uint32_t position = in().tellg();
+  const std::uint32_t position = in().tellg();
   const std::string entry_header = m_parser.read_line();
   in().seekg(position);
 
@@ -383,11 +381,9 @@ match_object_start(const std::string_view content) {
   return ObjectReference(id, gen);
 }
 
-/// True if `content` (already trimmed) ends with the `stream` keyword on a word
-/// boundary. This covers both a bare `stream` line and a compact object that
-/// inlines its dictionary and the `stream` token on one line
-/// (`N G obj<<...>>stream`). The boundary check rejects `endstream` and
-/// identifiers that merely end in `stream`.
+/// True if the trimmed `content` ends with the `stream` keyword on a word
+/// boundary — covering a compact `N G obj<<...>>stream` line as well as a bare
+/// one. The boundary check rejects `endstream`.
 bool opens_stream_body(const std::string_view content) {
   constexpr std::string_view keyword = "stream";
   if (!content.ends_with(keyword)) {

--- a/src/odr/internal/pdf/pdf_function.cpp
+++ b/src/odr/internal/pdf/pdf_function.cpp
@@ -55,8 +55,10 @@ protected:
   std::vector<double> compute(const std::vector<double> &in) const override {
     const double x = in.empty() ? 0.0 : in[0];
     const double xn = std::pow(x, m_n);
-    std::vector<double> out(m_c0.size());
-    for (std::size_t j = 0; j < m_c0.size(); ++j) {
+    // `/C0` and `/C1` must be equally long; a malformed file may disagree.
+    const std::size_t count = std::min(m_c0.size(), m_c1.size());
+    std::vector<double> out(count);
+    for (std::size_t j = 0; j < count; ++j) {
       out[j] = m_c0[j] + xn * (m_c1[j] - m_c0[j]);
     }
     return out;
@@ -95,8 +97,12 @@ protected:
     }
     const double lo = k == 0 ? d0 : m_bounds[k - 1];
     const double hi = k < m_bounds.size() ? m_bounds[k] : d1;
-    const double e0 = m_encode[2 * k];
-    const double e1 = m_encode[2 * k + 1];
+    // `/Bounds` must have one entry fewer than `/Functions`, and `/Encode` two
+    // per function; a malformed file may declare fewer of either.
+    k = std::min(k, m_functions.size() - 1);
+    const bool encoded_k = 2 * k + 1 < m_encode.size();
+    const double e0 = encoded_k ? m_encode[2 * k] : 0.0;
+    const double e1 = encoded_k ? m_encode[2 * k + 1] : 1.0;
     const double encoded = interpolate(x, lo, hi, e0, e1);
 
     if (m_functions[k] == nullptr) {
@@ -400,10 +406,15 @@ private:
         s.emplace_back(static_cast<double>(~static_cast<std::int32_t>(a)));
       }
     } else if (op == "bitshift") {
-      const auto shift = static_cast<std::int32_t>(pop_number(s));
+      const double shift = pop_number(s);
       const auto value = static_cast<std::int32_t>(pop_number(s));
-      s.emplace_back(
-          static_cast<double>(shift >= 0 ? value << shift : value >> -shift));
+      // Shifting a 32-bit value by 32 or more is undefined in C++; PostScript
+      // shifts every bit out. (The comparison also catches a NaN shift.)
+      const double magnitude = std::abs(shift);
+      const std::int32_t by =
+          magnitude < 32.0 ? static_cast<std::int32_t>(magnitude) : 32;
+      s.emplace_back(static_cast<double>(
+          by == 32 ? 0 : (shift >= 0 ? value << by : value >> by)));
     } else if (op == "true") {
       s.emplace_back(1.0);
     } else if (op == "false") {
@@ -416,9 +427,12 @@ private:
       s[s.size() - 1] = a;
       s[s.size() - 2] = b;
     } else if (op == "dup") {
-      s.push_back(s.back());
+      s.push_back(s.at(s.size() - 1));
     } else if (op == "copy") {
       const auto count = static_cast<std::size_t>(pop_number(s));
+      if (count > s.size()) {
+        throw std::runtime_error("stack underflow");
+      }
       const std::size_t start = s.size() - count;
       for (std::size_t i = 0; i < count; ++i) {
         s.push_back(s[start + i]);
@@ -430,6 +444,9 @@ private:
       const auto j = static_cast<std::int32_t>(pop_number(s));
       const auto count = static_cast<std::int32_t>(pop_number(s));
       if (count > 0) {
+        if (static_cast<std::size_t>(count) > s.size()) {
+          throw std::runtime_error("stack underflow");
+        }
         const auto first = s.end() - count;
         const std::int32_t shift = ((j % count) + count) % count;
         std::rotate(first, s.end() - shift, s.end());
@@ -614,7 +631,21 @@ pdf::parse_function(const Object &object, const FunctionContext &context) {
       decode = range;
     }
     std::string samples = context.load_stream(object);
-    if (size.empty() || bits == 0 || range.empty()) {
+    if (domain.empty()) {
+      domain.assign(2 * size.size(), 0.0);
+      for (std::size_t i = 1; i < domain.size(); i += 2) {
+        domain[i] = 1.0;
+      }
+    }
+    // `SampledFunction::compute` indexes `2 * m` domain/encode entries and
+    // `2 * n` decode entries, and interpolates over the `2^m` corners around
+    // the sample point — so a malformed `/Size` must not outrun any of them.
+    // Real sampled functions take one or two inputs (7.10.2).
+    constexpr std::size_t max_inputs = 8;
+    if (size.empty() || size.size() > max_inputs || bits < 1 || bits > 32 ||
+        range.empty() || domain.size() < 2 * size.size() ||
+        encode.size() < 2 * size.size() || decode.size() < range.size() ||
+        std::ranges::find(size, std::size_t{0}) != size.end()) {
       return nullptr;
     }
     return std::make_shared<SampledFunction>(

--- a/src/odr/internal/pdf/pdf_graphics_operator_parser.cpp
+++ b/src/odr/internal/pdf/pdf_graphics_operator_parser.cpp
@@ -140,11 +140,9 @@ std::optional<std::int32_t> inline_color_components(const Object &color_space) {
   return std::nullopt;
 }
 
-// Byte length of an inline image's raw data, derived from its sample geometry —
-// but only when that length is knowable: the image must be unfiltered (a
-// filtered payload's size is unknown until decoded) and its colour space must
-// be a device space. Returns `nullopt` otherwise, leaving the caller to scan
-// for the `EI` terminator.
+// Byte length of an inline image's raw data from its sample geometry, when
+// that is knowable at all: the image must be unfiltered and in a device colour
+// space. `nullopt` otherwise, leaving the caller to scan for `EI`.
 std::optional<std::size_t>
 inline_image_raw_length(const Dictionary &dictionary) {
   if (!inline_image_entry(dictionary, "F", "Filter").is_null()) {
@@ -241,11 +239,10 @@ GraphicsOperator GraphicsOperatorParser::read_operator() {
     } else if (m_parser.peek_dictionary()) {
       result.arguments.emplace_back(m_parser.read_dictionary());
     } else {
-      // A bareword here is either a `true`/`false` literal (a value inside an
-      // inline image dictionary, 8.9.7) or the operator name that ends the
-      // arguments. `peek_boolean` cannot disambiguate these because operators
-      // such as `f` (fill) or `Tj` share their leading character with the
-      // boolean keywords, so read the whole word and compare it.
+      // A bareword is either a `true`/`false` literal (inline image
+      // dictionaries carry them, 8.9.7) or the operator name ending the
+      // arguments. `peek_boolean` cannot tell them apart — `f` and `Tj` share
+      // their leading character with the keywords — so read the whole word.
       operator_name = read_operator_name();
       if (operator_name == "true") {
         result.arguments.emplace_back(Boolean(true));
@@ -301,11 +298,9 @@ GraphicsOperatorParser::read_inline_image_data(const Dictionary &dictionary) {
     m_parser.bumpc();
   }
 
-  // When the byte length is knowable (an unfiltered device-colour image), read
-  // exactly that many bytes. This is the only reliable terminator: raw samples
-  // can contain the bytes `E I <white-space>`, which the scan below would
-  // mistake for the real `EI` and so truncate the image (and corrupt the rest
-  // of the page).
+  // A knowable byte length is the only reliable terminator: raw samples can
+  // contain `E I <white-space>`, which the scan below would mistake for the
+  // real `EI`, truncating the image and derailing the rest of the page.
   if (const std::optional<std::size_t> length =
           inline_image_raw_length(dictionary)) {
     std::string data;
@@ -329,11 +324,9 @@ GraphicsOperatorParser::read_inline_image_data(const Dictionary &dictionary) {
     return data;
   }
 
-  // Otherwise the length is not encoded (a filtered payload), so scan for the
-  // `EI` terminator. `EI` also occurs inside the encoded bytes, so accept one
-  // only when it is bracketed by white-space — preceded by it (the writer's
-  // convention) and followed by it or eof — which makes a false match unlikely.
-  // The terminator (and the white-space before it) is left out of the data.
+  // A filtered payload encodes no length, so scan for `EI`. It also occurs
+  // inside encoded bytes, so accept it only bracketed by white-space, which
+  // makes a false match unlikely. The terminator is left out of the data.
   std::string data;
   while (true) {
     const int_type c = m_parser.geti();

--- a/src/odr/internal/pdf/pdf_graphics_state.cpp
+++ b/src/odr/internal/pdf/pdf_graphics_state.cpp
@@ -2,6 +2,8 @@
 
 #include <odr/internal/pdf/pdf_graphics_operator.hpp>
 
+#include <cstddef>
+
 namespace odr::internal::pdf {
 
 namespace {
@@ -10,6 +12,34 @@ util::math::Transform2D matrix_from_args(const GraphicsOperator &op) {
   return {op.arguments.at(0).as_real(), op.arguments.at(1).as_real(),
           op.arguments.at(2).as_real(), op.arguments.at(3).as_real(),
           op.arguments.at(4).as_real(), op.arguments.at(5).as_real()};
+}
+
+// The device colour operators carry their components inline and supersede any
+// `cs`/`CS`-selected colour space and pattern (ISO 32000-1 8.6.8).
+
+void set_device_grey(GraphicsState::Color &color, const GraphicsOperator &op) {
+  color.space = ColorSpace::device_grey;
+  color.grey = op.arguments.at(0).as_real();
+  color.def = nullptr;
+  color.pattern.clear();
+}
+
+void set_device_rgb(GraphicsState::Color &color, const GraphicsOperator &op) {
+  color.space = ColorSpace::device_rgb;
+  for (std::size_t i = 0; i < color.rgb.size(); ++i) {
+    color.rgb[i] = op.arguments.at(i).as_real();
+  }
+  color.def = nullptr;
+  color.pattern.clear();
+}
+
+void set_device_cmyk(GraphicsState::Color &color, const GraphicsOperator &op) {
+  color.space = ColorSpace::device_cmyk;
+  for (std::size_t i = 0; i < color.cmyk.size(); ++i) {
+    color.cmyk[i] = op.arguments.at(i).as_real();
+  }
+  color.def = nullptr;
+  color.pattern.clear();
 }
 
 } // namespace
@@ -140,7 +170,13 @@ void GraphicsState::clip_bounding_box(const double x0, const double y0,
 
 void GraphicsState::save() { stack.push_back(stack.back()); }
 
-void GraphicsState::restore() { stack.pop_back(); }
+void GraphicsState::restore() {
+  // A `Q` without a matching `q` is malformed (ISO 32000-1 8.4.4) and real
+  // files emit it; keep the initial state so `current()` stays valid.
+  if (stack.size() > 1) {
+    stack.pop_back();
+  }
+}
 
 void GraphicsState::concat_matrix(const util::math::Transform2D &matrix) {
   // CTM = matrix * CTM (ISO 32000-1 8.4.4).
@@ -284,69 +320,36 @@ void GraphicsState::execute(const GraphicsOperator &op) {
     next_line(0, -current().text.leading);
     break;
 
-  // The color-space (`cs`/`CS`) and general color (`sc`/`scn`/`SC`/`SCN`)
-  // operators need the `/ColorSpace` resources to resolve, so they are handled
-  // in `pdf_page_extractor` (which has the `Resources`), not here. The device
-  // color operators below carry their components inline and clear any active
-  // non-device color space.
+  // `cs`/`CS` and `sc`/`scn`/`SC`/`SCN` need the `/ColorSpace` resources, so
+  // they are handled in `pdf_page_extractor`, not here.
   case GraphicsOperatorType::set_stroke_grey_color:
-    current().stroke_color.space = ColorSpace::device_grey;
-    current().stroke_color.grey = op.arguments.at(0).as_real();
-    current().stroke_color.def = nullptr;
-    current().stroke_color.pattern.clear();
+    set_device_grey(current().stroke_color, op);
     break;
   case GraphicsOperatorType::set_stroke_rgb_color:
-    current().stroke_color.space = ColorSpace::device_rgb;
-    for (int i = 0; i < 3; ++i) {
-      current().stroke_color.rgb.at(i) = op.arguments.at(i).as_real();
-    }
-    current().stroke_color.def = nullptr;
-    current().stroke_color.pattern.clear();
+    set_device_rgb(current().stroke_color, op);
     break;
   case GraphicsOperatorType::set_stroke_cmyk_color:
-    current().stroke_color.space = ColorSpace::device_cmyk;
-    for (int i = 0; i < 4; ++i) {
-      current().stroke_color.cmyk.at(i) = op.arguments.at(i).as_real();
-    }
-    current().stroke_color.def = nullptr;
-    current().stroke_color.pattern.clear();
+    set_device_cmyk(current().stroke_color, op);
     break;
 
   case GraphicsOperatorType::set_other_grey_color:
-    current().other_color.space = ColorSpace::device_grey;
-    current().other_color.grey = op.arguments.at(0).as_real();
-    current().other_color.def = nullptr;
-    current().other_color.pattern.clear();
+    set_device_grey(current().other_color, op);
     break;
   case GraphicsOperatorType::set_other_rgb_color:
-    current().other_color.space = ColorSpace::device_rgb;
-    for (int i = 0; i < 3; ++i) {
-      current().other_color.rgb.at(i) = op.arguments.at(i).as_real();
-    }
-    current().other_color.def = nullptr;
-    current().other_color.pattern.clear();
+    set_device_rgb(current().other_color, op);
     break;
   case GraphicsOperatorType::set_other_cmyk_color:
-    current().other_color.space = ColorSpace::device_cmyk;
-    for (int i = 0; i < 4; ++i) {
-      current().other_color.cmyk.at(i) = op.arguments.at(i).as_real();
-    }
-    current().other_color.def = nullptr;
-    current().other_color.pattern.clear();
+    set_device_cmyk(current().other_color, op);
     break;
 
-  case GraphicsOperatorType::set_glyph_width:
-    for (int i = 0; i < 2; ++i) {
-      current().text.glyph_width.at(i) = op.arguments.at(i).as_real();
-    }
-    break;
   case GraphicsOperatorType::set_glyph_width_bounding_box:
-    for (int i = 0; i < 2; ++i) {
-      current().text.glyph_width.at(i) = op.arguments.at(i).as_real();
+    for (std::size_t i = 0; i < 4; ++i) {
+      current().text.glyph_bounding_box[i] = op.arguments.at(i + 2).as_real();
     }
-    for (int i = 0; i < 4; ++i) {
-      current().text.glyph_bounding_box.at(i) =
-          op.arguments.at(i + 2).as_real();
+    [[fallthrough]];
+  case GraphicsOperatorType::set_glyph_width:
+    for (std::size_t i = 0; i < 2; ++i) {
+      current().text.glyph_width[i] = op.arguments.at(i).as_real();
     }
     break;
 

--- a/src/odr/internal/pdf/pdf_graphics_state.hpp
+++ b/src/odr/internal/pdf/pdf_graphics_state.hpp
@@ -21,10 +21,8 @@ enum class ColorSpace {
   device_cmyk,
 };
 
-/// Text rendering mode (`Tr`, ISO 32000-1 Table 106): how shown glyphs are
-/// painted and/or added to the clipping path. The low two bits select the paint
-/// (fill / stroke / both / none); the `_clip` modes additionally add the glyph
-/// outlines to the clip. The integer values are the `Tr` operands.
+/// Text rendering mode (`Tr`, ISO 32000-1 Table 106). The values are the `Tr`
+/// operands; the low two bits select the paint, `>= 4` also clips.
 enum class TextRenderingMode {
   fill = 0,
   stroke = 1,
@@ -36,9 +34,8 @@ enum class TextRenderingMode {
   clip = 7,
 };
 
-/// One segment of a subpath, in user space (the CTM is already applied at
-/// construction time, ISO 32000-1 8.5.2.1). A line carries only `end`; a cubic
-/// Bézier carries its two control points as well.
+/// One segment of a subpath, in user space (the CTM is applied at construction
+/// time, ISO 32000-1 8.5.2.1).
 struct PathSegment {
   enum class Kind { line, cubic };
   Kind kind{Kind::line};
@@ -47,37 +44,32 @@ struct PathSegment {
   std::array<double, 2> end{}; // segment endpoint
 };
 
-/// A subpath: a start point (from `m`/`re`), its segments, and whether it was
-/// explicitly closed (`h` or a close-and-paint operator). Coordinates are user
-/// space.
+/// A subpath from `m`/`re`, in user space. `closed` records an explicit `h` or
+/// close-and-paint operator.
 struct Subpath {
   std::array<double, 2> start{};
   std::vector<PathSegment> segments;
   bool closed{false};
 };
 
-/// One clipping region (ISO 32000-1 8.5.4): the path established by a `W`/`W*`
-/// operator, in user space, plus the winding rule that fills it. The current
-/// clip is the *intersection* of an ordered list of these — a path is visible
-/// only where it lies inside every one.
+/// One `W`/`W*` clipping region in user space (ISO 32000-1 8.5.4). The current
+/// clip is the *intersection* of an ordered list of these.
 struct ClipPath {
   std::vector<Subpath> subpaths;
   bool even_odd{false};
 };
 
 struct GraphicsState {
-  /// Dash pattern (`d`): the on/off lengths and the starting phase, in user
-  /// space. An empty array is a solid line (ISO 32000-1 8.4.3.6).
+  /// Dash pattern (`d`, ISO 32000-1 8.4.3.6), user space; empty = solid.
   struct Dash {
     std::vector<double> array;
     double phase{0};
   };
 
   struct General {
-    // PDF initial graphics state (ISO 32000-1 Table 52): line width 1.0, butt
-    // cap, miter join, miter limit 10.0. Defaulting these to 0 would emit
-    // zero-width/invalid-miter path elements for streams that stroke without an
-    // explicit `w`/`M`.
+    // Defaults are the PDF initial graphics state (ISO 32000-1 Table 52), not
+    // zero: a stream that strokes without an explicit `w`/`M` must not produce
+    // zero-width/invalid-miter paths.
     double line_width{1};
     std::int32_t cap_style{};
     std::int32_t join_style{};
@@ -86,19 +78,11 @@ struct GraphicsState {
     std::string color_rendering_intent;
     double flatness_tolerance{};
     std::string graphics_state_parameters;
-    // Constant alpha (ISO 32000-1 11.6.4.4) set via an `/ExtGState` `ca`/`CA`:
-    // the nonstroking (fill) and stroking opacity in [0,1]. Part of the general
-    // graphics state, so `q`/`Q` scope them like the CTM. 1 = fully opaque.
-    double fill_alpha{1};   // ca
-    double stroke_alpha{1}; // CA
-    // Blend mode (ISO 32000-1 11.3.5) set via an `/ExtGState` `/BM`: the PDF
-    // separable/non-separable blend name (e.g. `Multiply`). Empty = `Normal`.
-    std::string blend_mode;
-    // Soft mask (ISO 32000-1 11.6.5.2) set via an `/ExtGState` `/SMask`: the
-    // rendered luminosity/alpha mask applied to painted content, or null for
-    // `/SMask /None`. Part of the general graphics state, so `q`/`Q` scope it
-    // like the CTM. Built by the extractor (it renders the mask's transparency
-    // group), which is why it is an opaque handle here.
+    double fill_alpha{1};   // `/ExtGState` ca (11.6.4.4)
+    double stroke_alpha{1}; // `/ExtGState` CA
+    std::string blend_mode; // `/ExtGState` /BM (11.3.5); empty = Normal
+    /// `/ExtGState` `/SMask` (11.6.5.2), already rendered by the extractor —
+    /// hence an opaque handle here. Null for `/SMask /None`.
     std::shared_ptr<const SoftMask> soft_mask;
     util::math::Transform2D transform_matrix; // CTM
   };
@@ -124,15 +108,12 @@ struct GraphicsState {
     double grey{};
     std::array<double, 3> rgb{};
     std::array<double, 4> cmyk{};
-    /// The active non-device colour space set by `cs`/`CS` (a `/ColorSpace`
-    /// resource: ICCBased, Separation, Indexed, …), owned by `Resources`. When
-    /// set, `sc`/`scn` components are converted through it to the `rgb` above
-    /// at the time the operator runs; null for a device colour space. Cleared
-    /// by the device colour operators (`g`/`rg`/`k`).
+    /// The `cs`/`CS`-selected non-device space (owned by `Resources`), through
+    /// which `sc`/`scn` components are converted into `rgb` as the operator
+    /// runs. Null for a device space; cleared by `g`/`rg`/`k`.
     const ColorSpaceDef *def{nullptr};
-    /// The resource name of the `/Pattern` selected by `scn`/`SCN` (a shading
-    /// or tiling pattern), resolved against `Resources::pattern` at paint time.
-    /// Empty for a plain colour; cleared by the device colour operators.
+    /// The `/Pattern` resource name `scn`/`SCN` selected, resolved against
+    /// `Resources::pattern` at paint time. Cleared by `g`/`rg`/`k`.
     std::string pattern;
   };
 
@@ -141,30 +122,22 @@ struct GraphicsState {
     Text text;
     Color stroke_color;
     Color other_color;
-    /// Current clipping path: the intersection of these regions (empty = the
-    /// whole page). Part of the saved/restored state (ISO 32000-1 8.5.4), so
-    /// `q`/`Q` and form-XObject invocation scope it like the CTM.
+    /// Clip in force: the intersection of these (empty = the whole page). Part
+    /// of the saved state (ISO 32000-1 8.5.4), so `q`/`Q` scope it.
     std::vector<ClipPath> clip;
   };
 
+  /// Never empty: `current()` is `back()`, and `restore()` keeps the base.
   std::vector<State> stack;
 
-  /// The path under construction. Unlike the rest of the state it is *not* part
-  /// of the `q`/`Q` stack (ISO 32000-1 8.5.2): it accumulates across
-  /// `m`/`l`/`c`/ `re`/… and is consumed (and cleared) by a path-painting
-  /// operator.
+  /// The path under construction. *Not* part of the `q`/`Q` stack (ISO 32000-1
+  /// 8.5.2); a path-painting operator consumes and clears it.
   std::vector<Subpath> path;
 
-  /// Nesting depth of Type3 char-proc rendering. A Type3 glyph is drawn by
-  /// running a content stream that may itself show Type3 text, so this bounds
-  /// pathological self-referential recursion. Deliberately *not* part of the
-  /// `q`/`Q`-saved `State`: it tracks call-chain depth, not graphics state.
+  /// Call-chain depths bounding self-referential Type3 char procs and soft-mask
+  /// groups. Deliberately outside `State`: they are not graphics state, so
+  /// `q`/`Q` must not scope them.
   std::int32_t type3_depth{0};
-
-  /// Nesting depth of soft-mask rendering. A soft mask's transparency group may
-  /// itself set a soft mask, so this bounds pathological recursion. Like
-  /// `type3_depth`, it tracks call-chain depth, not graphics state, so it is
-  /// deliberately *not* part of the `q`/`Q`-saved `State`.
   std::int32_t soft_mask_depth{0};
 
   GraphicsState();
@@ -174,8 +147,8 @@ struct GraphicsState {
 
   void execute(const GraphicsOperator &);
 
-  /// Path construction. Operands are taken in the operator's coordinate space;
-  /// each point is mapped through the current CTM and stored in user space.
+  /// Path construction. Operands arrive in the operator's coordinate space and
+  /// are stored mapped through the current CTM, i.e. in user space.
   void path_move_to(double x, double y);
   void path_line_to(double x, double y);
   void path_cubic_to(double x1, double y1, double x2, double y2, double x3,
@@ -186,58 +159,50 @@ struct GraphicsState {
   void path_cubic_to_y(double x1, double y1, double x3, double y3);
   void path_close();
   void path_rectangle(double x, double y, double w, double h);
-  /// Close the current subpath (without the `h`-style "closed" mark) and drop
-  /// the accumulated path, as every path-painting operator does on completion.
+  /// Drop the accumulated path, as every path-painting operator does.
   void clear_path();
 
-  /// Clipping (`W`/`W*`, ISO 32000-1 8.5.4). `set_pending_clip` records that
-  /// the current path is to *become* a clip; `commit_clip` then installs it —
-  /// as the intersection with the current clip — when the next painting (or
-  /// `n`) operator completes. The path painted by that operator is still
-  /// clipped by the *old* clip, so the caller snapshots the clip before calling
-  /// `commit_clip`.
+  /// Clipping (`W`/`W*`, ISO 32000-1 8.5.4). `set_pending_clip` only records
+  /// the intent; the next painting (or `n`) operator calls `commit_clip` to
+  /// intersect the path into the clip. That operator's own paint is still under
+  /// the *old* clip, so callers snapshot the clip before committing.
   void set_pending_clip(bool even_odd);
   void commit_clip();
-  /// Intersect a rectangle (in the current CTM's space, e.g. a form's `/BBox`)
-  /// into the current clip; the corners are mapped through the CTM.
+  /// Intersect a rectangle given in the current CTM's space (e.g. a form's
+  /// `/BBox`) into the clip.
   void clip_bounding_box(double x0, double y0, double x1, double y1);
 
-  /// Push a copy of the current state (`q`).
+  /// `q`: push a copy of the current state.
   void save();
-  /// Pop the current state (`Q`).
+  /// `Q`: pop it. An unmatched `Q` is ignored — the base state always remains.
   void restore();
-  /// Concatenate `matrix` onto the CTM (`CTM = matrix * CTM`), as `cm` does and
-  /// as invoking a form XObject does with its `/Matrix`.
+  /// `CTM = matrix * CTM`, as `cm` and form invocation do.
   void concat_matrix(const util::math::Transform2D &matrix);
 
-  /// Text rendering transform *excluding* the font size: maps text space (1
-  /// unit = 1 em at the current font size) to user space, with horizontal
-  /// scaling and rise folded in. The font size is applied separately (as the
-  /// rendered font-size), which keeps the run-vs-glyph mapping decision in the
-  /// renderer.
+  /// Text space -> user space with horizontal scaling and rise folded in, but
+  /// *not* the font size: that is applied separately as the rendered
+  /// font-size, which leaves the run-vs-glyph mapping to the renderer.
   [[nodiscard]] util::math::Transform2D text_placement_transform() const;
 
-  /// Advance the text matrix `Tm` by `(tx, ty)` in text space after showing
-  /// glyphs (the text line matrix `Tlm` is unaffected).
+  /// Advance `Tm` by `(tx, ty)` in text space after showing glyphs; `Tlm` is
+  /// unaffected.
   void advance_text(double tx, double ty);
 
 private:
-  /// Move to the start of a new text line: `Tlm = translate(tx, ty) * Tlm` and
-  /// `Tm = Tlm` (the shared mechanic behind `Td`, `TD`, `T*`, `'`, `"`).
+  /// `Tlm = translate(tx, ty) * Tlm`, `Tm = Tlm` — behind
+  /// `Td`/`TD`/`T*`/`'`/`"`.
   void next_line(double tx, double ty);
 
-  /// Map an operand point through the current CTM into user space.
   [[nodiscard]] std::array<double, 2> to_user(double x, double y) const;
-  /// Append `segment` to the current subpath, starting one at the current point
-  /// if a construction operator other than `m`/`re` opens the path (lenient).
+  /// Append `segment`, opening a subpath at the current point if a construction
+  /// operator other than `m`/`re` started the path (lenient).
   void append_segment(const PathSegment &segment);
 
   std::array<double, 2> m_current_point{0, 0}; // user space
   std::array<double, 2> m_subpath_start{0, 0}; // user space, for `h`/close
 
-  /// A pending `W`/`W*` between path construction and the painting operator
-  /// that installs it. Not part of the saved state: a `W` is always followed by
-  /// a painting/`n` operator before any `q`/`Q` (ISO 32000-1 8.5.4).
+  /// A pending `W`/`W*`. Not part of the saved state: a `W` is always followed
+  /// by a painting/`n` operator before any `q`/`Q` (ISO 32000-1 8.5.4).
   enum class PendingClip { none, nonzero, even_odd };
   PendingClip m_pending_clip{PendingClip::none};
 };

--- a/src/odr/internal/pdf/pdf_image.cpp
+++ b/src/odr/internal/pdf/pdf_image.cpp
@@ -18,11 +18,11 @@ namespace odr::internal::pdf {
 namespace {
 
 /// Append a PNG chunk: length, four-byte type, data, CRC over type+data.
-void write_chunk(std::string &out, const char (&type)[5],
+void write_chunk(std::string &out, const std::string_view type,
                  const std::string &data) {
   util::byte_string::put_u32_be(out, static_cast<std::uint32_t>(data.size()));
   const std::size_t crc_start = out.size();
-  out.append(type, 4);
+  out.append(type);
   out.append(data);
   util::byte_string::put_u32_be(
       out, crypto::util::crc32(std::string_view(out).substr(crc_start)));
@@ -95,11 +95,11 @@ std::string pdf::write_png(const std::string &pixels, const std::int32_t width,
     raw.append(pixels, static_cast<std::size_t>(y) * stride, stride);
   }
 
-  std::string out;
-  static const char signature[] = {
+  static constexpr std::array<char, 8> signature = {
       static_cast<char>(0x89), 'P', 'N', 'G', '\r', '\n',
       static_cast<char>(0x1A), '\n'};
-  out.append(signature, sizeof(signature));
+  std::string out;
+  out.append(signature.data(), signature.size());
 
   std::string ihdr;
   util::byte_string::put_u32_be(ihdr, static_cast<std::uint32_t>(width));
@@ -131,9 +131,7 @@ std::string pdf::encode_image_png(const std::string &samples,
   }
 
   const std::uint32_t max_sample =
-      (bits_per_component >= 32)
-          ? 0xFFFFFFFFu
-          : ((1u << static_cast<std::uint32_t>(bits_per_component)) - 1u);
+      (1u << static_cast<std::uint32_t>(bits_per_component)) - 1u;
   const bool indexed = color_space.kind == ColorSpaceKind::indexed;
 
   const auto row_bits = static_cast<std::size_t>(width) *

--- a/src/odr/internal/pdf/pdf_image.hpp
+++ b/src/odr/internal/pdf/pdf_image.hpp
@@ -18,19 +18,12 @@ struct EncodedImage {
   std::string mime;
 };
 
-/// Turn an image's raw (still filter-encoded) stream bytes into browser-ready
-/// bytes: a JPEG (`DCTDecode`) passes through undecoded, a fully decodable
-/// raster (Flate/LZW/RunLength/ASCII/raw) is decoded and re-encoded as PNG
-/// through `color_space`. `filter`/`decode_parms` are the resolved
-/// `/Filter`/`/DecodeParms`; `color_space` may be null (used only by the raster
-/// path — a null there yields nullopt). `alpha` is an optional per-pixel
-/// coverage plane (one byte per base pixel, row-major; 0 = transparent,
-/// 255 = opaque) resolved from a `/SMask` or stencil `/Mask`; `color_key` is an
-/// optional `/Mask` colour-key array ([min0 max0 ...] in raw sample units) —
-/// when either is present the raster path emits an RGBA PNG (both are ignored
-/// by the JPEG pass-through). Returns nullopt for a codec not yet handled
-/// (JPXDecode/CCITTFaxDecode/JBIG2Decode) or an inconsistent raster. Shared by
-/// image XObjects and inline images.
+/// Turn an image's raw (still filter-encoded) bytes into browser-ready ones: a
+/// `DCTDecode` JPEG passes through, any other decodable raster is re-encoded as
+/// PNG through `color_space` (required only on that path). `alpha` and
+/// `color_key` (see `encode_image_png`) make the raster RGBA and are ignored by
+/// the JPEG pass-through. `nullopt` for an undecodable codec
+/// (JPX/CCITTFax/JBIG2) or an inconsistent raster.
 std::optional<EncodedImage>
 encode_image(std::string raw, const Object &filter, const Object &decode_parms,
              std::int32_t width, std::int32_t height,
@@ -39,18 +32,13 @@ encode_image(std::string raw, const Object &filter, const Object &decode_parms,
              const std::vector<std::uint8_t> &alpha = {},
              const std::vector<double> &color_key = {});
 
-/// Assemble a raster image's decoded samples into a base-level (8-bit, RGB)
-/// PNG (ISO 32000-1 8.9.5 image samples -> a browser-ready raster). `samples`
-/// holds the raw component values packed most-significant-bit first, each row
-/// padded to a byte boundary. `bits_per_component` is 1/2/4/8/16;
-/// `color_space` supplies the component count and the sample -> sRGB
-/// conversion (Indexed palettes included). `decode`, when non-empty, is the
-/// `/Decode` array ([min, max] per component) remapping the sample range.
-/// Returns "" for an inconsistent configuration, so the caller skips the image.
-/// `alpha` (one byte per pixel, row-major) and `color_key` ([min0 max0 ...] in
-/// raw sample units) add transparency: when either is given the output is an
-/// RGBA PNG, a pixel made transparent where its coverage is 0 or every
-/// component falls inside the colour-key ranges (ISO 32000-1 8.9.6).
+/// Assemble decoded image samples (ISO 32000-1 8.9.5: MSB-first, rows padded
+/// to a byte boundary, `bits_per_component` of 1/2/4/8/16) into an 8-bit PNG,
+/// converting through `color_space`. `decode` is the `/Decode` array remapping
+/// the sample range. `alpha` (one byte per pixel, row-major) and `color_key`
+/// ([min0 max0 …] in raw sample units) each make the output RGBA, transparent
+/// where coverage is 0 / every component is inside the ranges (8.9.6). Returns
+/// "" for an inconsistent configuration, so the caller skips the image.
 std::string encode_image_png(const std::string &samples, std::int32_t width,
                              std::int32_t height,
                              std::int32_t bits_per_component,
@@ -59,34 +47,26 @@ std::string encode_image_png(const std::string &samples, std::int32_t width,
                              const std::vector<std::uint8_t> &alpha = {},
                              const std::vector<double> &color_key = {});
 
-/// Resolve a `/SMask` or stencil `/Mask` sub-image (a single-component raster)
-/// into a coverage plane sized to the *base* image (one byte per base pixel,
-/// row-major), nearest-neighbour resampled from the mask's own `width`/`height`
-/// (the two need not match — ISO 32000-1 8.9.5.4 / 11.6.5.2). `samples` is the
-/// mask's filter-decoded bytes. For a soft mask (`stencil` false) the decoded
-/// grey value becomes the alpha; for an explicit stencil `/Mask` (`stencil`
-/// true, 1 bpc) a sample decoding to 1 is masked out (alpha 0). `decode`, when
-/// non-empty, is the mask's `/Decode`. Returns empty for an inconsistent mask.
+/// Resolve a `/SMask` or stencil `/Mask` sub-image into a coverage plane sized
+/// to the *base* image, nearest-neighbour resampled — the two resolutions need
+/// not match (ISO 32000-1 8.9.5.4 / 11.6.5.2). A soft mask's grey value is the
+/// alpha; a stencil (`stencil`, 1 bpc) masks out where a sample decodes to 1.
+/// Empty for an inconsistent mask.
 std::vector<std::uint8_t>
 decode_mask_alpha(const std::string &samples, std::int32_t width,
                   std::int32_t height, std::int32_t bits_per_component,
                   const std::vector<double> &decode, bool stencil,
                   std::int32_t base_width, std::int32_t base_height);
 
-/// Wrap 8-bit pixels (`channels * width * height` bytes, row-major, no padding)
-/// into a PNG (single `IDAT`, no interlacing). `channels` is 3 for RGB (colour
-/// type 2) or 4 for RGBA (colour type 6); any other value yields "". The
-/// compression core; exposed for testing the container independently of sample
-/// assembly.
+/// Wrap 8-bit pixels (row-major, unpadded) into a PNG: single `IDAT`, no
+/// interlacing. `channels` is 3 (RGB) or 4 (RGBA); anything else yields "".
 std::string write_png(const std::string &pixels, std::int32_t width,
                       std::int32_t height, std::int32_t channels);
 
-/// Paint a 1-bit stencil image mask (ISO 32000-1 8.9.6.2) in `color` (sRGB in
-/// [0, 1]): a sample whose decoded value is 0 paints `color` opaquely, a 1 is
-/// transparent — inverted by a `/Decode` of `[1 0]`. `samples` is the decoded
-/// 1-bpc bitmap (rows byte-aligned, MSB first). The stencil's paint colour is
-/// the graphics-state fill colour at draw time, so this is resolved by the page
-/// extractor, not at parse time. Returns an RGBA PNG, or "" when inconsistent.
+/// Paint a 1-bpc stencil mask (ISO 32000-1 8.9.6.2) into an RGBA PNG: a sample
+/// decoding to 0 paints `color` (sRGB in [0, 1]) opaquely, a 1 is transparent,
+/// and a `/Decode` of `[1 0]` swaps that. `color` is the fill colour at draw
+/// time, so only the page extractor can call this. "" when inconsistent.
 std::string encode_stencil_png(const std::string &samples, std::int32_t width,
                                std::int32_t height,
                                const std::array<double, 3> &color,

--- a/src/odr/internal/pdf/pdf_object_parser.cpp
+++ b/src/odr/internal/pdf/pdf_object_parser.cpp
@@ -19,6 +19,17 @@ ObjectParser::ObjectParser(std::istream &in) : m_in{&in}, m_sb{in.rdbuf()} {
   const std::istream::sentry se(in, true);
 }
 
+ObjectParser::NestingGuard::NestingGuard(ObjectParser &parser)
+    : m_parser{&parser} {
+  if (++m_parser->m_depth > max_nesting_depth) {
+    // the guard never finishes constructing, so nothing will undo this
+    --m_parser->m_depth;
+    throw std::runtime_error("object nesting too deep");
+  }
+}
+
+ObjectParser::NestingGuard::~NestingGuard() { --m_parser->m_depth; }
+
 std::istream &ObjectParser::in() { return *m_in; }
 
 std::streambuf &ObjectParser::sb() { return *m_sb; }
@@ -373,11 +384,9 @@ std::variant<StandardString, HexString> ObjectParser::read_string() {
           string += three_octet_to_char(octet[0], octet[1], octet[2]);
         } else {
           bumpc();
-          // Reverse-solidus escapes (ISO 32000-1 7.3.4.2, Table 3): the control
-          // escapes translate to their byte value, a backslash before an
-          // end-of-line marker is a line continuation (both elided), and any
-          // other escaped character (including `(`, `)`, `\`) stands for
-          // itself.
+          // Reverse-solidus escapes (ISO 32000-1 7.3.4.2, Table 3). A
+          // backslash before an end-of-line marker is a line continuation;
+          // anything else unlisted stands for itself.
           switch (c) {
           case 'n':
             string += '\n';
@@ -452,6 +461,7 @@ bool ObjectParser::peek_array() {
 }
 
 Array ObjectParser::read_array() {
+  const NestingGuard guard(*this);
   Array::Holder result;
 
   if (bumpc() != '[') {
@@ -498,6 +508,7 @@ bool ObjectParser::peek_dictionary() {
 }
 
 Dictionary ObjectParser::read_dictionary() {
+  const NestingGuard guard(*this);
   Dictionary::Holder result;
 
   if (bumpc() != '<') {
@@ -557,11 +568,9 @@ Object ObjectParser::read_object() {
 }
 
 void ObjectParser::promote_indirect_reference(Object &value) {
-  // The cursor sits just past `value` (trailing whitespace already skipped).
-  // This is called only where a value cannot legitimately be followed by
-  // another number — a dictionary value or an indirect-object body, which are
-  // followed by the next key, `>>`, or `endobj`. A digit there can only be the
-  // generation of an `n g R` indirect reference whose object number is `value`.
+  // Called only where a value cannot legitimately be followed by another
+  // number — the next token is a key, `>>` or `endobj` — so a digit here can
+  // only be the `g` of an `n g R` whose object number is `value`.
   if (!value.is_integer() || !peek_unsigned_integer()) {
     return;
   }

--- a/src/odr/internal/pdf/pdf_object_parser.hpp
+++ b/src/odr/internal/pdf/pdf_object_parser.hpp
@@ -81,30 +81,43 @@ public:
   [[nodiscard]] Dictionary read_dictionary();
 
   /// Read one *self-delimiting* object: null, boolean, number, name, string,
-  /// array, or dictionary. Arrays and dictionaries may contain indirect
-  /// references (assembled while parsing them), but a bare top-level reference
-  /// is **not** returned as such — `n g R` is not recognizable from its first
-  /// token (it looks like the integer `n` until the `R` two tokens later, and
-  /// in an array `[1 2 3]` a leading integer is ambiguous with a reference
-  /// start). So a leading object number comes back as a plain integer; the
-  /// enclosing context folds it into a reference — `read_array` on seeing the
-  /// `R` token, dictionary values and indirect-object bodies via
-  /// `promote_indirect_reference` — or use `read_object_reference` where a
+  /// array, or dictionary. A bare `n g R` is **not** one: it is
+  /// indistinguishable from the integer `n` until the `R` two tokens later, so
+  /// it comes back as that integer and the enclosing context folds it in —
+  /// `read_array` at the `R`, dictionary values and indirect-object bodies via
+  /// `promote_indirect_reference`. Use `read_object_reference` where a
   /// reference is required outright.
   [[nodiscard]] Object read_object();
 
   /// With the cursor just past a freshly-read `value` (trailing whitespace
-  /// skipped), fold `value` in place into an `n g R` indirect reference if a
-  /// `g R` tail follows; otherwise leave `value` untouched. Only valid where a
-  /// value cannot be followed by another bare number — dictionary values and
-  /// indirect-object bodies — not array elements.
+  /// skipped), fold it into an `n g R` reference if a `g R` tail follows. Only
+  /// valid where a value cannot be followed by another bare number — so not for
+  /// array elements.
   void promote_indirect_reference(Object &value);
 
   [[nodiscard]] ObjectReference read_object_reference();
 
 private:
+  /// Bounds the `read_array`/`read_dictionary` -> `read_object` recursion: each
+  /// level is a C++ stack frame, so an unbounded nesting depth would overflow
+  /// it. Well past anything real content nests to.
+  static constexpr std::uint32_t max_nesting_depth = 256;
+
+  /// RAII depth counter around one composite read; `throw`s past the limit.
+  class NestingGuard {
+  public:
+    explicit NestingGuard(ObjectParser &parser);
+    ~NestingGuard();
+    NestingGuard(const NestingGuard &) = delete;
+    NestingGuard &operator=(const NestingGuard &) = delete;
+
+  private:
+    ObjectParser *m_parser;
+  };
+
   std::istream *m_in{nullptr};
   std::streambuf *m_sb{nullptr};
+  std::uint32_t m_depth{0};
 };
 
 } // namespace odr::internal::pdf

--- a/src/odr/internal/pdf/pdf_page_element.hpp
+++ b/src/odr/internal/pdf/pdf_page_element.hpp
@@ -17,15 +17,13 @@ struct Shading;
 struct Pattern;
 struct SoftMask;
 
-/// One show-text operation laid out in user space. The transform places the
-/// text origin and orientation; the font size is kept separate so the renderer
-/// can choose per-run or per-glyph mapping. Spacing parameters and the raw
-/// codes are carried for the (deferred) advance application.
+/// One show-text operation laid out in user space. The font size is kept out of
+/// `transform` so the renderer can choose per-run or per-glyph mapping.
 struct TextElement {
-  /// Text-space -> user-space, font size *not* applied (see
-  /// `GraphicsState::text_placement_matrix`).
+  /// Text space -> user space, font size *not* applied (see
+  /// `GraphicsState::text_placement_transform`).
   util::math::Transform2D transform;
-  /// Resolved font, or `nullptr` when the `/Font` resource name was unknown.
+  /// Null when the `/Font` resource name was unknown.
   Font *font{nullptr};
   double size{0};                                            // Tf size
   double char_spacing{0};                                    // Tc
@@ -33,202 +31,130 @@ struct TextElement {
   double horizontal_scaling{100};                            // Tz, percent
   double rise{0};                                            // Ts
   TextRenderingMode rendering_mode{TextRenderingMode::fill}; // Tr
-  /// Non-stroking (fill) and stroking colours in force when the run was shown,
-  /// as device colours. The renderer paints the run in whichever its rendering
-  /// mode selects — the fill colour for the common fill modes, the stroking
-  /// colour for the stroke-only modes (Tr 1/5) — defaulting to black.
+  /// Device colours in force when the run was shown; the rendering mode selects
+  /// which one paints (stroking only for `Tr` 1/5).
   GraphicsState::Color fill_color;
   GraphicsState::Color stroke_color;
-  /// Constant fill/stroke alpha (`/ExtGState` `ca`/`CA`) and blend mode
-  /// (`/BM`) in force when the run was shown; 1 = opaque, empty blend = Normal.
+  /// `/ExtGState` `ca`/`CA` and `/BM`; 1 = opaque, empty blend = Normal.
   double fill_alpha{1};
   double stroke_alpha{1};
   std::string blend_mode;
-  /// Raw character codes shown by this segment (one `Tj`, or one string of a
-  /// `TJ` array).
+  /// Raw codes shown (one `Tj`, or one string of a `TJ` array).
   std::string codes;
-  /// Unicode representation of `codes`, with an inferred leading space when a
-  /// large enough gap precedes this segment (space inference) so the
-  /// producer's omitted inter-word/-line spaces are recovered. Empty when the
-  /// segment carries no extractable text — either the code -> Unicode chain
-  /// yielded nothing (see `no_unicode`) or an enclosing `/ActualText` already
-  /// emitted the run's text.
+  /// `codes` as Unicode, possibly with an inferred leading space. Empty when
+  /// the segment carries no extractable text (see `no_unicode`, or an enclosing
+  /// `/ActualText` already emitted the run).
   std::string text;
-  /// True when the leading character of `text` is an inferred inter-word/-line
-  /// space (space inference), i.e. one prepended `U+0020` with no backing
-  /// character code or advance. Lets a consumer treat that space as metadata
-  /// (selectable but not part of the 1:1 code<->char run) rather than content:
-  /// the single-layer HTML collapse test skips it, so a run that would map
-  /// cleanly to real Unicode is not forced onto the PUA glyph path merely
-  /// because a word-break space was recovered in front of it.
+  /// The leading `U+0020` of `text` was inferred from a gap, so it backs no
+  /// code and no advance. Consumers that pair codes with characters 1:1 (the
+  /// HTML single-layer collapse test) must skip it.
   bool leading_space_inferred{false};
-  /// True when the font's code -> Unicode chain yielded nothing for this
-  /// segment (a composite font with no `/ToUnicode` or usable predefined
-  /// encoding is the common case), so `text` is empty. When the font has an
-  /// embedded font its glyphs still display (re-encoded to the Private Use
-  /// Area) with the run marked non-extractable; otherwise the run is simply not
-  /// selectable. An `/ActualText` override clears this.
+  /// The code -> Unicode chain yielded nothing, so `text` is empty and the run
+  /// is displayable but not extractable. Cleared by an `/ActualText` override.
   bool no_unicode{false};
-  /// True for a Type3 font: the glyphs are drawn as ordinary path/image
-  /// elements (the char procs, emitted alongside this element in paint order),
-  /// so the renderer keeps this element for selection/search but paints no
-  /// visible text of its own — as it does for an invisible (Tr 3) run.
+  /// Type3: the glyphs are emitted as separate path/image elements, so this
+  /// element only carries selection/search — as for an invisible (`Tr` 3) run.
   bool render_as_graphics{false};
-  /// Total advance of this segment, in text-space units (the displacement
-  /// applied to the text matrix after it — already scaled by the font size and
-  /// including char/word spacing and horizontal scaling). 0 when the font is
-  /// unknown. Equal to the sum of `advances`.
+  /// Total advance in text-space units (font size, char/word spacing and
+  /// horizontal scaling folded in), the sum of `advances`. 0 with no font.
   double width{0};
-  /// Per-character-code advance, in code order and text-space units, summing to
-  /// `width`. Empty when the font is unknown. Lets a renderer place glyphs
-  /// individually without re-deriving widths from `font->advance_width`.
+  /// Per-code advance, in code order. Empty with no font.
   std::vector<double> advances;
 };
 
-/// One path-painting operation (`S`/`s`/`f`/`F`/`f*`/`B`/…), laid out in user
-/// space. The geometry is fully resolved (the CTM applied at construction), so
-/// a renderer maps it through the page transform alone. The paint intent and
-/// the paint-relevant graphics state are snapshotted; colors are kept as PDF
-/// device colors and converted to RGB by the renderer. A `/PatternType 2`
-/// shading pattern fill is carried by `fill_shading`; tiling patterns
-/// (`/PatternType 1`) are a later stage.
+/// One path-painting operation (`S`/`s`/`f`/`F`/`f*`/`B`/…). The geometry is
+/// fully resolved (the CTM applied at construction) and the paint-relevant
+/// graphics state snapshotted, so a renderer needs no state replay.
 struct PathElement {
-  /// The subpaths to paint, in user space.
-  std::vector<Subpath> subpaths;
-  /// The clip in force when this path was painted: the intersection of these
-  /// regions (empty = unclipped). Snapshotted from the graphics state at paint
-  /// time so the renderer can install it without replaying the clip stack.
-  std::vector<ClipPath> clip;
+  std::vector<Subpath> subpaths; ///< user space
+  std::vector<ClipPath> clip;    ///< intersection; empty = unclipped
   bool fill{false};
   bool stroke{false};
-  /// Fill rule: false = nonzero winding, true = even-odd.
-  bool even_odd{false};
-  /// Non-stroking (fill) color and stroking color, as device colors.
+  bool even_odd{false}; ///< fill rule: false = nonzero winding
   GraphicsState::Color fill_color;
   GraphicsState::Color stroke_color;
-  /// When the fill is a shading pattern (`scn` naming a `/PatternType 2`
-  /// pattern), the resolved shading to paint through the path instead of
-  /// `fill_color`, with `shading_transform` mapping shading space to user space
-  /// (the pattern `/Matrix`). Null for a plain colour fill. Owned by
-  /// `Resources`, which outlives the element.
+  /// A `/PatternType 2` fill (`scn`): paint this shading through the path
+  /// instead of `fill_color`. `shading_transform` is the pattern `/Matrix`
+  /// (shading space -> user space). Owned by `Resources`, which outlives us.
   const Shading *fill_shading{nullptr};
   util::math::Transform2D shading_transform;
-  /// When the fill is a tiling pattern (`scn` naming a `/PatternType 1`
-  /// pattern), the resolved pattern whose content cell tiles the path, with
-  /// `pattern_transform` mapping pattern space to user space (the pattern
-  /// `/Matrix`). An uncoloured pattern (`/PaintType 2`) is painted in
-  /// `fill_color`. Null for a non-tiling fill. Owned by `Resources`.
+  /// A `/PatternType 1` fill: tile this pattern's cell across the path. An
+  /// uncoloured pattern (`/PaintType 2`) is painted in `fill_color`. Owned by
+  /// `Resources`.
   const Pattern *fill_pattern{nullptr};
   util::math::Transform2D pattern_transform;
-  /// Stroke parameters. `line_width` and the dash lengths are in the path's
-  /// user space (the CTM scale is already folded in, so they live in the same
-  /// space as the geometry). A `line_width` of 0 means a device-thin line.
+  /// Stroke parameters. `line_width` and the dash lengths carry the CTM scale,
+  /// so they are in the geometry's user space; 0 means a device-thin line.
   double line_width{1};
   std::int32_t line_cap{0};
   std::int32_t line_join{0};
   double miter_limit{10};
   std::vector<double> dash_array; // empty = solid
   double dash_phase{0};
-  /// Constant fill/stroke alpha (`/ExtGState` `ca`/`CA`) and blend mode (`/BM`)
-  /// in force when the path was painted; 1 = opaque, empty blend = Normal.
+  /// `/ExtGState` `ca`/`CA` and `/BM`; 1 = opaque, empty blend = Normal.
   double fill_alpha{1};
   double stroke_alpha{1};
   std::string blend_mode;
-  /// Soft mask (`/ExtGState` `/SMask`) in force when the path was painted, or
-  /// null when none. Snapshotted like the clip so the renderer can install it
-  /// without replaying the graphics state.
-  std::shared_ptr<const SoftMask> soft_mask;
+  std::shared_ptr<const SoftMask> soft_mask; ///< `/ExtGState` `/SMask`
 };
 
-/// One image XObject painted by `Do`, placed by the CTM in effect when it was
-/// invoked (ISO 32000-1 8.10.5): the image fills the unit square in user space,
-/// which `transform` maps. The encoded bytes are browser-ready — a JPEG passed
-/// through (`DCTDecode`) or a raster re-encoded as PNG — with `mime` naming the
-/// format. The clip is snapshotted as for a path.
+/// One image painted by `Do` or `BI`…`EI` (ISO 32000-1 8.10.5). The bytes are
+/// browser-ready: a `DCTDecode` JPEG passed through, or a raster re-encoded as
+/// PNG.
 struct ImageElement {
   /// CTM at `Do` time: maps the image's unit square to user space.
   util::math::Transform2D transform;
   std::vector<ClipPath> clip;
-  std::string data; // encoded image bytes (e.g. a JPEG)
+  std::string data;
   std::string mime; // e.g. "image/jpeg"
-  /// Constant alpha (`/ExtGState` `ca`, the nonstroking alpha applies to
-  /// images) and blend mode (`/BM`) in force at `Do`; 1 = opaque, empty blend =
-  /// Normal.
+  /// `/ExtGState` `ca` (the nonstroking alpha applies to images) and `/BM`.
   double alpha{1};
   std::string blend_mode;
-  /// Soft mask (`/ExtGState` `/SMask`) in force at `Do`, or null when none.
   std::shared_ptr<const SoftMask> soft_mask;
 };
 
-/// One area painted by the `sh` operator (ISO 32000-1 8.7.4.2): a shading
-/// flooded over the current clip region (no path geometry of its own). The
-/// transform maps shading space to user space (the CTM at `sh` time); the clip
-/// is snapshotted as for a path. The renderer paints the shading's gradient
-/// across the clipped area.
+/// One `sh` (ISO 32000-1 8.7.4.2): a shading flooded over the current clip,
+/// with no path geometry of its own.
 struct ShadingElement {
-  /// The shading to paint. Owned by `Resources`, which outlives the element.
-  const Shading *shading{nullptr};
-  /// Shading space -> user space (the CTM in force at `sh` time).
-  util::math::Transform2D transform;
-  /// The clip in force, snapshotted so the renderer bounds the flood.
-  std::vector<ClipPath> clip;
-  /// Constant fill alpha (`/ExtGState` `ca`) and blend mode (`/BM`) in force at
-  /// `sh`; 1 = opaque, empty blend = Normal.
-  double alpha{1};
+  const Shading *shading{nullptr};   ///< owned by `Resources`
+  util::math::Transform2D transform; ///< shading space -> user space
+  std::vector<ClipPath> clip;        ///< bounds the flood
+  double alpha{1};                   ///< `/ExtGState` `ca`
   std::string blend_mode;
-  /// Soft mask (`/ExtGState` `/SMask`) in force at `sh`, or null when none.
   std::shared_ptr<const SoftMask> soft_mask;
 };
 
 struct GroupChildren;
 
-/// A transparency group painted as a unit (ISO 32000-1 11.6.6): its content is
-/// composited first, then the whole result is painted with the group-level
-/// constant alpha, blend mode and soft mask in force when the group was
-/// invoked. This is *not* the same as folding those onto each interior element
-/// — for content whose paints overlap (a figure's hair over its face, say) the
-/// group must composite opaquely first, then fade, or the overlaps show
-/// through. The renderer emits the children into one container (`<g>`) carrying
-/// the group parameters. `children` is held indirectly so `PageElement` can
-/// hold a `GroupElement` (a recursive variant).
+/// A transparency group painted as a unit (ISO 32000-1 11.6.6): composite the
+/// content first, *then* apply the group-level alpha/blend/mask. Folding those
+/// onto each interior element instead would show the overlaps through.
+/// `children` is indirect to break the recursive-variant type cycle.
 struct GroupElement {
   std::shared_ptr<const GroupChildren> children;
-  /// Group-level nonstroking constant alpha (`ca`), 1 = opaque.
-  double alpha{1};
-  /// Group-level blend mode (`/BM`); empty = Normal.
+  double alpha{1}; ///< `ca`
   std::string blend_mode;
-  /// Group-level soft mask (`/SMask`), or null when none.
   std::shared_ptr<const SoftMask> soft_mask;
 };
 
-/// A single page-content element in paint (z) order: a shown text segment, a
-/// painted path, an image, a shading flood (`sh`), or a transparency group.
-/// Shading *patterns* ride on `PathElement::fill_shading`; tiling patterns join
-/// in a later stage.
+/// A single page-content element, in paint (z) order. Shading *patterns* ride
+/// on `PathElement::fill_shading` rather than appearing here.
 using PageElement = std::variant<TextElement, PathElement, ImageElement,
                                  ShadingElement, GroupElement>;
 
-/// The content of a `GroupElement`, in paint order. A distinct type (rather
-/// than a bare `std::vector<PageElement>` member) breaks the `PageElement` ->
-/// `GroupElement` -> `PageElement` type cycle.
 struct GroupChildren {
   std::vector<PageElement> elements;
 };
 
-/// A rendered soft mask (`/SMask` in an `/ExtGState`, ISO 32000-1 11.6.5.2),
-/// ready for a renderer to apply to the elements that reference it. The mask's
-/// transparency group `/G` has been run through the page machinery into `group`
-/// (its content in user space, the establishment CTM and the group `/Matrix`
-/// already folded in and clipped to the group `/BBox`). The alpha is derived
-/// from that content per `type`: `luminosity` (the content's luminosity is the
-/// alpha — an SVG luminance `<mask>`) or `alpha` (its coverage is). `backdrop`
-/// is the `/BC` colour as RGB behind the group (default black, i.e. fully
-/// masked out where the group paints nothing); empty when the default applies.
+/// A rendered soft mask (`/ExtGState` `/SMask`, ISO 32000-1 11.6.5.2): the
+/// `/G` group already run through the page machinery into user space (its
+/// `/Matrix` folded in, clipped to its `/BBox`). `type` says whether the
+/// content's luminosity or its coverage is the alpha.
 struct SoftMask {
   enum class Type { luminosity, alpha };
   Type type{Type::luminosity};
   std::vector<PageElement> group;
-  std::optional<std::array<double, 3>> backdrop; // /BC as RGB; empty = black
+  std::optional<std::array<double, 3>> backdrop; ///< `/BC`; empty = black
 };
 
 } // namespace odr::internal::pdf

--- a/src/odr/internal/pdf/pdf_page_extractor.cpp
+++ b/src/odr/internal/pdf/pdf_page_extractor.cpp
@@ -16,6 +16,7 @@
 #include <cmath>
 #include <memory>
 #include <optional>
+#include <ranges>
 #include <set>
 #include <sstream>
 #include <unordered_map>
@@ -54,11 +55,9 @@ struct MarkedContent {
 };
 using MarkedContentStack = std::vector<MarkedContent>;
 
-/// Resolve the extraction text of a shown segment. The nearest enclosing
-/// `/ActualText` sequence, if any, governs: its text is emitted for the first
-/// segment and the rest of the sequence is suppressed (empty). Otherwise the
-/// font's code -> Unicode chain applies; an empty result for non-empty codes is
-/// reported as `no_unicode` (the run is not extractable, only displayable).
+/// The extraction text of a shown segment. The nearest enclosing
+/// `/ActualText` wins, emitted once and then suppressed; otherwise the font's
+/// code -> Unicode chain, whose empty result is reported as `no_unicode`.
 struct ResolvedText {
   std::string text;
   bool no_unicode{false};
@@ -66,13 +65,13 @@ struct ResolvedText {
 
 ResolvedText resolve_text(MarkedContentStack &marked, const Font *font,
                           const std::string &codes) {
-  for (auto it = marked.rbegin(); it != marked.rend(); ++it) {
-    if (it->actual_text.has_value()) {
-      if (it->consumed) {
+  for (MarkedContent &entry : marked | std::views::reverse) {
+    if (entry.actual_text.has_value()) {
+      if (entry.consumed) {
         return {};
       }
-      it->consumed = true;
-      return {*it->actual_text, false};
+      entry.consumed = true;
+      return {*entry.actual_text, false};
     }
   }
   if (font == nullptr) {
@@ -230,14 +229,11 @@ void set_color_space(GraphicsState::Color &color, const std::string &name,
   }
 }
 
-/// Resolve a general colour operator (`sc`/`scn`/`SC`/`SCN`): convert the
-/// operand components through the active colour space to RGB. With no resource
-/// colour space, interpret the components as a device colour by their count
-/// (ISO 32000-1 8.6.8). A trailing name operand selects a `/Pattern`: its name
-/// is recorded on `color.pattern` and resolved against `Resources::pattern` at
-/// paint time (a shading pattern fills through its gradient). An uncoloured
-/// tiling pattern carries leading components — the colour in the pattern colour
-/// space's underlying space — which are still resolved into the fill colour.
+/// Apply `sc`/`scn`/`SC`/`SCN` (ISO 32000-1 8.6.8): convert the components
+/// through the active colour space, or — with no resource space — read them as
+/// a device colour by their count. A trailing name selects a `/Pattern`,
+/// resolved at paint time; an uncoloured tiling pattern also carries the
+/// components, which still resolve into the fill colour.
 void set_color(GraphicsState::Color &color, const GraphicsOperator &op) {
   std::vector<double> components;
   std::string pattern_name;
@@ -310,7 +306,7 @@ bool is_supported_blend_mode(const std::string &name) {
       "Darken",    "Lighten",    "ColorDodge", "ColorBurn", "HardLight",
       "SoftLight", "Difference", "Exclusion",  "Hue",       "Saturation",
       "Color",     "Luminosity"};
-  return supported.count(name) != 0;
+  return supported.contains(name);
 }
 
 /// Form XObjects currently being rendered, by element identity. The parser
@@ -333,14 +329,11 @@ build_soft_mask(const SoftMaskDef &def, const Resources &resources,
                 GraphicsState &state, const Logger &logger,
                 std::set<std::string> &warned, ActiveForms &active);
 
-/// Apply a `gs` operator: resolve the named `/ExtGState` dictionary and fold
-/// its constant alpha (`ca`/`CA`), blend mode (`/BM`) and soft mask (`/SMask`)
-/// into the general graphics state (ISO 32000-1 8.4.5). Other entries (line
-/// params,
-/// `/Font`) are out of scope. `/BM` may be a single name or an array of names,
-/// an ordered fallback list from which the reader picks the first mode it
-/// supports; `Compatible` is a legacy alias for `Normal`. `/SMask` is a mask
-/// dictionary (set) or `/None` (clear); absent leaves the mask unchanged.
+/// Apply `gs` (ISO 32000-1 8.4.5): fold the named `/ExtGState`'s `ca`/`CA`,
+/// `/BM` and `/SMask` into the general state. Other entries are out of scope.
+/// `/BM` may be an array — an ordered fallback list, so pick the first
+/// supported name. An absent `/SMask` leaves the mask unchanged; `/None`
+/// clears it.
 void apply_ext_g_state(const std::string &name, const Resources &resources,
                        GraphicsState &state, const Logger &logger,
                        std::set<std::string> &warned, ActiveForms &active) {
@@ -504,11 +497,9 @@ resolve_inline_color_space(const Object &color_space,
   return parse_color_space(color_space, context);
 }
 
-/// Emit an `ImageElement` for an inline image (`BI`/`ID`/`EI`). The operator
-/// carries the inline dictionary and the raw bytes; both are routed through the
-/// same image emission as an image XObject (placed by the CTM, under the
-/// current clip). An `/ImageMask true` stencil is painted in the current fill
-/// colour; an unsupported codec or colour space yields nothing.
+/// Emit an `ImageElement` for an inline image (`BI`/`ID`/`EI`), whose operator
+/// carries the dictionary and the raw bytes. Routed through the same emission
+/// as an image XObject; an unsupported codec or colour space yields nothing.
 void emit_inline_image(const GraphicsOperator &op, const Resources &resources,
                        GraphicsState &state, std::vector<PageElement> &out) {
   if (op.arguments.size() < 2 || !op.arguments[0].is_dictionary() ||
@@ -620,12 +611,10 @@ void begin_marked_content(const GraphicsOperator &op,
   marked.push_back(std::move(entry));
 }
 
-/// Invoke a form XObject named by `Do`: save the state, concatenate the form's
-/// `/Matrix` onto the CTM, run its content with the form's own `/Resources`
-/// (falling back to the enclosing scope), then restore (ISO 32000-1 8.10.1).
-/// `/BBox` clips the form's content. An image XObject emits an `ImageElement`
-/// (when its codec passes through); unknown subtypes are skipped, and a form
-/// already on the render stack is skipped (cycle guard).
+/// Invoke the XObject `Do` names (ISO 32000-1 8.10.1): an image emits an
+/// `ImageElement`; a form runs inside a `save`/`restore` with its `/Matrix`
+/// concatenated, clipped to its `/BBox` and scoped to its own `/Resources`.
+/// Unknown subtypes and forms already on the render stack are skipped.
 void invoke_x_object(const std::string &name, const Resources &resources,
                      GraphicsState &state, std::vector<PageElement> &out,
                      const Logger &logger, std::set<std::string> &warned,
@@ -680,13 +669,10 @@ void invoke_x_object(const std::string &name, const Resources &resources,
     return; // already on the render stack
   }
 
-  // A transparency group is composited as a unit, then that result is painted
-  // with the constant alpha, blend mode and soft mask in force when the group
-  // was invoked (ISO 32000-1 11.6.6) — not each interior painting, which the
-  // group's own content may reset. Snapshot those, isolate them inside the
-  // group, and fold them into the produced elements below. (Per-element folding
-  // is exact for non-overlapping group content, as here; it approximates true
-  // group compositing where interior paints overlap.)
+  // A transparency group composites as a unit, and only then takes the alpha /
+  // blend / mask in force at invocation (ISO 32000-1 11.6.6) — not each
+  // interior painting, which the group's own content may reset. So snapshot
+  // them here and isolate them inside the group.
   const GraphicsState::General &invoke_general = state.current().general;
   const bool group = x_object->transparency_group;
   const double group_alpha = group ? invoke_general.fill_alpha : 1.0;
@@ -809,15 +795,11 @@ build_soft_mask(const SoftMaskDef &def, const Resources &resources,
   return mask;
 }
 
-/// Render a Type3 text-showing operation (ISO 32000-1 9.6.5). The selectable
-/// text element goes through the normal `show` — flagged so the renderer paints
-/// no visible text of its own — then each shown code's char proc is run through
-/// the page machinery at that glyph's transform
-/// (`/FontMatrix` x size x `Tm` x CTM), advancing the text matrix per glyph so
-/// the procs land where the glyphs belong. A `d1` (shape-only) glyph inherits
-/// the current fill colour from the graphics state; a `d0` glyph's own colour
-/// operators take effect as they run. Recursion (a char proc that shows text in
-/// the same Type3 font) is bounded by a depth guard.
+/// Show text in a Type3 font (ISO 32000-1 9.6.5): emit the selectable run via
+/// `show` (flagged to paint nothing), then replay the per-glyph advance,
+/// running each code's char proc at `/FontMatrix` x size x `Tm` x CTM so the
+/// glyphs paint as ordinary elements. Depth-guarded, since a char proc may
+/// itself show Type3 text.
 void show_type3(std::vector<PageElement> &out, const Resources &resources,
                 GraphicsState &state, const Logger &logger,
                 std::set<std::string> &warned, ActiveForms &active,

--- a/src/odr/internal/pdf/pdf_shading.cpp
+++ b/src/odr/internal/pdf/pdf_shading.cpp
@@ -2,6 +2,7 @@
 
 #include <odr/internal/pdf/pdf_object.hpp>
 
+#include <algorithm>
 #include <cstddef>
 
 namespace odr::internal::pdf {
@@ -34,10 +35,9 @@ parse_shading_functions(const Object &function, const ShadingContext &context) {
   }
   // A null entry (an unsupported function type) makes the whole shading
   // unusable: sampling would yield wrong colours silently.
-  for (const auto &f : functions) {
-    if (f == nullptr) {
-      return {};
-    }
+  if (std::ranges::any_of(functions,
+                          [](const auto &f) { return f == nullptr; })) {
+    return {};
   }
   return functions;
 }

--- a/src/odr/internal/svm/svm_format.cpp
+++ b/src/odr/internal/svm/svm_format.cpp
@@ -4,6 +4,8 @@
 
 #include <odr/internal/util/string_util.hpp>
 
+#include <array>
+#include <cstdint>
 #include <cstring>
 
 namespace odr::internal {
@@ -107,15 +109,15 @@ svm::read_poly_polygon(std::istream &in) {
 svm::Header svm::read_header(std::istream &in) {
   Header result;
 
-  char magic[6];
-  in.read(magic, sizeof(magic));
-  if (std::strncmp("VCLMTF", magic, sizeof(magic)) != 0) {
+  std::array<char, 6> magic{};
+  in.read(magic.data(), static_cast<std::streamsize>(magic.size()));
+  if (!in || std::memcmp("VCLMTF", magic.data(), magic.size()) != 0) {
     throw NoSvmFile();
   }
 
   result.vl = read_version_length(in);
 
-  const std::size_t start = in.tellg();
+  const std::int64_t start = in.tellg();
   read_primitive(in, result.compression_mode);
   result.map_mode = read_map_mode(in);
   result.size = read_int_pair(in);
@@ -125,8 +127,10 @@ svm::Header svm::read_header(std::istream &in) {
     read_primitive(in, result.render_graphic_replacements);
   }
 
-  if (const std::size_t left =
-          result.vl.length - (static_cast<std::size_t>(in.tellg()) - start);
+  // Only skip forward: reading past the declared length would otherwise wrap
+  // the difference and swallow the rest of the stream.
+  if (const std::int64_t left =
+          result.vl.length - (static_cast<std::int64_t>(in.tellg()) - start);
       left > 0) {
     // TODO log header skipping bytes
     in.ignore(static_cast<std::streamsize>(left));

--- a/src/odr/internal/svm/svm_to_svg.cpp
+++ b/src/odr/internal/svm/svm_to_svg.cpp
@@ -208,11 +208,9 @@ void translate_action(const ActionHeader &action_header, std::istream &in,
         read_stretch_text_action(in, action_header.vl, context.encoding);
     write_text(out, action.point, action.text, context);
   } break;
-  case META_TEXTRECT_ACTION: {
-    TextRectangleAction action;
-    // action.read(in, action_header.vl, context.encoding);
-    // TODO
-  } break;
+  case META_TEXTRECT_ACTION:
+    // TODO read_text_rectangle_action; the caller skips the body meanwhile
+    break;
   case META_NULL_ACTION:
   case META_PUSH_ACTION:
   case META_POP_ACTION:

--- a/src/odr/internal/text/text_util.cpp
+++ b/src/odr/internal/text/text_util.cpp
@@ -2,6 +2,7 @@
 
 #include <odr/exceptions.hpp>
 
+#include <array>
 #include <istream>
 
 #include <uchardet/uchardet.h>
@@ -9,18 +10,16 @@
 namespace odr::internal {
 
 std::string text::guess_charset(std::istream &in) {
-  static constexpr auto BUFFER_SIZE = 4096;
-
   const auto ud = uchardet_new();
-  char buffer[BUFFER_SIZE];
+  std::array<char, 4096> buffer{};
 
   while (true) {
-    in.read(buffer, BUFFER_SIZE);
+    in.read(buffer.data(), static_cast<std::streamsize>(buffer.size()));
     const auto read = in.gcount();
     if (read == 0) {
       break;
     }
-    uchardet_handle_data(ud, buffer, read);
+    uchardet_handle_data(ud, buffer.data(), read);
   }
 
   uchardet_data_end(ud);

--- a/src/odr/internal/util/byte_stream_util.cpp
+++ b/src/odr/internal/util/byte_stream_util.cpp
@@ -31,7 +31,7 @@ std::uint8_t byte_stream::read_u8(std::istream &in) {
     in.setstate(std::ios::eofbit);
     throw std::runtime_error("unexpected stream exhaust");
   }
-  return static_cast<char_type>(c);
+  return static_cast<std::uint8_t>(c);
 }
 
 std::string byte_stream::read_u8s(std::istream &in, const std::size_t n) {

--- a/src/odr/internal/util/byte_stream_util.hpp
+++ b/src/odr/internal/util/byte_stream_util.hpp
@@ -5,7 +5,9 @@
 #include <cstdint>
 #include <iostream>
 #include <optional>
+#include <stdexcept>
 #include <streambuf>
+#include <string>
 
 namespace odr::internal::util::byte_stream {
 
@@ -18,7 +20,7 @@ bool try_read(std::istream &in, char *out, std::size_t count);
 
 template <typename T> void try_read(std::istream &in, std::optional<T> &out) {
   out.emplace();
-  if (!try_read(in, reinterpret_cast<char *>(&out), sizeof(T))) {
+  if (!try_read(in, reinterpret_cast<char *>(&*out), sizeof(T))) {
     out.reset();
   }
 }
@@ -44,8 +46,8 @@ template <typename T> T read(std::istream &in) {
 std::uint8_t read_u8(std::istream &in);
 
 template <std::uint32_t N> std::array<char, N> read_u8s(std::istream &in) {
-  std::array<char, N> result;
-  if (in.rdbuf()->sgetn(result.data(), result.size()) != result.size()) {
+  std::array<char, N> result{};
+  if (in.rdbuf()->sgetn(result.data(), N) != static_cast<std::streamsize>(N)) {
     throw std::runtime_error("unexpected stream exhaust");
   }
   return result;

--- a/src/odr/internal/util/byte_string.hpp
+++ b/src/odr/internal/util/byte_string.hpp
@@ -7,12 +7,9 @@
 
 namespace odr::internal::util::byte_string {
 
-// Byte primitives over in-memory buffers, the `std::string`/`std::string_view`
-// counterpart to `byte_stream` (which reads from an `std::istream`). Reads take
-// a `std::string_view` and decode from its **front** — the view's data pointer
-// is the offset, its `size()` is the bound — so a sequential reader advances by
-// shrinking the view and a random-access reader passes `view.substr(offset)`.
-// Reads throw `std::runtime_error` when the view is too short.
+// The in-memory counterpart to `byte_stream`. Reads decode from the front of
+// the view — its data pointer is the offset, its `size()` the bound — and
+// throw `std::runtime_error` when it is too short.
 
 [[nodiscard]] std::uint8_t read_u8(std::string_view data);
 

--- a/src/odr/internal/util/document_util.cpp
+++ b/src/odr/internal/util/document_util.cpp
@@ -90,14 +90,8 @@ document::extract_path(const abstract::ElementAdapter &element_adapter,
     if (parent_id == null_element_id) {
       break;
     }
-    if (current_id == null_element_id) {
-      throw std::invalid_argument(
-          "Element is not a descendant of the specified root.");
-    }
 
-    const DocumentPath::Component component =
-        extract_path_component(element_adapter, current_id);
-    reverse.push_back(component);
+    reverse.push_back(extract_path_component(element_adapter, current_id));
 
     current_id = parent_id;
   }

--- a/src/odr/internal/util/file_util.cpp
+++ b/src/odr/internal/util/file_util.cpp
@@ -20,7 +20,8 @@ std::ifstream file::open(const std::string &path) {
 
 std::size_t file::size(const std::string &path) {
   std::ifstream in = open(path);
-  return in.tellg();
+  in.seekg(0, std::ios::end);
+  return static_cast<std::size_t>(in.tellg());
 }
 
 std::string file::read(const std::string &path) {

--- a/src/odr/internal/util/number_util.cpp
+++ b/src/odr/internal/util/number_util.cpp
@@ -15,9 +15,8 @@ std::string number::to_string_significant(const double value,
     return ss.str();
   }
 
-  // `std::fixed` counts decimals, not significant digits, so shift by the size
-  // of the integer part. Clamped: a denormal would otherwise ask for hundreds
-  // of decimals, and a huge value for a negative count.
+  // `std::fixed` counts decimals, not significant digits, so shift by the
+  // integer part; clamped because a denormal or a huge value would blow up
   int integer_digits = 1;
   if (value != 0.0) {
     integer_digits =

--- a/src/odr/internal/util/number_util.hpp
+++ b/src/odr/internal/util/number_util.hpp
@@ -4,16 +4,10 @@
 
 namespace odr::internal::util::number {
 
-/// Renders @p value with @p significant_digits significant digits, always in
-/// positional notation and without trailing zeros.
-///
-/// Unlike the iostream/printf default (`%g`), this never switches to
-/// scientific notation — CSS and SVG lengths do not accept it. Non-finite
-/// values are passed through to the stream default.
-///
-/// @p significant_digits is what bounds the noise: a value that came from a
-/// `float` carries about 7 digits (`FLT_DIG` is 6), so asking for more digits
-/// than the source has turns `68.55` into `68.550003`.
+/// Renders @p value with @p significant_digits significant digits, without
+/// trailing zeros and never in scientific notation, which CSS and SVG lengths
+/// do not accept. Asking for more digits than the source has shows its noise:
+/// a `float` carries about 7, beyond that `68.55` becomes `68.550003`.
 std::string to_string_significant(double value, int significant_digits);
 
 } // namespace odr::internal::util::number

--- a/src/odr/internal/util/odr_meta_util.cpp
+++ b/src/odr/internal/util/odr_meta_util.cpp
@@ -15,10 +15,8 @@ nlohmann::json meta_to_json(const FileMeta &meta) {
       file_category_to_string(file_category_by_file_type(meta.type));
   result["isEncrypted"] = meta.password_encrypted;
 
-  // Only a known document type gets the document block. An office container we
-  // cannot name a type for (an encrypted OOXML package, an ODF file with an
-  // unrecognized mimetype) is therefore treated like any other non-document and
-  // omits these keys, rather than reporting `"documentType": "unknown"`.
+  // only a known document type gets the document block; an unnamed one omits
+  // these keys rather than reporting `"documentType": "unknown"`
   if (meta.document_type != DocumentType::unknown) {
     result["documentType"] = document_type_to_string(meta.document_type);
 

--- a/src/odr/internal/util/stream_util.cpp
+++ b/src/odr/internal/util/stream_util.cpp
@@ -1,5 +1,6 @@
 #include <odr/internal/util/stream_util.hpp>
 
+#include <array>
 #include <iterator>
 #include <sstream>
 #include <streambuf>
@@ -17,34 +18,30 @@ std::string stream::read(std::istream &in) {
 std::string stream::read(std::istream &in, const std::size_t size) {
   std::string result(size, '\0');
   in.read(result.data(), static_cast<std::streamsize>(size));
-  result.resize(in.gcount());
+  result.resize(static_cast<std::size_t>(in.gcount()));
   return result;
 }
 
 void stream::pipe(std::istream &in, std::ostream &out) {
-  static constexpr auto BUFFER_SIZE = 4096;
+  static constexpr std::size_t BUFFER_SIZE = 4096;
 
-  char buffer[BUFFER_SIZE];
+  std::array<char, BUFFER_SIZE> buffer{};
 
   while (true) {
-    in.read(buffer, BUFFER_SIZE);
+    in.read(buffer.data(), BUFFER_SIZE);
     const auto read = in.gcount();
     if (read == 0) {
       break;
     }
-    out.write(buffer, read);
+    out.write(buffer.data(), read);
   }
 }
 
 // from https://stackoverflow.com/a/6089413
 std::istream &stream::pipe_line(std::istream &in, std::ostream &out,
                                 const bool inclusive) {
-  // The characters in the stream are read one-by-one using a std::streambuf.
-  // That is faster than reading them one-by-one using the std::istream.
-  // Code that uses streambuf this way must be guarded by a sentry object.
-  // The sentry object performs various tasks, such as thread synchronization
-  // and updating the stream state.
-
+  // reading through the streambuf is faster than through the istream, but has
+  // to be guarded by a sentry
   std::istream::sentry se(in, true);
   std::streambuf *sb = in.rdbuf();
 
@@ -117,15 +114,12 @@ namespace odr::internal::util::stream {
 
 namespace {
 
-/// Read-only stream buffer over an existing `string_view`, so a `std::istream`
-/// can scan it without copying into a `std::string`/`std::istringstream`. The
-/// view must outlive the buffer. Only the get area is exposed; seeking is not
-/// supported.
+/// Read-only stream buffer over an existing `string_view`, which must outlive
+/// it. No seeking.
 class ViewStreamBuf : public std::streambuf {
 public:
   explicit ViewStreamBuf(std::string_view view) {
-    // The get area is only ever read, never written through, so dropping the
-    // `const` is safe.
+    // the get area is never written through
     auto *begin = const_cast<char *>(view.data());
     setg(begin, begin, begin + view.size());
   }

--- a/src/odr/internal/util/string_util.cpp
+++ b/src/odr/internal/util/string_util.cpp
@@ -12,13 +12,11 @@
 namespace odr::internal::util {
 
 bool string::starts_with(const std::string &string, const std::string &with) {
-  return string.rfind(with, 0) == 0;
+  return string.starts_with(with);
 }
 
 bool string::ends_with(const std::string &string, const std::string &with) {
-  return string.length() >= with.length() &&
-         string.compare(string.length() - with.length(), with.length(), with) ==
-             0;
+  return string.ends_with(with);
 }
 
 bool string::is_ascii_space(const char c) {

--- a/src/odr/internal/util/string_util.hpp
+++ b/src/odr/internal/util/string_util.hpp
@@ -10,9 +10,8 @@ namespace odr::internal::util::string {
 bool starts_with(const std::string &string, const std::string &with);
 bool ends_with(const std::string &string, const std::string &with);
 
-/// Predicate deciding whether a byte counts as whitespace for the `*_view`
-/// trims. Takes a single `char`; implementations must handle the full byte
-/// range without relying on the sign of `char`.
+/// Whether a byte counts as whitespace for the trims; must handle the full
+/// byte range without relying on the sign of `char`.
 using CharPredicate = bool (*)(char);
 
 /// `std::isspace` for the default C locale, made safe for any `char` value.
@@ -28,8 +27,7 @@ std::string rtrim(const std::string &s,
                   CharPredicate is_space = is_ascii_space);
 std::string trim(const std::string &s, CharPredicate is_space = is_ascii_space);
 
-/// Trim leading/trailing whitespace and return a view into `s`. The result is a
-/// subrange of `s`, so the leading offset is recoverable as
+/// Trim and return a subrange of `s`, so the leading offset is recoverable as
 /// `result.data() - s.data()`.
 std::string_view ltrim_view(std::string_view s,
                             CharPredicate is_space = is_ascii_space);
@@ -55,6 +53,7 @@ std::size_t utf8_length(const std::string &string);
 
 std::string u16string_to_string(const std::u16string &string);
 std::u16string string_to_u16string(const std::string &string);
+/// @p length is a byte count, not a number of code units.
 std::string c16str_to_string(const char16_t *c16str, std::size_t length);
 void append_c32(char32_t c, std::string &string);
 

--- a/src/odr/internal/zip/zip_archive.cpp
+++ b/src/odr/internal/zip/zip_archive.cpp
@@ -8,6 +8,7 @@
 #include <odr/internal/zip/zip_exceptions.hpp>
 #include <odr/internal/zip/zip_util.hpp>
 
+#include <algorithm>
 #include <string>
 
 #include <miniz/miniz.h>
@@ -83,7 +84,8 @@ void ZipArchive::save(std::ostream &out) const {
     const auto o = static_cast<std::ostream *>(opaque);
     o->write(static_cast<const char *>(buffer),
              static_cast<std::streamsize>(size));
-    return size;
+    // A short write has to surface, or the archive is silently truncated.
+    return o->good() ? size : std::size_t{0};
   };
   state = mz_zip_writer_init(&archive, 0);
   if (!state) {
@@ -131,13 +133,8 @@ ZipArchive::Iterator ZipArchive::begin() const {
 ZipArchive::Iterator ZipArchive::end() const { return std::cend(m_entries); }
 
 ZipArchive::Iterator ZipArchive::find(const RelPath &path) const {
-  for (auto it = begin(); it != end(); ++it) {
-    if (it->path() == path) {
-      return it;
-    }
-  }
-
-  return end();
+  return std::ranges::find_if(
+      *this, [&path](const Entry &entry) { return entry.path() == path; });
 }
 
 ZipArchive::Iterator

--- a/src/odr/internal/zip/zip_util.cpp
+++ b/src/odr/internal/zip/zip_util.cpp
@@ -5,6 +5,7 @@
 #include <odr/internal/common/file.hpp>
 
 #include <algorithm>
+#include <array>
 
 namespace odr::internal::zip::util {
 
@@ -38,6 +39,11 @@ protected:
         std::min<std::uint64_t>(m_remaining, m_buffer.size());
     const std::uint32_t result =
         mz_zip_reader_extract_iter_read(m_iter, m_buffer.data(), amount);
+    // miniz reports a failed inflate as a short read; leaving the get area
+    // empty while claiming success would spin `underflow` forever.
+    if (result == 0) {
+      return traits_type::eof();
+    }
     m_remaining -= result;
     setg(m_buffer.data(), m_buffer.data(), m_buffer.data() + result);
 
@@ -125,10 +131,10 @@ bool Archive::Entry::is_directory() const {
 
 RelPath Archive::Entry::path() const {
   std::lock_guard lock(m_archive->mutex());
-  char filename[MZ_ZIP_MAX_ARCHIVE_FILENAME_SIZE];
-  mz_zip_reader_get_filename(m_archive->zip(), m_index, filename,
-                             MZ_ZIP_MAX_ARCHIVE_FILENAME_SIZE);
-  return RelPath(filename);
+  std::array<char, MZ_ZIP_MAX_ARCHIVE_FILENAME_SIZE> filename{};
+  mz_zip_reader_get_filename(m_archive->zip(), m_index, filename.data(),
+                             static_cast<mz_uint>(filename.size()));
+  return RelPath(filename.data());
 }
 
 Method Archive::Entry::method() const {
@@ -197,9 +203,13 @@ void util::open_from_file(mz_zip_archive &archive, const abstract::File &file,
   archive.m_pRead = [](void *opaque, const std::uint64_t offset, void *buffer,
                        const std::size_t size) {
     const auto in = static_cast<std::istream *>(opaque);
+    // Reporting `size` regardless would hand miniz whatever was already in the
+    // buffer; a short read has to surface as one. Clear first so an earlier
+    // read past the end does not poison every later seek.
+    in->clear();
     in->seekg(static_cast<std::streamsize>(offset));
     in->read(static_cast<char *>(buffer), static_cast<std::streamsize>(size));
-    return size;
+    return static_cast<std::size_t>(in->gcount());
   };
   const bool state = mz_zip_reader_init(
       &archive, file.size(), MZ_ZIP_FLAG_DO_NOT_SORT_CENTRAL_DIRECTORY);

--- a/src/odr/logger.cpp
+++ b/src/odr/logger.cpp
@@ -96,6 +96,13 @@ std::shared_ptr<ILogger> null_impl() {
   return instance;
 }
 
+/// Writes @p text clipped to @p width, padded to it, and one trailing space.
+void print_padded(std::ostream &out, const std::string_view text,
+                  const std::size_t width) {
+  const std::string_view clipped = text.substr(0, width);
+  out << clipped << std::string(width - clipped.size(), ' ') << " ";
+}
+
 std::string_view level_to_string(const LogLevel level) {
   switch (level) {
   case LogLevel::verbose:
@@ -163,45 +170,27 @@ void Logger::print_head(std::ostream &out, Time time, LogLevel level,
   }
 
   if (format.level_width > 0) {
-    std::string_view level_str = level_to_string(level);
-    std::stringstream level_ss;
-    level_ss << level_str.substr(0, format.level_width);
-    level_ss << std::string(
-        std::max<std::size_t>(0, format.level_width - level_ss.str().size()),
-        ' ');
-    out << level_ss.str() << " ";
+    print_padded(out, level_to_string(level), format.level_width);
   }
 
   if (format.name_width > 0) {
-    std::stringstream name_ss;
-    name_ss << name.substr(0, format.name_width);
-    name_ss << std::string(
-        std::max<std::size_t>(0, format.name_width - name_ss.str().size()),
-        ' ');
-    out << name_ss.str() << " ";
+    print_padded(out, name, format.name_width);
   }
 
   if (format.location_width > 0) {
     const std::string file_name =
         std::filesystem::path(location.file_name()).filename().string();
     const std::string line_number = std::to_string(location.line());
-    std::stringstream location_ss;
-    if (file_name.size() + 1 + line_number.size() > format.location_width) {
-      if (1 + line_number.size() < format.location_width) {
-        location_ss << file_name.substr(0, format.location_width - 1 -
-                                               line_number.size())
-                    << ":" << line_number;
-      } else {
-        location_ss << file_name.substr(0, format.location_width);
-      }
-    } else {
-      location_ss << file_name << ":" << line_number;
+    std::string text = file_name + ":" + line_number;
+    if (text.size() > format.location_width) {
+      // drop the file name's tail, or the line number if that leaves no room
+      text = 1 + line_number.size() < format.location_width
+                 ? file_name.substr(0, format.location_width - 1 -
+                                           line_number.size()) +
+                       ":" + line_number
+                 : file_name;
     }
-    location_ss << std::string(
-        std::max<std::size_t>(0,
-                              format.location_width - location_ss.str().size()),
-        ' ');
-    out << location_ss.str() << " ";
+    print_padded(out, text, format.location_width);
   }
 }
 

--- a/src/odr/odr.hpp
+++ b/src/odr/odr.hpp
@@ -10,122 +10,74 @@
 
 namespace odr {
 
-/// @brief Get the version of the library.
-/// @return The version of the library.
+/// @brief The version of the library.
 [[nodiscard]] std::string version();
-/// @brief Get the commit hash of the library.
-/// @return The commit hash of the library.
+/// @brief The commit the library was built from.
 [[nodiscard]] std::string commit_hash();
-/// @brief Check if the library is dirty (i.e., has uncommitted changes).
-/// @return True if the library is dirty, false otherwise.
+/// @brief Whether that commit had uncommitted changes.
 [[nodiscard]] bool is_dirty() noexcept;
-/// @brief Check if the library is built in debug mode.
-/// @return True if the library is built in debug mode, false otherwise.
+/// @brief Whether the library is built in debug mode.
 [[nodiscard]] bool is_debug() noexcept;
-/// @brief Get the identification string of the library.
-/// @return The identification string of the library.
+/// @brief All of the above in one string.
 [[nodiscard]] std::string identify() noexcept;
 
-/// @brief Get every file type this library knows about.
-/// @return All file types, in declaration order, including
-///         @ref FileType::unknown.
+/// @brief Every file type this library knows about, in declaration order,
+/// including @ref FileType::unknown.
 [[nodiscard]] std::vector<FileType> all_file_types();
 
-/// @brief Get the file type by the file extension.
-/// @param extension The file extension.
-/// @return The file type.
+/// @brief The file type for a file extension, @ref FileType::unknown if none.
 [[nodiscard]] FileType
 file_type_by_file_extension(const std::string &extension) noexcept;
-/// @brief Get every file extension accepted for the file type.
+/// @brief Every file extension accepted for the file type, without a leading
+/// dot, canonical one first.
 ///
-/// The first entry is the canonical one. Some file types have no extension of
-/// their own (e.g. @ref FileType::office_open_xml_encrypted, which is carried
-/// by an ordinary `docx`/`pptx`/`xlsx` file), in which case the result is
-/// empty.
-/// @param type The file type.
-/// @return The file extensions, without a leading dot.
+/// Empty for a file type with no extension of its own, e.g.
+/// @ref FileType::office_open_xml_encrypted, which is carried by an ordinary
+/// `docx`/`pptx`/`xlsx` file.
 [[nodiscard]] std::span<const std::string_view>
 file_extensions_by_file_type(FileType type) noexcept;
-/// @brief Get the canonical file extension by the file type.
-/// @param type The file type.
-/// @return The file extension, without a leading dot.
+/// @brief The canonical file extension, without a leading dot.
+/// @throws UnsupportedFileType if the type has none.
 [[nodiscard]] std::string_view file_extension_by_file_type(FileType type);
-/// @brief Get the file category by the file type.
-/// @param type The file type.
-/// @return The file category.
+/// @brief The file category the file type belongs to.
 [[nodiscard]] FileCategory file_category_by_file_type(FileType type) noexcept;
-/// @brief Get the document type by the file type.
-/// @param type The file type.
-/// @return The document type.
+/// @brief The document type the file type carries, if any.
 [[nodiscard]] DocumentType document_type_by_file_type(FileType type) noexcept;
-/// @brief Get the file type as a string.
-/// @param type The file type.
-/// @return The file type as a string.
+/// @brief The file type's name.
 [[nodiscard]] std::string file_type_to_string(FileType type);
-/// @brief Get the file category as a string.
-/// @param type The file type.
-/// @return The file type as a string.
+/// @brief The file category's name.
 [[nodiscard]] std::string file_category_to_string(FileCategory type);
-/// @brief Get the document type as a string.
-/// @param type The file type.
-/// @return The file type as a string.
+/// @brief The document type's name.
 [[nodiscard]] std::string document_type_to_string(DocumentType type);
-/// @brief Get the file type by the MIME type.
-/// @param mimetype The MIME type.
-/// @return The file type.
+/// @brief The file type for a MIME type, @ref FileType::unknown if none.
 [[nodiscard]] FileType
 file_type_by_mimetype(std::string_view mimetype) noexcept;
-/// @brief Get the canonical MIME type by the file type.
-/// @param type The file type.
-/// @return The MIME type.
+/// @brief The canonical MIME type.
+/// @throws UnsupportedFileType if the type has none.
 [[nodiscard]] std::string_view mimetype_by_file_type(FileType type);
-/// @brief Get every MIME type accepted for the file type.
-///
-/// The first entry is the canonical one.
-/// @param type The file type.
-/// @return The MIME types.
+/// @brief Every MIME type accepted for the file type, canonical one first.
 [[nodiscard]] std::span<const std::string_view>
 mimetypes_by_file_type(FileType type) noexcept;
 
-/// @brief Get what this library can do with the file type.
-///
-/// Format-level support, i.e. an upper bound — see @ref FileTypeCapabilities.
-/// @param type The file type.
-/// @return The capabilities.
+/// @brief What this library can do with the file type: format-level support,
+/// i.e. an upper bound — see @ref FileTypeCapabilities.
 [[nodiscard]] FileTypeCapabilities
 capabilities_by_file_type(FileType type) noexcept;
 
-/// @brief Determine the file types by the file path.
-/// @param path The file path.
-/// @param logger The logger to use.
-/// @return The file types.
+/// @brief The file types detected for the file at @p path.
 [[nodiscard]] std::vector<FileType>
 list_file_types(const std::string &path, const Logger &logger = Logger::null());
-/// @brief Determine MIME types by the file path.
-/// @param path The file path.
-/// @param logger The logger to use.
-/// @return The MIME types.
+/// @brief The MIME type detected for the file at @p path.
 [[nodiscard]] std::string_view mimetype(const std::string &path,
                                         const Logger &logger = Logger::null());
 
-/// @brief Open a file.
-/// @param path The file path.
-/// @param logger The logger to use.
-/// @return The decoded file.
+/// @brief Opens and decodes the file at @p path.
 [[nodiscard]] DecodedFile open(const std::string &path,
                                const Logger &logger = Logger::null());
-/// @brief Open a file.
-/// @param path The file path.
-/// @param as The file type.
-/// @param logger The logger to use.
-/// @return The decoded file.
+/// @brief Opens the file at @p path, decoding it as @p as.
 [[nodiscard]] DecodedFile open(const std::string &path, FileType as,
                                const Logger &logger = Logger::null());
-/// @brief Open a file.
-/// @param path The file path.
-/// @param preference The decode preference.
-/// @param logger The logger to use.
-/// @return The decoded file.
+/// @brief Opens the file at @p path, decoding it by @p preference.
 [[nodiscard]] DecodedFile open(const std::string &path,
                                const DecodePreference &preference,
                                const Logger &logger = Logger::null());

--- a/src/odr/quantity.cpp
+++ b/src/odr/quantity.cpp
@@ -7,11 +7,9 @@
 
 namespace odr {
 
-/// 7 significant digits: enough that document geometry survives a
-/// parse/format round trip (drawing coordinates reach the thousands of mm,
-/// which the stream default of 6 would round), and no more than a `float`
-/// carries, so an xlsx column width stored as float `68.55` does not come back
-/// as `68.550003`.
+/// 7 significant digits: one more than the stream default, which rounds
+/// drawing coordinates in the thousands of mm, and no more than a `float`
+/// carries, so `68.55` does not come back as `68.550003`.
 std::string QuantityBase::format_magnitude(const double magnitude) {
   return internal::util::number::to_string_significant(magnitude, 7);
 }
@@ -46,10 +44,8 @@ private:
   }
 };
 
-/// The unitless unit, i.e. the same one `Measure("5")` parses out of a bare
-/// number. Registered rather than left null so that `m_unit` is never null and
-/// every accessor below can dereference it, and so that a default-constructed
-/// unit compares equal to a parsed one.
+/// Registered rather than left null, so that `m_unit` is always dereferenceable
+/// and this compares equal to the unit `Measure("5")` parses.
 DynamicUnit::DynamicUnit() : m_unit{Registry::unit("")} {}
 
 DynamicUnit::DynamicUnit(const std::string_view name)

--- a/src/odr/style.cpp
+++ b/src/odr/style.cpp
@@ -2,6 +2,18 @@
 
 namespace odr {
 
+namespace {
+
+template <typename T>
+void override_if_set(std::optional<T> &property,
+                     const std::optional<T> &other) {
+  if (other.has_value()) {
+    property = other;
+  }
+}
+
+} // namespace
+
 Color Color::from_rgb(const std::uint32_t rgb) {
   return {static_cast<std::uint8_t>(rgb >> 16),
           static_cast<std::uint8_t>(rgb >> 8),
@@ -26,119 +38,63 @@ Color::Color(const std::uint8_t red, const std::uint8_t green,
     : red{red}, green{green}, blue{blue}, alpha{alpha} {}
 
 std::uint32_t Color::rgb() const {
-  std::uint32_t result{0};
-  result |= red << 16;
-  result |= green << 8;
-  result |= blue << 0;
-  return result;
+  return static_cast<std::uint32_t>(red) << 16 |
+         static_cast<std::uint32_t>(green) << 8 |
+         static_cast<std::uint32_t>(blue);
 }
 
 std::uint32_t Color::argb() const {
-  std::uint32_t result{0};
-  result |= alpha << 24;
-  result |= red << 16;
-  result |= green << 8;
-  result |= blue << 0;
-  return result;
+  // `alpha` promotes to `int`, so it has to be widened before the shift
+  return static_cast<std::uint32_t>(alpha) << 24 | rgb();
 }
 
 void TextStyle::override(const TextStyle &other) {
-  if (other.font_name.has_value()) {
-    font_name = other.font_name;
-  }
-  if (other.font_size.has_value()) {
-    font_size = other.font_size;
-  }
-  if (other.font_weight.has_value()) {
-    font_weight = other.font_weight;
-  }
-  if (other.font_style.has_value()) {
-    font_style = other.font_style;
-  }
-  if (other.font_underline.has_value()) {
-    font_underline = other.font_underline;
-  }
-  if (other.font_line_through.has_value()) {
-    font_line_through = other.font_line_through;
-  }
-  if (other.font_shadow.has_value()) {
-    font_shadow = other.font_shadow;
-  }
-  if (other.font_color.has_value()) {
-    font_color = other.font_color;
-  }
-  if (other.background_color.has_value()) {
-    background_color = other.background_color;
-  }
-  if (other.font_position.has_value()) {
-    font_position = other.font_position;
-  }
+  override_if_set(font_name, other.font_name);
+  override_if_set(font_size, other.font_size);
+  override_if_set(font_weight, other.font_weight);
+  override_if_set(font_style, other.font_style);
+  override_if_set(font_underline, other.font_underline);
+  override_if_set(font_line_through, other.font_line_through);
+  override_if_set(font_shadow, other.font_shadow);
+  override_if_set(font_color, other.font_color);
+  override_if_set(background_color, other.background_color);
+  override_if_set(font_position, other.font_position);
 }
 
 void ParagraphStyle::override(const ParagraphStyle &other) {
-  if (other.text_align.has_value()) {
-    text_align = other.text_align;
-  }
+  override_if_set(text_align, other.text_align);
   margin.override(other.margin);
-  if (other.line_height.has_value()) {
-    line_height = other.line_height;
-  }
-  if (other.text_indent.has_value()) {
-    text_indent = other.text_indent;
-  }
+  override_if_set(line_height, other.line_height);
+  override_if_set(text_indent, other.text_indent);
 }
 
 void TableStyle::override(const TableStyle &other) {
-  if (other.width.has_value()) {
-    width = other.width;
-  }
+  override_if_set(width, other.width);
 }
 
 void TableColumnStyle::override(const TableColumnStyle &other) {
-  if (other.width.has_value()) {
-    width = other.width;
-  }
+  override_if_set(width, other.width);
 }
 
 void TableRowStyle::override(const TableRowStyle &other) {
-  if (other.height.has_value()) {
-    height = other.height;
-  }
+  override_if_set(height, other.height);
 }
 
 void TableCellStyle::override(const TableCellStyle &other) {
-  if (other.horizontal_align.has_value()) {
-    horizontal_align = other.horizontal_align;
-  }
-  if (other.vertical_align.has_value()) {
-    vertical_align = other.vertical_align;
-  }
-  if (other.background_color.has_value()) {
-    background_color = other.background_color;
-  }
+  override_if_set(horizontal_align, other.horizontal_align);
+  override_if_set(vertical_align, other.vertical_align);
+  override_if_set(background_color, other.background_color);
   padding.override(other.padding);
   border.override(other.border);
-  if (other.text_rotation.has_value()) {
-    text_rotation = other.text_rotation;
-  }
+  override_if_set(text_rotation, other.text_rotation);
 }
 
 void GraphicStyle::override(const GraphicStyle &other) {
-  if (other.stroke_width.has_value()) {
-    stroke_width = other.stroke_width;
-  }
-  if (other.stroke_color.has_value()) {
-    stroke_color = other.stroke_color;
-  }
-  if (other.fill_color.has_value()) {
-    fill_color = other.fill_color;
-  }
-  if (other.vertical_align.has_value()) {
-    vertical_align = other.vertical_align;
-  }
-  if (other.text_wrap.has_value()) {
-    text_wrap = other.text_wrap;
-  }
+  override_if_set(stroke_width, other.stroke_width);
+  override_if_set(stroke_color, other.stroke_color);
+  override_if_set(fill_color, other.fill_color);
+  override_if_set(vertical_align, other.vertical_align);
+  override_if_set(text_wrap, other.text_wrap);
 }
 
 } // namespace odr

--- a/src/odr/table_position.cpp
+++ b/src/odr/table_position.cpp
@@ -12,11 +12,11 @@ std::uint32_t TablePosition::to_column_num(const std::string &string) {
   }
 
   std::uint32_t result = 0;
-  for (std::size_t i = 0; i < string.size(); ++i) {
-    if (string[i] < 'A' || string[i] > 'Z') {
+  for (const char c : string) {
+    if (c < 'A' || c > 'Z') {
       throw std::invalid_argument("illegal character in \"" + string + "\"");
     }
-    result = result * 26 + (string[i] - 'A' + 1);
+    result = result * 26 + static_cast<std::uint32_t>(c - 'A' + 1);
   }
   return result - 1;
 }
@@ -25,19 +25,21 @@ std::uint32_t TablePosition::to_row_num(const std::string &string) {
   return std::stoul(string) - 1;
 }
 
-std::string TablePosition::to_column_string(std::uint32_t column) {
+std::string TablePosition::to_column_string(const std::uint32_t column) {
   std::string result;
 
-  column += 1;
+  // bijective base 26, i.e. digits 1-26 - a remainder of 0 is the `Z` of the
+  // previous multiple and borrows from the quotient
+  std::uint64_t number = static_cast<std::uint64_t>(column) + 1;
   do {
-    if (const std::uint32_t rem = column % 26; rem == 0) {
+    if (const std::uint64_t rem = number % 26; rem == 0) {
       result = 'Z' + result;
-      column /= 27;
+      number = number / 26 - 1;
     } else {
       result = static_cast<char>('A' + rem - 1) + result;
-      column /= 26;
+      number /= 26;
     }
-  } while (column > 0);
+  } while (number > 0);
 
   return result;
 }

--- a/test/data.cmake
+++ b/test/data.cmake
@@ -17,9 +17,9 @@ odr_test_data(
 odr_test_data(
         PATH "reference-output/odr-public"
         URL "https://github.com/opendocument-app/OpenDocument.test.output.git"
-        REVISION "47b226f82957e6976e692c818a91656c1f40f773")
+        REVISION "2da5f0a3a246a0e0bc79fcee4c2f52afbc189fc4")
 
 odr_test_data(
         PATH "reference-output/odr-private"
         URL "https://github.com/opendocument-app/OpenDocument.test-private.output.git"
-        REVISION "439447f37320e4d93d23bc5b2990ea772e19a8eb")
+        REVISION "27367bf7cdfe73ac40a01afed92f325627652755")

--- a/test/src/document_test.cpp
+++ b/test/src/document_test.cpp
@@ -9,6 +9,8 @@
 #include <gtest/gtest.h>
 
 #include <filesystem>
+#include <optional>
+#include <string>
 
 using namespace odr;
 using namespace odr::test;
@@ -30,6 +32,56 @@ Element find_paragraph_with_text_prefix(const Element root,
     }
   }
   return {};
+}
+
+// Both skip empty texts — TODO make editing empty text possible.
+
+void set_every_text(const Element element, const std::string &content) {
+  for (const Element child : element.children()) {
+    set_every_text(child, content);
+  }
+  if (const Text text = element.as_text(); text && !text.content().empty()) {
+    text.set_content(content);
+  }
+}
+
+void expect_every_text(const Element element, const std::string &content) {
+  for (const Element child : element.children()) {
+    expect_every_text(child, content);
+  }
+  if (const Text text = element.as_text(); text && !text.content().empty()) {
+    EXPECT_EQ(content, text.content());
+  }
+}
+
+void expect_text_at(const Document &document, const std::string &path,
+                    const std::string &expected) {
+  EXPECT_EQ(expected, document.root_element()
+                          .navigate_path(DocumentPath(path))
+                          .as_text()
+                          .content());
+}
+
+/// Applies `diff` to `path`'s document, saves to `output_name` in the working
+/// directory and reopens it, so the assertions see what was written.
+Document edit_and_reload(const std::string &path, const char *diff,
+                         const std::string &output_name,
+                         const std::optional<std::string> &password = {}) {
+  const Logger logger = Logger::create_stdio("odr-test", LogLevel::verbose);
+
+  DocumentFile document_file(TestData::test_file_path(path), logger);
+  if (password.has_value()) {
+    document_file = document_file.decrypt(*password);
+  }
+  const Document document = document_file.document();
+
+  html::edit(document, diff);
+
+  const std::string output_path =
+      (std::filesystem::current_path() / output_name).string();
+  document.save(output_path);
+
+  return DocumentFile(output_path).document();
 }
 
 } // namespace
@@ -167,190 +219,74 @@ TEST(Document, odg) {
   }
 }
 
-TEST(Document, edit_odt) {
+namespace {
+
+void edit_every_text_and_reload(const std::string &path,
+                                const std::string &output_name) {
   const Logger logger = Logger::create_stdio("odr-test", LogLevel::verbose);
 
-  const DocumentFile document_file(
-      TestData::test_file_path("odr-public/odt/about.odt"), logger);
+  const DocumentFile document_file(TestData::test_file_path(path), logger);
   const Document document = document_file.document();
 
-  std::function<void(Element)> edit = [&](const Element &element) {
-    for (const Element child : element.children()) {
-      edit(child);
-    }
-    // TODO make editing empty text possible
-    if (const Text text = element.as_text(); text && !text.content().empty()) {
-      text.set_content("hello world!");
-    }
-  };
-  edit(document.root_element());
+  set_every_text(document.root_element(), "hello world!");
 
   const std::string output_path =
-      (std::filesystem::current_path() / "about_edit.odt").string();
+      (std::filesystem::current_path() / output_name).string();
   document.save(output_path);
 
-  const DocumentFile validate_file(output_path);
-  const Document validate_document = validate_file.document();
-  std::function<void(Element)> validate = [&](const Element &element) {
-    for (const Element child : element.children()) {
-      validate(child);
-    }
-    // TODO make editing empty text possible
-    if (const Text text = element.as_text(); text && !text.content().empty()) {
-      EXPECT_EQ("hello world!", text.content());
-    }
-  };
-  validate(validate_document.root_element());
+  const Document reloaded = DocumentFile(output_path).document();
+  expect_every_text(reloaded.root_element(), "hello world!");
+}
+
+} // namespace
+
+TEST(Document, edit_odt) {
+  edit_every_text_and_reload("odr-public/odt/about.odt", "about_edit.odt");
 }
 
 TEST(Document, edit_docx) {
-  const Logger logger = Logger::create_stdio("odr-test", LogLevel::verbose);
-
-  const DocumentFile document_file(
-      TestData::test_file_path("odr-public/docx/style-various-1.docx"), logger);
-  const Document document = document_file.document();
-
-  std::function<void(Element)> edit = [&](const Element &element) {
-    for (const Element child : element.children()) {
-      edit(child);
-    }
-    // TODO make editing empty text possible
-    if (const Text text = element.as_text(); text && !text.content().empty()) {
-      text.set_content("hello world!");
-    }
-  };
-  edit(document.root_element());
-
-  const std::string output_path =
-      (std::filesystem::current_path() / "style-various-1_edit.docx").string();
-  document.save(output_path);
-
-  const DocumentFile validate_file(output_path);
-  const Document validate_document = validate_file.document();
-  std::function<void(Element)> validate = [&](const Element &element) {
-    for (const Element child : element.children()) {
-      validate(child);
-    }
-    // TODO make editing empty text possible
-    if (const Text text = element.as_text(); text && !text.content().empty()) {
-      EXPECT_EQ("hello world!", text.content());
-    }
-  };
-  validate(validate_document.root_element());
+  edit_every_text_and_reload("odr-public/docx/style-various-1.docx",
+                             "style-various-1_edit.docx");
 }
 
 TEST(Document, edit_odt_diff) {
-  const Logger logger = Logger::create_stdio("odr-test", LogLevel::verbose);
-
   const char *diff =
       R"({"modifiedText":{"/child:16/child:0":"Outasdfsdafdline","/child:24/child:0":"Colorasdfasdfasdfed Line","/child:6/child:0":"Text hello world!"}})";
-  const DocumentFile document_file(
-      TestData::test_file_path("odr-public/odt/style-various-1.odt"), logger);
-  const Document document = document_file.document();
+  const Document document =
+      edit_and_reload("odr-public/odt/style-various-1.odt", diff,
+                      "style-various-1_edit_diff.odt");
 
-  html::edit(document, diff);
-
-  const std::string output_path =
-      (std::filesystem::current_path() / "style-various-1_edit_diff.odt")
-          .string();
-  document.save(output_path);
-
-  const DocumentFile validate_file(output_path);
-  const Document validate_document = validate_file.document();
-  EXPECT_EQ("Outasdfsdafdline",
-            validate_document.root_element()
-                .navigate_path(DocumentPath("/child:16/child:0"))
-                .as_text()
-                .content());
-  EXPECT_EQ("Colorasdfasdfasdfed Line",
-            validate_document.root_element()
-                .navigate_path(DocumentPath("/child:24/child:0"))
-                .as_text()
-                .content());
-  EXPECT_EQ("Text hello world!",
-            validate_document.root_element()
-                .navigate_path(DocumentPath("/child:6/child:0"))
-                .as_text()
-                .content());
+  expect_text_at(document, "/child:16/child:0", "Outasdfsdafdline");
+  expect_text_at(document, "/child:24/child:0", "Colorasdfasdfasdfed Line");
+  expect_text_at(document, "/child:6/child:0", "Text hello world!");
 }
 
 TEST(Document, edit_ods_diff) {
-  const Logger logger = Logger::create_stdio("odr-test", LogLevel::verbose);
-
   const char *diff =
       R"({"modifiedText":{"/child:0/cell:A1/child:0/child:0":"Page 1 hi","/child:1/cell:A1/child:0/child:0":"Page 2 hihi","/child:2/cell:A1/child:0/child:0":"Page 3 hihihi","/child:3/cell:A1/child:0/child:0":"Page 4 hihihihi","/child:4/cell:A1/child:0/child:0":"Page 5 hihihihihi"}})";
-  DocumentFile document_file(
-      TestData::test_file_path("odr-public/ods/pages.ods"), logger);
-  document_file = document_file.decrypt(
-      TestData::test_file("odr-public/ods/pages.ods").password.value());
-  const Document document = document_file.document();
+  const std::string path = "odr-public/ods/pages.ods";
+  const Document document =
+      edit_and_reload(path, diff, "pages_edit_diff.ods",
+                      TestData::test_file(path).password.value());
 
-  html::edit(document, diff);
-
-  const std::string output_path =
-      (std::filesystem::current_path() / "pages_edit_diff.ods").string();
-  document.save(output_path);
-
-  const DocumentFile validate_file(output_path);
-  const Document validate_document = validate_file.document();
-  EXPECT_EQ("Page 1 hi",
-            validate_document.root_element()
-                .navigate_path(DocumentPath("/child:0/cell:A1/child:0/child:0"))
-                .as_text()
-                .content());
-  EXPECT_EQ("Page 2 hihi",
-            validate_document.root_element()
-                .navigate_path(DocumentPath("/child:1/cell:A1/child:0/child:0"))
-                .as_text()
-                .content());
-  EXPECT_EQ("Page 3 hihihi",
-            validate_document.root_element()
-                .navigate_path(DocumentPath("/child:2/cell:A1/child:0/child:0"))
-                .as_text()
-                .content());
-  EXPECT_EQ("Page 4 hihihihi",
-            validate_document.root_element()
-                .navigate_path(DocumentPath("/child:3/cell:A1/child:0/child:0"))
-                .as_text()
-                .content());
-  EXPECT_EQ("Page 5 hihihihihi",
-            validate_document.root_element()
-                .navigate_path(DocumentPath("/child:4/cell:A1/child:0/child:0"))
-                .as_text()
-                .content());
+  expect_text_at(document, "/child:0/cell:A1/child:0/child:0", "Page 1 hi");
+  expect_text_at(document, "/child:1/cell:A1/child:0/child:0", "Page 2 hihi");
+  expect_text_at(document, "/child:2/cell:A1/child:0/child:0", "Page 3 hihihi");
+  expect_text_at(document, "/child:3/cell:A1/child:0/child:0",
+                 "Page 4 hihihihi");
+  expect_text_at(document, "/child:4/cell:A1/child:0/child:0",
+                 "Page 5 hihihihihi");
 }
 
 TEST(Document, edit_docx_diff) {
-  const Logger logger = Logger::create_stdio("odr-test", LogLevel::verbose);
-
-  const auto *diff =
+  const char *diff =
       R"({"modifiedText":{"/child:16/child:0/child:0":"Outasdfsdafdline","/child:24/child:0/child:0":"Colorasdfasdfasdfed Line","/child:6/child:0/child:0":"Text hello world!"}})";
-  const DocumentFile document_file(
-      TestData::test_file_path("odr-public/docx/style-various-1.docx"), logger);
-  const Document document = document_file.document();
+  const Document document =
+      edit_and_reload("odr-public/docx/style-various-1.docx", diff,
+                      "style-various-1_edit_diff.docx");
 
-  html::edit(document, diff);
-
-  const std::string output_path =
-      (std::filesystem::current_path() / "style-various-1_edit_diff.docx")
-          .string();
-  document.save(output_path);
-
-  const DocumentFile validate_file(output_path);
-  const Document validate_document = validate_file.document();
-  EXPECT_EQ("Outasdfsdafdline",
-            validate_document.root_element()
-                .navigate_path(DocumentPath("/child:16/child:0/child:0"))
-                .as_text()
-                .content());
-  EXPECT_EQ("Colorasdfasdfasdfed Line",
-            validate_document.root_element()
-                .navigate_path(DocumentPath("/child:24/child:0/child:0"))
-                .as_text()
-                .content());
-  EXPECT_EQ("Text hello world!",
-            validate_document.root_element()
-                .navigate_path(DocumentPath("/child:6/child:0/child:0"))
-                .as_text()
-                .content());
+  expect_text_at(document, "/child:16/child:0/child:0", "Outasdfsdafdline");
+  expect_text_at(document, "/child:24/child:0/child:0",
+                 "Colorasdfasdfasdfed Line");
+  expect_text_at(document, "/child:6/child:0/child:0", "Text hello world!");
 }

--- a/test/src/html_output_test.cpp
+++ b/test/src/html_output_test.cpp
@@ -21,6 +21,8 @@ using namespace odr::internal;
 using namespace odr::test;
 namespace fs = std::filesystem;
 
+namespace {
+
 FileType expected_file_type_pre_decryption(const TestFile &test_file) {
   if (test_file.password.has_value()) {
     if (test_file.type == FileType::office_open_xml_document ||
@@ -45,6 +47,8 @@ bool document_type_is_comparable(const TestFile &test_file,
   return test_file.type != FileType::portable_document_format ||
          file_meta.document_type != DocumentType::unknown;
 }
+
+} // namespace
 
 struct TestParams {
   TestFile test_file;
@@ -166,11 +170,10 @@ TEST_P(HtmlOutputTests, html_meta) {
   config.pdf_text_mode = params.pdf_text_mode;
 
   const std::string output_path_tmp = output_path + "/tmp";
-  fs::create_directories(output_path);
-  std::filesystem::create_directories(output_path_tmp);
+  fs::create_directories(output_path_tmp);
   HtmlService service = html::translate(file, output_path_tmp, config);
   Html html = service.bring_offline(output_path);
-  std::filesystem::remove_all(output_path_tmp);
+  fs::remove_all(output_path_tmp);
 
   for (const HtmlPage &html_page : html.pages()) {
     EXPECT_TRUE(fs::is_regular_file(html_page.path));

--- a/test/src/internal/common/path_test.cpp
+++ b/test/src/internal/common/path_test.cpp
@@ -92,3 +92,21 @@ TEST(Path, common_root_relative) {
   EXPECT_EQ("../..",
             Path("../../other/directory").common_root(Path("../..")).string());
 }
+
+TEST(Path, escaping_relative_parent) {
+  EXPECT_EQ("..", Path("../a").parent().string());
+  EXPECT_EQ("../..", Path("../../a").parent().string());
+}
+
+TEST(Path, descendant_of) {
+  EXPECT_TRUE(Path("/a/b").descendant_of(Path("/a")));
+  EXPECT_FALSE(Path("/a").descendant_of(Path("/a/b")));
+  EXPECT_TRUE(Path("/a").ancestor_of(Path("/a/b")));
+  EXPECT_FALSE(Path("/a/b").ancestor_of(Path("/a")));
+}
+
+TEST(Path, descendant_of_respects_component_boundary) {
+  EXPECT_FALSE(Path("/ab/c").descendant_of(Path("/a")));
+  EXPECT_FALSE(Path("/a").parent_of(Path("/ab")));
+  EXPECT_TRUE(Path("/a").parent_of(Path("/a/b")));
+}

--- a/test/src/internal/font/font_file.cpp
+++ b/test/src/internal/font/font_file.cpp
@@ -107,20 +107,13 @@ std::string name_table(const std::string &ascii) {
   return t;
 }
 
-std::string
-build_sfnt_bytes(std::uint32_t version,
-                 std::vector<std::pair<std::string, std::string>> tables) {
-  return build_sfnt(version, std::move(tables));
-}
-
 std::string sample_ttf() {
-  return build_sfnt_bytes(0x00010000,
-                          {{"cmap", cmap_table()},
-                           {"head", head_table()},
-                           {"hhea", hhea_table(4)},
-                           {"hmtx", hmtx_table({500, 600, 700, 800})},
-                           {"maxp", maxp_table(4)},
-                           {"name", name_table("TestFont")}});
+  return build_sfnt(0x00010000, {{"cmap", cmap_table()},
+                                 {"head", head_table()},
+                                 {"hhea", hhea_table(4)},
+                                 {"hmtx", hmtx_table({500, 600, 700, 800})},
+                                 {"maxp", maxp_table(4)},
+                                 {"name", name_table("TestFont")}});
 }
 
 } // namespace

--- a/test/src/internal/font/sfnt_transform.cpp
+++ b/test/src/internal/font/sfnt_transform.cpp
@@ -23,13 +23,6 @@ sfnt::SfntFont parse(std::string bytes) {
   return sfnt::SfntFont(std::move(bytes));
 }
 
-/// Serialize an SFNT to bytes.
-std::string
-build_font(std::uint32_t version,
-           std::vector<std::pair<std::string, std::string>> tables) {
-  return build_sfnt(version, std::move(tables));
-}
-
 /// Parse @p bytes, re-encode it to the PUA in place, and write it back out.
 std::string reencoded(std::string bytes) {
   sfnt::SfntFont font = parse(std::move(bytes));
@@ -90,7 +83,7 @@ std::string name_table(const std::string &ascii) {
 // A 3-glyph TrueType font (no original cmap — the re-encode supplies one),
 // assembled through the library's own serializer.
 std::string sample_font(std::uint16_t glyphs = 3) {
-  return build_font(0x00010000, {{"head", head_table()},
+  return build_sfnt(0x00010000, {{"head", head_table()},
                                  {"maxp", maxp_table(glyphs)},
                                  {"hhea", hhea_table(3)},
                                  {"hmtx", hmtx_table({500, 600, 700})},
@@ -159,7 +152,7 @@ TEST(SfntTransform, serialize_cmap_round_trips_multiple_segments) {
   // second segment — exercises the segment builder beyond a single run.
   const std::map<char32_t, std::uint16_t> map{{'A', 1}, {'B', 2}, {'Z', 5}};
   const std::string font =
-      build_font(0x00010000, {{"head", head_table()},
+      build_sfnt(0x00010000, {{"head", head_table()},
                               {"maxp", maxp_table(6)},
                               {"hhea", hhea_table(0)},
                               {"cmap", serialize_cmap(map)}});
@@ -178,7 +171,7 @@ TEST(SfntTransform, serialize_cmap_format12_round_trips_beyond_bmp) {
   const std::map<char32_t, std::uint16_t> map{
       {'A', 1}, {0xf0000, 2}, {0xf0001, 3}, {0x10fffd, 9}};
   const std::string font =
-      build_font(0x00010000, {{"head", head_table()},
+      build_sfnt(0x00010000, {{"head", head_table()},
                               {"maxp", maxp_table(10)},
                               {"hhea", hhea_table(0)},
                               {"cmap", serialize_cmap(map)}});
@@ -298,7 +291,7 @@ TEST(SfntTransform, write_synthesizes_post_when_absent) {
 TEST(SfntTransform, write_keeps_existing_post) {
   std::string original_post(32, '\0');
   original_post[1] = 0x02; // version 2.0 marker, distinct from the synthesized
-  const std::string font = build_font(0x00010000, {{"head", head_table()},
+  const std::string font = build_sfnt(0x00010000, {{"head", head_table()},
                                                    {"maxp", maxp_table(3)},
                                                    {"hhea", hhea_table(0)},
                                                    {"post", original_post}});
@@ -314,7 +307,7 @@ TEST(SfntTransform, write_keeps_existing_post) {
 TEST(SfntTransform, write_synthesizes_name_when_absent) {
   // OTS requires `name` and TrueType subsets often drop it; the writer must
   // synthesize a minimal one (empty source name falls back to "ODR Font").
-  const std::string font = build_font(0x00010000, {{"head", head_table()},
+  const std::string font = build_sfnt(0x00010000, {{"head", head_table()},
                                                    {"maxp", maxp_table(3)},
                                                    {"hhea", hhea_table(0)}});
   ASSERT_FALSE(table(font, "name").has_value());
@@ -358,7 +351,7 @@ TEST(SfntTransform, write_synthesizes_os2_when_absent) {
 TEST(SfntTransform, write_keeps_existing_os2) {
   std::string original_os2(96, '\0');
   original_os2[1] = 0x02; // version 2 marker, distinct from the synthesized 4
-  const std::string font = build_font(0x00010000, {{"head", head_table()},
+  const std::string font = build_sfnt(0x00010000, {{"head", head_table()},
                                                    {"maxp", maxp_table(3)},
                                                    {"hhea", hhea_table(0)},
                                                    {"OS/2", original_os2}});

--- a/test/src/internal/oldms/xls_test.cpp
+++ b/test/src/internal/oldms/xls_test.cpp
@@ -27,6 +27,7 @@
 using namespace odr;
 using namespace odr::test;
 using odr::test::oldms::append_u16;
+using odr::test::oldms::append_u32;
 using odr::test::oldms::collect_text;
 
 namespace {
@@ -117,11 +118,6 @@ TEST(OldMs, xls_decode_rk) {
 }
 
 namespace {
-
-void append_u32(std::string &out, const std::uint32_t value) {
-  append_u16(out, static_cast<std::uint16_t>(value & 0xFFFF));
-  append_u16(out, static_cast<std::uint16_t>(value >> 16));
-}
 
 /// A Font record body ([MS-XLS] 2.4.122).
 std::string make_font(const std::uint16_t dy_height, const std::uint16_t grbit,

--- a/test/src/internal/pdf/pdf_document_parser.cpp
+++ b/test/src/internal/pdf/pdf_document_parser.cpp
@@ -26,12 +26,18 @@ using PdfFileBuilder = odr::test::pdf::PdfFileBuilder;
 
 namespace {
 
+/// Null rather than undefined behaviour when the parse fell short, so the
+/// caller's `ASSERT_NE` reports instead of the test crashing.
 const Page *first_page(const Document &document) {
-  return dynamic_cast<Page *>(document.catalog->pages->kids.front());
+  const auto &kids = document.catalog->pages->kids;
+  return kids.empty() ? nullptr : dynamic_cast<Page *>(kids.front());
 }
 
 const Font *first_page_font(const Document &document, const std::string &name) {
   const auto *page = first_page(document);
+  if (page == nullptr || page->resources == nullptr) {
+    return nullptr;
+  }
   return page->resources->font.at(name);
 }
 
@@ -405,6 +411,7 @@ TEST(DocumentParser, form_xobject_cycle_is_represented_via_cache) {
   const std::unique_ptr<Document> document = parser.parse_document();
 
   const Page *page = first_page(*document);
+  ASSERT_NE(page, nullptr);
   ASSERT_NE(page->resources, nullptr);
 
   const XObject *fm0 = page->resources->x_object.at("Fm0");
@@ -434,6 +441,7 @@ TEST(DocumentParser, image_named_colorspace_resolves_and_encodes) {
   const std::unique_ptr<Document> document = parser.parse_document();
 
   const Page *page = first_page(*document);
+  ASSERT_NE(page, nullptr);
   ASSERT_NE(page->resources, nullptr);
   const XObject *image = page->resources->x_object.at("Im0");
   ASSERT_NE(image, nullptr);

--- a/test/src/internal/pdf/pdf_encryption.cpp
+++ b/test/src/internal/pdf/pdf_encryption.cpp
@@ -9,10 +9,9 @@
 using namespace odr::internal::pdf;
 using namespace odr::internal::crypto::util;
 
-// Known-answer test from the real R 2 / RC4-40 fixture
-// (odr-public/pdf/Casio_WVA-M650-7AJF.pdf): derive the file key from /O, /P and
-// /ID[0] with the empty user password, then Algorithm 4 must reproduce /U. The
-// vectors come from a real producer, so this is not circular through our code.
+// Known-answer test against the real R 2 / RC4-40 fixture
+// (odr-public/pdf/Casio_WVA-M650-7AJF.pdf), so the vectors are a producer's,
+// not ours: Algorithm 4 over the derived file key must reproduce its /U.
 TEST(PdfEncryption, casio_r2_rc4_user_key) {
   const std::string o = hex_decode(
       "5ee983cbdfb3f64baa265a496c450467891a307fd45c5f7d53282fd1835ce1b1");
@@ -74,13 +73,11 @@ TEST(PdfEncryption, fontfile3_r6_aesv3) {
   EXPECT_FALSE(authenticator->authenticate("wrong-password").has_value());
 }
 
-// The fixtures above cover R 2 (RC4-40) and R 6 (AES-256). The remaining R 3
-// (RC4-128) and R 4 (AES-128 / AESV2) paths have no real-world fixture, so the
-// vectors below were produced by `qpdf --encrypt user owner 128 ...` over a
-// one-object content stream holding the marker "KAT-MARKER-12345". Decrypting
-// qpdf's output back to the marker proves the whole chain — file key,
-// per-object key (Algorithm 1, incl. the AES "sAlT"), RC4 / AES-128-CBC +
-// PKCS#7 — against an independent implementation, with no fixture file to ship.
+// R 3 (RC4-128) and R 4 (AES-128 / AESV2) have no real-world fixture; the
+// vectors below come from `qpdf --encrypt user owner 128 ...` over a content
+// stream holding "KAT-MARKER-12345". Recovering the marker proves the whole
+// chain (file key, Algorithm 1 object key, RC4 / AES-128-CBC + PKCS#7) against
+// an independent implementation, with no fixture file to ship.
 namespace {
 
 constexpr const char *kMarker = "KAT-MARKER-12345";

--- a/test/src/internal/pdf/pdf_file_parser.cpp
+++ b/test/src/internal/pdf/pdf_file_parser.cpp
@@ -5,10 +5,11 @@
 
 #include <test_util.hpp>
 
+#include <cstddef>
 #include <memory>
-#include <ranges>
 #include <sstream>
 #include <string>
+#include <vector>
 
 #include <gtest/gtest.h>
 
@@ -16,7 +17,9 @@ using namespace odr::internal;
 using namespace odr::internal::pdf;
 using namespace odr::test;
 
-TEST(FileParser, foo) {
+// A linear walk from the header to eof: every indirect object comes out, the
+// trailer names the catalog, and the FlateDecode streams inflate.
+TEST(FileParser, reads_every_entry_linearly) {
   const auto file = std::make_shared<DiskFile>(
       TestData::test_file_path("odr-public/pdf/style-various-1.pdf"));
 
@@ -24,6 +27,10 @@ TEST(FileParser, foo) {
   FileParser parser(*in);
 
   parser.read_header();
+
+  std::size_t objects = 0;
+  std::size_t inflated_streams = 0;
+  Dictionary trailer;
   while (true) {
     Entry entry = parser.read_entry();
 
@@ -31,53 +38,34 @@ TEST(FileParser, foo) {
       break;
     }
     if (entry.is_trailer()) {
-      const auto &[size, dictionary] = entry.as_trailer();
-
-      for (const auto &key : dictionary | std::views::keys) {
-        std::cout << key << '\n';
-      }
+      trailer = entry.as_trailer().dictionary;
     }
-    if (entry.is_object()) {
-      const IndirectObject &object = entry.as_object();
+    if (!entry.is_object()) {
+      continue;
+    }
 
-      std::cout << "object " << object.reference.id << " "
-                << object.reference.gen << '\n';
+    ++objects;
+    const IndirectObject &object = entry.as_object();
+    if (!object.has_stream) {
+      continue;
+    }
 
-      if (object.object.is_integer()) {
-        std::cout << "integer " << object.object.as_integer() << '\n';
-      }
-      if (object.object.is_array()) {
-        std::cout << "array size " << object.object.as_array().size() << '\n';
-      }
-      if (object.object.is_dictionary()) {
-        const auto &dictionary = object.object.as_dictionary();
-        std::cout << "dictionary size " << dictionary.size() << '\n';
-        for (const auto &key : dictionary | std::views::keys) {
-          std::cout << key << '\n';
-        }
-      }
-
-      if (object.has_stream) {
-        const Dictionary &dictionary = object.object.as_dictionary();
-        std::string stream = parser.read_stream();
-        std::cout << stream.size() << '\n';
-
-        if (dictionary.has_key("Filter")) {
-          const std::string &filter = dictionary["Filter"].as_string();
-          std::cout << filter << '\n';
-          if (filter == "FlateDecode") {
-            std::string inflated = crypto::util::zlib_inflate(stream);
-            std::cout << inflated.size() << '\n';
-          }
-        }
-      }
-
-      std::cout << '\n';
+    // reading the stream is what advances the parser past the object
+    const std::string stream = parser.read_stream();
+    const Dictionary &dictionary = object.object.as_dictionary();
+    if (dictionary.has_key("Filter") &&
+        dictionary["Filter"].as_string() == "FlateDecode") {
+      EXPECT_FALSE(crypto::util::zlib_inflate(stream).empty());
+      ++inflated_streams;
     }
   }
+
+  EXPECT_GT(objects, 0u);
+  EXPECT_GT(inflated_streams, 0u);
+  EXPECT_TRUE(trailer.has_key("Root"));
 }
 
-TEST(FileParser, bar) {
+TEST(FileParser, walks_the_xref_chain_to_the_catalog) {
   const auto file = std::make_shared<DiskFile>(
       TestData::test_file_path("odr-public/pdf/style-various-1.pdf"));
 
@@ -111,7 +99,7 @@ TEST(FileParser, bar) {
     if (ref.id == 0) {
       EXPECT_TRUE(entry.is_free());
     } else {
-      EXPECT_TRUE(entry.is_used());
+      ASSERT_TRUE(entry.is_used());
       EXPECT_GT(entry.as_used().position, 0);
     }
   }

--- a/test/src/internal/pdf/pdf_function.cpp
+++ b/test/src/internal/pdf/pdf_function.cpp
@@ -66,6 +66,7 @@ TEST(PdfFunction, exponential_power) {
   dict["N"] = Object(Real{2});
 
   const auto fn = parse_function(Object(dict), context());
+  ASSERT_NE(fn, nullptr);
   EXPECT_DOUBLE_EQ(fn->eval({0.5})[0], 0.25);
 }
 
@@ -79,6 +80,7 @@ TEST(PdfFunction, clips_domain) {
   dict["N"] = Object(Real{1});
 
   const auto fn = parse_function(Object(dict), context());
+  ASSERT_NE(fn, nullptr);
   EXPECT_DOUBLE_EQ(fn->eval({2.0})[0], 1.0);  // clipped to 1
   EXPECT_DOUBLE_EQ(fn->eval({-1.0})[0], 0.0); // clipped to 0
 }

--- a/test/src/internal/pdf/pdf_page_extractor.cpp
+++ b/test/src/internal/pdf/pdf_page_extractor.cpp
@@ -491,9 +491,13 @@ TEST(PdfPageExtractor, tj_kern_threshold) {
   res.font["F1"] = &font;
 
   // -50 -> +0.5 gap, below 0.2 em
-  EXPECT_EQ(run("BT /F1 10 Tf 0 0 Td [(A) -50 (B)] TJ ET", res)[1].text, "B");
+  const auto below = run("BT /F1 10 Tf 0 0 Td [(A) -50 (B)] TJ ET", res);
+  ASSERT_EQ(below.size(), 2);
+  EXPECT_EQ(below[1].text, "B");
   // -400 -> +4 gap, above 0.2 em
-  EXPECT_EQ(run("BT /F1 10 Tf 0 0 Td [(A) -400 (B)] TJ ET", res)[1].text, " B");
+  const auto above = run("BT /F1 10 Tf 0 0 Td [(A) -400 (B)] TJ ET", res);
+  ASSERT_EQ(above.size(), 2);
+  EXPECT_EQ(above[1].text, " B");
 }
 
 // A perpendicular jump (a new text line) infers a space so lines don't merge.
@@ -802,12 +806,9 @@ TEST(PdfPageExtractor, gs_soft_mask_scoped_by_q_Q) {
   EXPECT_EQ(path_at(page, 1).soft_mask, nullptr); // restored after Q
 }
 
-// A transparency group with a group-level parameter (soft mask here) is emitted
-// as a single `GroupElement` carrying that parameter, with the interior content
-// as its children — so the renderer composites the group first, then applies
-// the mask (ISO 32000-1 11.6.6). The mask survives even though the group's own
-// content resets it to none: the common drop-shadow/reflection idiom (a `gs`
-// sets the mask, then a group form paints the shape).
+// A group-level parameter (a soft mask here) rides on one `GroupElement` with
+// the interior as its children, so the renderer composites and then masks
+// (ISO 32000-1 11.6.6) — surviving the group resetting the mask internally.
 TEST(PdfPageExtractor, soft_mask_wraps_transparency_group) {
   XObject mask_group = form_x_object("0 0 10 10 re f");
   Resources form_res;
@@ -832,11 +833,9 @@ TEST(PdfPageExtractor, soft_mask_wraps_transparency_group) {
             nullptr);
 }
 
-// A transparency group's constant alpha rides on the `GroupElement`, not each
-// interior element, so the group composites first and then fades — the correct
-// model for content whose interior paints overlap (ISO 32000-1 11.6.6). The
-// group resets alpha internally (as real group content does), yet the group's
-// own alpha is the outer `ca`.
+// The constant alpha rides on the `GroupElement`, not each interior element, so
+// overlapping interior paints composite before fading (ISO 32000-1 11.6.6) —
+// even though the group resets alpha internally.
 TEST(PdfPageExtractor, transparency_group_carries_constant_alpha) {
   Resources form_res;
   form_res.ext_g_state["GS0"] = ext_g_state(1.0, std::nullopt, ""); // reset
@@ -1307,10 +1306,8 @@ TEST(PdfPageExtractor, scn_uncoloured_tiling_pattern_carries_colour) {
   EXPECT_EQ(p.fill_pattern->paint_type, 2);
 }
 
-// An uncoloured pattern selected through a *named* Pattern colour space with an
-// underlying base (`[/Pattern /DeviceRGB]`) resolves its leading components
-// through that base — `1 0 0` is red, not black (the base would be ignored if
-// the Pattern space's `to_rgb` dropped it).
+// A named Pattern space with an underlying base (`[/Pattern /DeviceRGB]`)
+// resolves the leading components through that base: `1 0 0` is red, not black.
 TEST(PdfPageExtractor, scn_uncoloured_tiling_pattern_colour_through_base) {
   Pattern pattern;
   pattern.type = Pattern::Type::tiling;

--- a/test/src/internal/svm/svm_test.cpp
+++ b/test/src/internal/svm/svm_test.cpp
@@ -6,8 +6,8 @@
 
 #include <test_util.hpp>
 
-#include <fstream>
 #include <memory>
+#include <sstream>
 
 #include <gtest/gtest.h>
 
@@ -27,10 +27,6 @@ TEST(SvmToSvg, string) {
 
   std::stringstream out;
   svm::Translator::svg(svm, out);
-  auto out_string = out.str();
 
-  EXPECT_LT(0, out_string.size());
-
-  std::ofstream test("test.svg");
-  test << out_string;
+  EXPECT_LT(0, out.str().size());
 }

--- a/test/src/internal/util/map_util_test.cpp
+++ b/test/src/internal/util/map_util_test.cpp
@@ -21,3 +21,33 @@ TEST(map_util, lookup_greater_or_equals) {
   EXPECT_EQ(data.find(2), lookup_greater_or_equals(data, 2));
   EXPECT_EQ(std::end(data), lookup_greater_or_equals(data, 3));
 }
+
+TEST(map_util, lookup_on_empty_map) {
+  const std::map<int, int> data;
+  EXPECT_EQ(std::end(data), lookup_greater_than(data, 0));
+  EXPECT_EQ(std::end(data), lookup_greater_or_equals(data, 0));
+}
+
+// A miss leaves the out parameter untouched.
+TEST(map_util, lookup_reports_hit_and_miss) {
+  const std::map<int, int> data = {{1, 10}};
+
+  int value = -1;
+  EXPECT_TRUE(lookup(data, 1, value));
+  EXPECT_EQ(10, value);
+  EXPECT_FALSE(lookup(data, 2, value));
+  EXPECT_EQ(10, value);
+}
+
+TEST(map_util, lookup_default_falls_back) {
+  const std::map<int, int> data = {{1, 10}};
+
+  int value = -1;
+  EXPECT_TRUE(lookup_default(data, 1, value, 99));
+  EXPECT_EQ(10, value);
+  EXPECT_FALSE(lookup_default(data, 2, value, 99));
+  EXPECT_EQ(99, value);
+
+  EXPECT_EQ(10, lookup_default(data, 1, 99));
+  EXPECT_EQ(99, lookup_default(data, 2, 99));
+}

--- a/test/src/internal/util/string_util_test.cpp
+++ b/test/src/internal/util/string_util_test.cpp
@@ -68,6 +68,13 @@ TEST(string_util, split) {
     EXPECT_EQ(strings[1], "");
     EXPECT_EQ(strings[2], "y");
   }
+
+  // Empty input is one empty segment, never zero segments.
+  {
+    const std::vector<std::string> strings = split("", ",");
+    EXPECT_EQ(strings.size(), 1);
+    EXPECT_EQ(strings[0], "");
+  }
 }
 
 TEST(string_util, trim_view) {

--- a/test/src/internal/util/xml_util_test.cpp
+++ b/test/src/internal/util/xml_util_test.cpp
@@ -41,11 +41,22 @@ TEST(xml_util, tokenize_text) {
   EXPECT_EQ("world!", example5[2].string);
 
   auto example6 = tokenize_text("\t  \t");
-  EXPECT_EQ(3, example5.size());
+  EXPECT_EQ(3, example6.size());
   EXPECT_EQ(StringToken::Type::tabs, example6[0].type);
   EXPECT_EQ("\t", example6[0].string);
   EXPECT_EQ(StringToken::Type::spaces, example6[1].type);
   EXPECT_EQ("  ", example6[1].string);
   EXPECT_EQ(StringToken::Type::tabs, example6[2].type);
   EXPECT_EQ("\t", example6[2].string);
+}
+
+TEST(xml_util, tokenize_text_empty) { EXPECT_TRUE(tokenize_text("").empty()); }
+
+// Only a run of two or more spaces is significant; a lone space is ordinary
+// text, so it must not be split off as a `spaces` token.
+TEST(xml_util, tokenize_text_single_space) {
+  const auto tokens = tokenize_text("a b");
+  ASSERT_EQ(1, tokens.size());
+  EXPECT_EQ(StringToken::Type::string, tokens[0].type);
+  EXPECT_EQ("a b", tokens[0].string);
 }

--- a/test/src/internal/zip/zip_archive_test.cpp
+++ b/test/src/internal/zip/zip_archive_test.cpp
@@ -12,6 +12,8 @@
 #include <filesystem>
 #include <fstream>
 #include <memory>
+#include <string>
+#include <vector>
 
 using namespace odr;
 using namespace odr::internal;
@@ -118,10 +120,10 @@ TEST(ZipArchive, create_order) {
   {
     util::Archive zip(std::make_shared<DiskFile>(path));
 
-    auto it = entries.begin();
+    std::vector<std::string> actual;
     for (auto &&e : zip) {
-      EXPECT_EQ(Path(*it), e.path());
-      ++it;
+      actual.push_back(e.path().string());
     }
+    EXPECT_EQ(actual, entries);
   }
 }

--- a/test/src/odr_test.cpp
+++ b/test/src/odr_test.cpp
@@ -33,6 +33,7 @@ std::vector<FileType> every_file_type() {
 
 } // namespace
 
+/// `main` carries no version — only a release build stamps one (see AGENTS.md).
 TEST(odr, version) { EXPECT_TRUE(odr::version().empty()); }
 
 TEST(odr, commit) { EXPECT_FALSE(odr::commit_hash().empty()); }

--- a/test/src/quantity_test.cpp
+++ b/test/src/quantity_test.cpp
@@ -9,10 +9,8 @@ TEST(Quantity, construct) {
   Quantity<double>{"10 ms"};
 }
 
-/// A default-constructed unit used to leave the unit pointer null, so anything
-/// that rendered such a quantity — the geometry fallback for a shape missing
-/// its `svg:*` attribute, for one — dereferenced null instead of emitting a
-/// bare number.
+/// A default-constructed unit used to leave the unit pointer null, so rendering
+/// such a quantity dereferenced null instead of emitting a bare number.
 TEST(DynamicUnit, default_constructed_is_the_unitless_unit) {
   EXPECT_EQ(DynamicUnit(), DynamicUnit(""));
   EXPECT_EQ(DynamicUnit().name(), "");

--- a/test/src/test_util.cpp
+++ b/test/src/test_util.cpp
@@ -29,11 +29,12 @@ TestFile get_test_file(const std::string &root_path,
 
   std::string short_path = absolute_path.substr(root_path.size() + 1);
 
+  // `name$password$.ext` names the password in the file name itself.
   std::optional<std::string> password;
   const std::string filename = fs::path(absolute_path).filename().string();
   if (const auto left = filename.find('$'), right = filename.rfind('$');
       left != std::string::npos && left != right) {
-    password = filename.substr(left, right);
+    password = filename.substr(left + 1, right - left - 1);
   }
 
   return {std::move(absolute_path), std::move(short_path), type,


### PR DESCRIPTION
🤖 Generated with [Claude Code](https://claude.com/claude-code)

A whole-codebase review for correctness and conciseness, run as twelve parallel
per-area reviews (public API, common/util/detection, odf, ooxml, oldms, pdf,
html renderer, font/zip/cfb/crypto, python+cli, jni+android, apple, tests) with
every finding verified against a build and the full suite.

**172 files, +2651 / −3442.** Net −799 comment lines.

## Verification

| | |
|---|---|
| Baseline at `main` | 759 tests, 750 passed, 0 failed |
| Build (lib + tests + CLI + JNI) | clean, **0 warnings** |
| Full suite | **767 tests, 758 passed, 9 skipped, 0 failed** |
| JNI JUnit (`ctest`) | passed |
| Python bindings | build clean, **49/49 pytest** |
| Apple bindings (`ODR_APPLE=ON`) | build clean, 0 compiler warnings |
| clang-format | clean |

## The bugs that matter most

**CID-keyed CFF fonts had wrong glyph metrics in every PDF.** The parser never
read `/FDArray` or `/FDSelect`, so `nominalWidthX` stayed 0 and every
charstring width resolved against it. Real subset fonts came out with negative
advances that wrapped into an `advanceWidthMax` of 65431 — 65 em. All 152
glyphs of two corpus PDFs now agree with fontTools' own CFF interpreter, with
zero mismatches.

**`TablePosition::to_column_string` produced wrong column names.** The borrow
was `column /= 27` where bijective base 26 needs `column / 26 - 1`; they agree
only while the quotient is ≤ 27. 792 of the first 20 000 columns were wrong,
the first at 727 (`ZZ` instead of `AAZ`). Reaches spreadsheet headers and the
Python and JNI bindings.

**Document content was written into HTML attributes unescaped** — link `href`,
bookmark `id`, image `src`, font name, font shadow, the four cell border
strings, archive entry paths. A quote in document content broke out of the
attribute.

**Two unbounded recursions and an iterator invalidation** in ODF and OOXML
style resolution: a cyclic `w:basedOn` / `style:parent-style-name` recursed
until the stack ran out, and resolving an unknown parent id through
`operator[]` rehashed the map that `generate_styles_` was iterating.

**JNI wrappers could be collected mid-call.** `Html.translate` and
`HtmlService.bringOffline` passed a bare handle into a static native, so
nothing in the Java frame referred to the wrapper. Plus local-reference leaks
that overflow ART's table on a chatty translate.

**Python reported failed typed casts as valid.** Only `Element::operator bool`
was bound, so `bool(paragraph.as_slide())` was `True` for a cast that failed
and callers silently read defaults. Iterator-yielded elements also did not keep
their document alive.

Beyond those: bounds and overflow hardening across the hand-rolled binary
parsers (PDF, CFB, ZIP, fonts, oldms) — unchecked `substr`, wrapping lengths,
allocation bombs from file-supplied counts, empty-stack pops, unbounded
nesting — and `Path::descendant_of` was simply backwards, with its only caller
written against the inverted answer so the two bugs cancelled.

## ⚠️ Reference output changes — 72 of 1141 files

Every diff is traced and each is a correction. **The output repos need
regenerating before this merges.**

- **65 files** — repeated ODS cells lose `contenteditable`.
  `element_is_editable` recursed to the parent before testing `sheet_cell`, and
  a sheet cell always has a sheet parent, so the branch was dead and everything
  reported editable. Confirmed against the source XML that these are
  `table:number-columns-repeated` cells sharing one node, where editing one
  would silently rewrite all of them.
- **2 files** — `&` now escaped in `href`. The current reference output is
  invalid HTML.
- **5 files** — the PDF font-metrics fix above.

## Conciseness

Comments were cut to the AGENTS.md bar — a couple of terse lines stating the
key point, citing the spec rather than paraphrasing it. Worst offenders:
`html/pdf_file.cpp` 534 → 344 comment lines, `pdf_page_element.hpp` 125 → 51,
`pdf_document_element.hpp` 197 → 111. Several were also factually wrong
(`sfnt_transform.hpp` still documented a BMP-only limitation the code had
outgrown). Structural dedup where it was clearly safe: three near-identical
HTML fragment classes behind one template, 23 pybind11 class bindings behind a
helper, the `override_if_set` collapse in `style.cpp`, `link_child` in the ODF
registry.

A stacked follow-up carries the findings this PR deliberately left alone.
