### PR TITLE
test(html): keep page margins in the output tests

### DIFF
--- a/test/data.cmake
+++ b/test/data.cmake
@@ -17,9 +17,9 @@ odr_test_data(
 odr_test_data(
         PATH "reference-output/odr-public"
         URL "https://github.com/opendocument-app/OpenDocument.test.output.git"
-        REVISION "5d817e661fd9b83aeadf9f9f1b829b658a10303b")
+        REVISION "e8413d37cfcd943f88bc05b325ee3bb91912212d")
 
 odr_test_data(
         PATH "reference-output/odr-private"
         URL "https://github.com/opendocument-app/OpenDocument.test-private.output.git"
-        REVISION "000a6b92c4498797edd0e47a875ff1124ba4eef8")
+        REVISION "bfe777c6e3236b892dc125d61997036224208fbc")

--- a/test/src/html_output_test.cpp
+++ b/test/src/html_output_test.cpp
@@ -168,6 +168,11 @@ TEST_P(HtmlOutputTests, html_meta) {
       Path(output_path_prefix).parent().join(RelPath("resources")).string();
   config.relative_resource_paths = true;
   config.editable = true;
+  // Keep a text document's page margins instead of reflowing it to the
+  // viewport. The Android viewer turns this on by default, so leaving it off
+  // here left the reference output showing a rendering path most readers never
+  // see — including the page box and the backdrop it brings with it.
+  config.text_document_margin = true;
   config.spreadsheet_limit = TableDimensions(4000, 500);
   config.page_range_end = 100;
   config.format_html = true;


### PR DESCRIPTION
`html_output_test.cpp` left `text_document_margin` at its default, so every text document in the reference output was rendered reflowed to the viewport.

The Android viewer defaults the setting to **on** ([`PaginationSetting.DEFAULT_ENABLED`](https://github.com/opendocument-app/OpenDocument.droid/blob/master/app/src/main/java/app/opendocument/droid/background/PaginationSetting.kt) — *"On unless the user says otherwise: the margins are the document as it was written."*). So the output the tests have been showing is the one most readers never see, and the paged path was covered by nothing at all.

## What changes

Only text documents move — presentations and drawings are paged either way, and spreadsheets ignore the setting. For those 48 files the output gains:

- `<body class="odr-body odr-background">` and the `.odr-pages` / `.odr-page-outer` / `.odr-page-inner` boxes, carrying the document's real page size and margins
- a fit-width viewport instead of `initial-scale=1.0`, since `is_paged_content` now holds for text

```diff
-<body class="odr-body">
-  <div>
-    <x-p style="display:block;margin-top:0in;…">
+<body class="odr-body odr-background">
+  <div class="odr-pages">
+    <div class="odr-page-outer" style="width:8.2673in;min-height:11.6925in;">
+      <div class="odr-page-inner" style="margin-right:0.7874in;margin-top:0.7874in;…">
+        <x-p style="display:block;margin-top:0in;…">
```

Worth being precise about the name: the flag is the page *margins*, not pagination. The document stays one continuous sheet — it does not break into pages.

## Test plan

- [x] `odr_test --gtest_filter='*HtmlOutput*'` — 234 passed, 9 skipped (the pre-existing skips), 0 failed
- [ ] **Reference output needs regenerating** before this merges — 48 html files under `odt/`, `docx/`, `doc/`, … change

🤖 Generated with [Claude Code](https://claude.com/claude-code)