### PR TITLE
feat(html): translate without a cache path

### DIFF
--- a/src/odr/html.cpp
+++ b/src/odr/html.cpp
@@ -210,34 +210,31 @@ void HtmlResource::write_resource(std::ostream &os) const {
   m_impl->write_resource(os);
 }
 
-HtmlService html::translate(const DecodedFile &file,
-                            const std::string &cache_path,
-                            const HtmlConfig &config, const Logger &logger) {
+HtmlService html::translate(const DecodedFile &file, const HtmlConfig &config,
+                            const Logger &logger) {
   if (file.is_text_file()) {
-    return translate(file.as_text_file(), cache_path, config, logger);
+    return translate(file.as_text_file(), config, logger);
   }
   if (file.is_image_file()) {
-    return translate(file.as_image_file(), cache_path, config, logger);
+    return translate(file.as_image_file(), config, logger);
   }
   if (file.is_archive_file()) {
-    return translate(file.as_archive_file(), cache_path, config, logger);
+    return translate(file.as_archive_file(), config, logger);
   }
   if (file.is_document_file()) {
-    return translate(file.as_document_file(), cache_path, config, logger);
+    return translate(file.as_document_file(), config, logger);
   }
   if (file.is_pdf_file()) {
-    return translate(file.as_pdf_file(), cache_path, config, logger);
+    return translate(file.as_pdf_file(), config, logger);
   }
   if (file.is_font_file()) {
-    return translate(file.as_font_file(), cache_path, config, logger);
+    return translate(file.as_font_file(), config, logger);
   }
   // No wrapper type to go through: nothing is decoded, so the plain
   // `DecodedFile` already carries the bytes and the type that names them.
   if (const FileCategory category = file.file_category();
       category == FileCategory::audio || category == FileCategory::video) {
-    std::filesystem::create_directories(cache_path);
-    return internal::html::create_media_service(file, cache_path, config,
-                                                logger);
+    return internal::html::create_media_service(file, config, logger);
   }
 
   throw UnsupportedFileType(file.file_type());
@@ -256,69 +253,113 @@ HtmlResourceLocator html::standard_resource_locator() {
   };
 }
 
-HtmlService html::translate(const TextFile &text_file,
-                            const std::string &cache_path,
-                            const HtmlConfig &config, const Logger &logger) {
-  std::filesystem::create_directories(cache_path);
-  return internal::html::create_text_service(text_file, cache_path, config,
-                                             logger);
+HtmlService html::translate(const TextFile &text_file, const HtmlConfig &config,
+                            const Logger &logger) {
+  return internal::html::create_text_service(text_file, config, logger);
 }
 
 HtmlService html::translate(const ImageFile &image_file,
-                            const std::string &cache_path,
                             const HtmlConfig &config, const Logger &logger) {
-  std::filesystem::create_directories(cache_path);
-  return internal::html::create_image_service(image_file, cache_path, config,
-                                              logger);
+  return internal::html::create_image_service(image_file, config, logger);
 }
 
 HtmlService html::translate(const ArchiveFile &archive_file,
-                            const std::string &cache_path,
                             const HtmlConfig &config, const Logger &logger) {
-  return translate(archive_file.archive(), cache_path, config, logger);
+  return translate(archive_file.archive(), config, logger);
 }
 
 HtmlService html::translate(const DocumentFile &document_file,
-                            const std::string &cache_path,
                             const HtmlConfig &config, const Logger &logger) {
-  return translate(document_file.document(), cache_path, config, logger);
+  return translate(document_file.document(), config, logger);
 }
 
-HtmlService html::translate(const PdfFile &pdf_file,
-                            const std::string &cache_path,
-                            const HtmlConfig &config, const Logger &logger) {
-  return internal::html::create_pdf_service(pdf_file, cache_path, config,
-                                            logger);
+HtmlService html::translate(const PdfFile &pdf_file, const HtmlConfig &config,
+                            const Logger &logger) {
+  return internal::html::create_pdf_service(pdf_file, config, logger);
 }
 
-HtmlService html::translate(const FontFile &font_file,
-                            const std::string &cache_path,
-                            const HtmlConfig &config, const Logger &logger) {
-  std::filesystem::create_directories(cache_path);
-  return internal::html::create_font_service(font_file, cache_path, config,
-                                             logger);
+HtmlService html::translate(const FontFile &font_file, const HtmlConfig &config,
+                            const Logger &logger) {
+  return internal::html::create_font_service(font_file, config, logger);
 }
 
 HtmlService html::translate(const Filesystem &filesystem,
-                            const std::string &cache_path,
                             const HtmlConfig &config, const Logger &logger) {
-  std::filesystem::create_directories(cache_path);
-  return internal::html::create_filesystem_service(filesystem, cache_path,
-                                                   config, logger);
+  return internal::html::create_filesystem_service(filesystem, config, logger);
+}
+
+HtmlService html::translate(const Archive &archive, const HtmlConfig &config,
+                            const Logger &logger) {
+  return translate(archive.as_filesystem(), config, logger);
+}
+
+HtmlService html::translate(const Document &document, const HtmlConfig &config,
+                            const Logger &logger) {
+  return internal::html::create_document_service(document, config, logger);
+}
+
+// The `cache_path` overloads. Nothing reads the path: no renderer has since the
+// output became a set of streams, and the `create_directories` that used to sit
+// here made a directory nobody wrote into.
+
+HtmlService html::translate(const DecodedFile &file,
+                            const std::string & /*cache_path*/,
+                            const HtmlConfig &config, const Logger &logger) {
+  return translate(file, config, logger);
+}
+
+HtmlService html::translate(const TextFile &text_file,
+                            const std::string & /*cache_path*/,
+                            const HtmlConfig &config, const Logger &logger) {
+  return translate(text_file, config, logger);
+}
+
+HtmlService html::translate(const ImageFile &image_file,
+                            const std::string & /*cache_path*/,
+                            const HtmlConfig &config, const Logger &logger) {
+  return translate(image_file, config, logger);
+}
+
+HtmlService html::translate(const ArchiveFile &archive_file,
+                            const std::string & /*cache_path*/,
+                            const HtmlConfig &config, const Logger &logger) {
+  return translate(archive_file, config, logger);
+}
+
+HtmlService html::translate(const DocumentFile &document_file,
+                            const std::string & /*cache_path*/,
+                            const HtmlConfig &config, const Logger &logger) {
+  return translate(document_file, config, logger);
+}
+
+HtmlService html::translate(const PdfFile &pdf_file,
+                            const std::string & /*cache_path*/,
+                            const HtmlConfig &config, const Logger &logger) {
+  return translate(pdf_file, config, logger);
+}
+
+HtmlService html::translate(const FontFile &font_file,
+                            const std::string & /*cache_path*/,
+                            const HtmlConfig &config, const Logger &logger) {
+  return translate(font_file, config, logger);
+}
+
+HtmlService html::translate(const Filesystem &filesystem,
+                            const std::string & /*cache_path*/,
+                            const HtmlConfig &config, const Logger &logger) {
+  return translate(filesystem, config, logger);
 }
 
 HtmlService html::translate(const Archive &archive,
-                            const std::string &cache_path,
+                            const std::string & /*cache_path*/,
                             const HtmlConfig &config, const Logger &logger) {
-  return translate(archive.as_filesystem(), cache_path, config, logger);
+  return translate(archive, config, logger);
 }
 
 HtmlService html::translate(const Document &document,
-                            const std::string &cache_path,
+                            const std::string & /*cache_path*/,
                             const HtmlConfig &config, const Logger &logger) {
-  std::filesystem::create_directories(cache_path);
-  return internal::html::create_document_service(document, cache_path, config,
-                                                 logger);
+  return translate(document, config, logger);
 }
 
 void html::edit(const Document &document, const std::string_view diff,

--- a/src/odr/html.hpp
+++ b/src/odr/html.hpp
@@ -257,50 +257,78 @@ namespace html {
 
 HtmlResourceLocator standard_resource_locator();
 
-/// @brief Translates a decoded file to HTML. `cache_path` is the directory
-/// temporary output goes into.
-HtmlService translate(const DecodedFile &file, const std::string &cache_path,
-                      const HtmlConfig &config,
+/// @brief Translates a decoded file to HTML.
+HtmlService translate(const DecodedFile &file, const HtmlConfig &config,
                       const Logger &logger = Logger::null());
 
 /// @brief Translates a text file to HTML.
-HtmlService translate(const TextFile &text_file, const std::string &cache_path,
-                      const HtmlConfig &config,
+HtmlService translate(const TextFile &text_file, const HtmlConfig &config,
                       const Logger &logger = Logger::null());
 /// @brief Translates an image file to HTML.
-HtmlService translate(const ImageFile &image_file,
-                      const std::string &cache_path, const HtmlConfig &config,
+HtmlService translate(const ImageFile &image_file, const HtmlConfig &config,
                       const Logger &logger = Logger::null());
 /// @brief Translates an archive file to HTML.
-HtmlService translate(const ArchiveFile &archive_file,
-                      const std::string &cache_path, const HtmlConfig &config,
+HtmlService translate(const ArchiveFile &archive_file, const HtmlConfig &config,
                       const Logger &logger = Logger::null());
 /// @brief Translates a document file to HTML.
 HtmlService translate(const DocumentFile &document_file,
-                      const std::string &cache_path, const HtmlConfig &config,
+                      const HtmlConfig &config,
                       const Logger &logger = Logger::null());
 /// @brief Translates a PDF file to HTML.
-HtmlService translate(const PdfFile &pdf_file, const std::string &cache_path,
-                      const HtmlConfig &config,
+HtmlService translate(const PdfFile &pdf_file, const HtmlConfig &config,
                       const Logger &logger = Logger::null());
 
 /// @brief Translates a font file to HTML (a specimen page).
-HtmlService translate(const FontFile &font_file, const std::string &cache_path,
-                      const HtmlConfig &config,
+HtmlService translate(const FontFile &font_file, const HtmlConfig &config,
                       const Logger &logger = Logger::null());
 
 /// @brief Translates a filesystem to HTML.
+HtmlService translate(const Filesystem &filesystem, const HtmlConfig &config,
+                      const Logger &logger = Logger::null());
+/// @brief Translates an archive to HTML.
+HtmlService translate(const Archive &archive, const HtmlConfig &config,
+                      const Logger &logger = Logger::null());
+/// @brief Translates a document to HTML.
+HtmlService translate(const Document &document, const HtmlConfig &config,
+                      const Logger &logger = Logger::null());
+
+/// @name Translation with a cache path
+///
+/// `cache_path` is ignored — nothing on the render path writes to disk, and no
+/// renderer has read it since the output became a set of streams. Kept so
+/// existing callers keep compiling; prefer the overloads above.
+/// @{
+HtmlService translate(const DecodedFile &file, const std::string &cache_path,
+                      const HtmlConfig &config,
+                      const Logger &logger = Logger::null());
+HtmlService translate(const TextFile &text_file, const std::string &cache_path,
+                      const HtmlConfig &config,
+                      const Logger &logger = Logger::null());
+HtmlService translate(const ImageFile &image_file,
+                      const std::string &cache_path, const HtmlConfig &config,
+                      const Logger &logger = Logger::null());
+HtmlService translate(const ArchiveFile &archive_file,
+                      const std::string &cache_path, const HtmlConfig &config,
+                      const Logger &logger = Logger::null());
+HtmlService translate(const DocumentFile &document_file,
+                      const std::string &cache_path, const HtmlConfig &config,
+                      const Logger &logger = Logger::null());
+HtmlService translate(const PdfFile &pdf_file, const std::string &cache_path,
+                      const HtmlConfig &config,
+                      const Logger &logger = Logger::null());
+HtmlService translate(const FontFile &font_file, const std::string &cache_path,
+                      const HtmlConfig &config,
+                      const Logger &logger = Logger::null());
 HtmlService translate(const Filesystem &filesystem,
                       const std::string &cache_path, const HtmlConfig &config,
                       const Logger &logger = Logger::null());
-/// @brief Translates an archive to HTML.
 HtmlService translate(const Archive &archive, const std::string &cache_path,
                       const HtmlConfig &config,
                       const Logger &logger = Logger::null());
-/// @brief Translates a document to HTML.
 HtmlService translate(const Document &document, const std::string &cache_path,
                       const HtmlConfig &config,
                       const Logger &logger = Logger::null());
+/// @}
 
 /// @brief Applies a diff to a document. The diff is what our JavaScript
 /// produces in the browser.

--- a/src/odr/internal/html/document.cpp
+++ b/src/odr/internal/html/document.cpp
@@ -353,7 +353,6 @@ using PageHtmlFragment = ElementHtmlFragment<Page, translate_page>;
 namespace odr::internal {
 
 HtmlService html::create_document_service(const Document &document,
-                                          const std::string & /*cache_path*/,
                                           HtmlConfig config,
                                           const Logger &logger) {
   std::vector<std::shared_ptr<HtmlFragmentBase>> fragments;

--- a/src/odr/internal/html/document.hpp
+++ b/src/odr/internal/html/document.hpp
@@ -12,8 +12,7 @@ class Logger;
 
 namespace odr::internal::html {
 
-HtmlService create_document_service(const Document &document,
-                                    const std::string &cache_path,
-                                    HtmlConfig config, const Logger &logger);
+HtmlService create_document_service(const Document &document, HtmlConfig config,
+                                    const Logger &logger);
 
 } // namespace odr::internal::html

--- a/src/odr/internal/html/filesystem.cpp
+++ b/src/odr/internal/html/filesystem.cpp
@@ -136,7 +136,6 @@ protected:
 namespace odr::internal {
 
 HtmlService html::create_filesystem_service(const Filesystem &filesystem,
-                                            const std::string & /*cache_path*/,
                                             HtmlConfig config,
                                             const Logger &logger) {
   return odr::HtmlService(

--- a/src/odr/internal/html/filesystem.hpp
+++ b/src/odr/internal/html/filesystem.hpp
@@ -13,7 +13,6 @@ class Logger;
 namespace odr::internal::html {
 
 HtmlService create_filesystem_service(const Filesystem &filesystem,
-                                      const std::string &cache_path,
                                       HtmlConfig config, const Logger &logger);
 
 }

--- a/src/odr/internal/html/font_file.cpp
+++ b/src/odr/internal/html/font_file.cpp
@@ -162,7 +162,6 @@ private:
 } // namespace
 
 odr::HtmlService create_font_service(const FontFile &font_file,
-                                     const std::string & /*cache_path*/,
                                      HtmlConfig config, const Logger &logger) {
   return odr::HtmlService(
       std::make_unique<HtmlServiceImpl>(font_file, std::move(config), logger));

--- a/src/odr/internal/html/font_file.hpp
+++ b/src/odr/internal/html/font_file.hpp
@@ -16,8 +16,7 @@ namespace odr::internal::html {
 /// name/metrics header plus a glyph grid showing *every* glyph (including ones
 /// the original `cmap` never reached), the font served via `@font-face` after
 /// the uniform PUA re-encode.
-HtmlService create_font_service(const FontFile &font_file,
-                                const std::string &cache_path,
-                                HtmlConfig config, const Logger &logger);
+HtmlService create_font_service(const FontFile &font_file, HtmlConfig config,
+                                const Logger &logger);
 
 } // namespace odr::internal::html

--- a/src/odr/internal/html/image_file.cpp
+++ b/src/odr/internal/html/image_file.cpp
@@ -154,7 +154,6 @@ void html::translate_image_src(const ImageFile &image_file, std::ostream &out,
 }
 
 HtmlService html::create_image_service(const ImageFile &image_file,
-                                       const std::string & /*cache_path*/,
                                        HtmlConfig config,
                                        const Logger &logger) {
   return odr::HtmlService(

--- a/src/odr/internal/html/image_file.hpp
+++ b/src/odr/internal/html/image_file.hpp
@@ -18,8 +18,7 @@ void translate_image_src(const File &file, std::ostream &out,
 void translate_image_src(const ImageFile &image_file, std::ostream &out,
                          const HtmlConfig &config);
 
-HtmlService create_image_service(const ImageFile &image_file,
-                                 const std::string &cache_path,
-                                 HtmlConfig config, const Logger &logger);
+HtmlService create_image_service(const ImageFile &image_file, HtmlConfig config,
+                                 const Logger &logger);
 
 } // namespace odr::internal::html

--- a/src/odr/internal/html/media_file.cpp
+++ b/src/odr/internal/html/media_file.cpp
@@ -205,10 +205,9 @@ private:
 
 namespace odr::internal {
 
-HtmlService
-html::create_media_service(const DecodedFile &media_file,
-                           [[maybe_unused]] const std::string &cache_path,
-                           HtmlConfig config, const Logger &logger) {
+HtmlService html::create_media_service(const DecodedFile &media_file,
+                                       HtmlConfig config,
+                                       const Logger &logger) {
   return odr::HtmlService(
       std::make_unique<HtmlServiceImpl>(media_file, std::move(config), logger));
 }

--- a/src/odr/internal/html/media_file.hpp
+++ b/src/odr/internal/html/media_file.hpp
@@ -15,7 +15,6 @@ namespace odr::internal::html {
 /// here — nothing is decoded, so the plain @ref DecodedFile carries everything
 /// the page needs: the bytes and the file type they are named by.
 HtmlService create_media_service(const DecodedFile &media_file,
-                                 const std::string &cache_path,
                                  HtmlConfig config, const Logger &logger);
 
 } // namespace odr::internal::html

--- a/src/odr/internal/html/pdf_file.cpp
+++ b/src/odr/internal/html/pdf_file.cpp
@@ -2577,9 +2577,8 @@ protected:
 
 namespace odr::internal {
 
-HtmlService html::create_pdf_service(const PdfFile &pdf_file,
-                                     const std::string & /*cache_path*/,
-                                     HtmlConfig config, const Logger &logger) {
+HtmlService html::create_pdf_service(const PdfFile &pdf_file, HtmlConfig config,
+                                     const Logger &logger) {
   return odr::HtmlService(
       std::make_unique<HtmlServiceImpl>(pdf_file, std::move(config), logger));
 }

--- a/src/odr/internal/html/pdf_file.hpp
+++ b/src/odr/internal/html/pdf_file.hpp
@@ -12,8 +12,7 @@ class Logger;
 
 namespace odr::internal::html {
 
-HtmlService create_pdf_service(const PdfFile &pdf_file,
-                               const std::string &cache_path, HtmlConfig config,
+HtmlService create_pdf_service(const PdfFile &pdf_file, HtmlConfig config,
                                const Logger &logger);
 
 }

--- a/src/odr/internal/html/text_file.cpp
+++ b/src/odr/internal/html/text_file.cpp
@@ -141,10 +141,8 @@ protected:
 
 namespace odr::internal {
 
-HtmlService
-html::create_text_service(const TextFile &text_file,
-                          [[maybe_unused]] const std::string &cache_path,
-                          HtmlConfig config, const Logger &logger) {
+HtmlService html::create_text_service(const TextFile &text_file,
+                                      HtmlConfig config, const Logger &logger) {
   return odr::HtmlService(
       std::make_unique<HtmlServiceImpl>(text_file, std::move(config), logger));
 }

--- a/src/odr/internal/html/text_file.hpp
+++ b/src/odr/internal/html/text_file.hpp
@@ -12,8 +12,7 @@ class Logger;
 
 namespace odr::internal::html {
 
-HtmlService create_text_service(const TextFile &text_file,
-                                const std::string &cache_path,
-                                HtmlConfig config, const Logger &logger);
+HtmlService create_text_service(const TextFile &text_file, HtmlConfig config,
+                                const Logger &logger);
 
 }

--- a/test/src/internal/pdf/pdf_file.cpp
+++ b/test/src/internal/pdf/pdf_file.cpp
@@ -28,7 +28,7 @@ std::shared_ptr<pdf::PdfFile> open_pdf(const std::string &bytes) {
 HtmlService make_service(const std::string &bytes, const HtmlConfig &config) {
   const odr::PdfFile file(open_pdf(bytes));
   const Logger logger = Logger::null();
-  return internal::html::create_pdf_service(file, "", config, logger);
+  return internal::html::create_pdf_service(file, config, logger);
 }
 
 std::string render_path(const HtmlService &service, const std::string &path) {


### PR DESCRIPTION
🤖 Generated with [Claude Code](https://claude.com/claude-code)

Split out of #661 — no wasm in here. Stacked on #662.

`html::translate` has taken a `cache_path` on every overload, documented as "the
directory temporary output goes into". Nothing goes into it. All seven
`create_*_service` factories had already marked the parameter unused — media
included, which was the last plausible candidate — so the only thing the public
wrapper did with it was `create_directories` on a directory nobody subsequently
wrote into.

This adds an overload per `translate` without it, and drops the parameter from
the internal factories rather than only from the public surface. That is the
point: with it gone from the factories, "no renderer writes to disk" stops being
a coincidence and becomes structural. The only `std::filesystem` left in
`html.cpp` is inside `bring_offline`, which writes to disk by definition.

The `cache_path` overloads stay, as forwards, and are deliberately **not**
`[[deprecated]]`: CI builds with `-Werror` and `cli/`, `python/`, `jni/` and
`apple/` all still pass one.

**Behaviour change:** `translate` no longer creates the directory it was handed.
Nothing reads or writes there, and `cli/src/server.cpp` — the only caller that
cares where its cache lives — already creates its own.

Reference output unchanged; full suite green.
