### PR TITLE
test(html): render csv and zip in the output tests

### DIFF
--- a/test/data.cmake
+++ b/test/data.cmake
@@ -7,7 +7,7 @@
 odr_test_data(
         PATH "input/odr-public"
         URL "https://github.com/opendocument-app/OpenDocument.test.git"
-        REVISION "42694a9ab07659ac1f9b937670385b6bc287455b")
+        REVISION "d7c093dffc987e8e5cf093ea7412371ce9d7363d")
 
 odr_test_data(
         PATH "input/odr-private"
@@ -17,7 +17,7 @@ odr_test_data(
 odr_test_data(
         PATH "reference-output/odr-public"
         URL "https://github.com/opendocument-app/OpenDocument.test.output.git"
-        REVISION "2da5f0a3a246a0e0bc79fcee4c2f52afbc189fc4")
+        REVISION "e9aa12feb1601896f38ecbd04d7d84c31d805d26")
 
 odr_test_data(
         PATH "reference-output/odr-private"

--- a/test/src/html_output_test.cpp
+++ b/test/src/html_output_test.cpp
@@ -112,10 +112,8 @@ TEST_P(HtmlOutputTests, html_meta) {
     EXPECT_EQ(test_file.type, file.file_type());
   }
 
-  // TODO enable zip, csv, json
-  if (test_file.type == FileType::zip ||
-      test_file.type == FileType::comma_separated_values ||
-      test_file.type == FileType::javascript_object_notation) {
+  // TODO enable json
+  if (test_file.type == FileType::javascript_object_notation) {
     GTEST_SKIP();
   }
 


### PR DESCRIPTION
🤖 Generated with [Claude Code](https://claude.com/claude-code)

Fifth of the csv stack. **Based on #669** — the value types change what a cell renders as, so the reference output has to be generated with them in.

Both csv and zip sat behind a `TODO enable` in `html_output_test.cpp`, and for different reasons.

## Csv

Skipped because it rendered as a line list, which was not worth pinning. It renders as a table since #668, so the skip has outlived its reason. The reference output gains `document.html` and `sheet0.html` — the one-sheet spreadsheet the generic renderer walks, capped at the suite's 4000 rows.

Until now the only thing pinned for a csv was `meta.json`, which is written before the skip. That is also why the `documentType` line reverted in #668 needed an output-repo commit of its own; it is folded into the same one here.

## Zip

Skipped because there was nothing to render. `get_test_files` walks the input directory and maps by extension, and the public input set had no archive at all — so the skip was dead code.

`zip/small.zip` is new input and deliberately tiny: **271 bytes**, two text files.

```
  Length      Date    Time    Name
---------  ---------- -----   ----
       14  01-01-2026 00:00   hello.txt
       33  01-01-2026 00:00   nested/note.txt
```

The reason for the size is `html/filesystem.cpp`: an archive renders as a file listing and every entry becomes a `data:application/octet-stream;base64,…` download link (`html/common.cpp:96`). A real-world archive would carry its whole content into the reference output, base64-inflated. At this size the whole listing is 854 bytes and reads in a diff:

```html
<a href="data:application/octet-stream;base64,SGVsbG8sIHdvcmxkIQo=" download="hello.txt">
```

Json stays skipped — no renderer of its own yet.

## Data repositories

Both pins move, and both commits are on `main` of their repo:

- input `OpenDocument.test` → `d7c093d` *a small zip to render*
- reference output `OpenDocument.test.output` → `e9aa12f` *zip: render the file listing*, on top of `33300e7` *csv: render as a table*

## Verification

Full suite, 815 passed / 8 skipped. `diff -rq` of the generated tree against the reference is empty for both repos — the only files that moved are the three the two new renders produce.
