### PR TITLE
feat(html): let a page set its own body margin and background

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,6 +22,8 @@ The release run heads these entries with the version and opens a fresh
   that are not one no longer open as an image that cannot be shown.
 - A text file reads in a quieter gutter: the line numbers line up with their
   lines, stay out of a copy of the page, and the hovered line is marked.
+- Every page states its own body margin and background instead of inheriting the
+  browser's, so no view opens inset by an eight-pixel border.
 
 ## v6.4.0 - 2026-08-09
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,8 @@ The release run heads these entries with the version and opens a fresh
   rather than as one very long line, in the encoding its declaration names.
 - An svg is recognised by reading it rather than by what it is called, so bytes
   that are not one no longer open as an image that cannot be shown.
+- A text file reads in a quieter gutter: the line numbers line up with their
+  lines, stay out of a copy of the page, and the hovered line is marked.
 
 ## v6.4.0 - 2026-08-09
 

--- a/src/odr/internal/html/font_file.cpp
+++ b/src/odr/internal/html/font_file.cpp
@@ -110,7 +110,9 @@ public:
     out.out() << "<style>";
     out.out() << "@font-face{font-family:'odr-specimen';src:url(" << url
               << ");}";
-    out.out() << "body{font-family:sans-serif;}";
+    // The page's own margin, so it does not depend on the browser's.
+    out.out() << "body{margin:0;padding:8px;background:#fff;"
+                 "font-family:sans-serif;}";
     out.out() << ".grid{display:flex;flex-wrap:wrap;}";
     out.out() << ".cell{width:4em;height:4em;border:1px solid #ddd;margin:2px;"
                  "display:flex;flex-direction:column;align-items:center;"

--- a/src/odr/internal/html/frontend.cpp
+++ b/src/odr/internal/html/frontend.cpp
@@ -80,11 +80,30 @@ td x-p{height:inherit}
 .odr-sheet-sort-asc::after{content:"\25B4"}
 )css";
 
+/// A whole-pixel line height, because the line numbers are a second column
+/// whose cells are sized to the lines by script - a fractional line would round
+/// per cell and the two columns would drift apart.
 constexpr std::string_view text_css = R"css(
-.odr-text{display:flex;flex-direction:row;font-family:monospace}
-.odr-text-nr{display:flex;flex-direction:column;text-align:right;vertical-align:top;color:#999;border-right:solid #999}
-.odr-text-body{display:flex;flex-direction:column;padding-left:5pt;white-space:pre}
+:root{
+--odr-text-fg:#1f2328;
+--odr-text-muted:#8c959f;
+--odr-text-line:#d8dee4;
+--odr-text-gutter:#f6f8fa;
+--odr-text-wash:rgba(0,0,0,.04);
+--odr-text-mono:ui-monospace,SFMono-Regular,Menlo,Consolas,monospace;
+}
+body{margin:0;background:#fff}
+.odr-text{display:flex;align-items:stretch;min-height:100vh;color:var(--odr-text-fg);font:13px/20px var(--odr-text-mono);tab-size:4}
+/* The numbers are ours, not the file's, so the gutter stays out of a selection
+   of the page. */
+.odr-text-nr{display:flex;flex-direction:column;flex:none;padding:16px 12px 16px 16px;text-align:right;color:var(--odr-text-muted);background:var(--odr-text-gutter);border-right:1px solid var(--odr-text-line);font-variant-numeric:tabular-nums;user-select:none;-webkit-user-select:none}
+.odr-text-body{display:flex;flex-direction:column;flex:1;min-width:0;padding:16px;white-space:pre}
 .odr-text-wrap{white-space:break-spaces;word-break:break-word;overflow-wrap:anywhere}
+/* A hovered line reaches its number, which is in the other column, by beginning
+   a viewport to the left of it; the padding puts the text back where it was.
+   Overflow to the left of the page does not scroll. */
+.odr-text-body>div{margin-left:-100vw;padding-left:100vw}
+.odr-text-body>div:hover{background:var(--odr-text-wash)}
 [contenteditable]:focus{outline:none}
 )css";
 
@@ -641,11 +660,14 @@ constexpr std::string_view text_js = R"js(
     });
   }
 
+  // The measured height is fractional; `offsetHeight` would round it per line
+  // and the numbers would walk away from the lines they belong to.
   TextEditor.prototype.updateLineNumberHeight = function () {
     var nrCells = this.textNr.querySelectorAll("div");
     var textCells = this.textBody.querySelectorAll("div");
     for (var i = 0; i < textCells.length && i < nrCells.length; ++i) {
-      nrCells[i].style.height = textCells[i].offsetHeight + "px";
+      nrCells[i].style.height =
+        textCells[i].getBoundingClientRect().height + "px";
     }
   };
 

--- a/src/odr/internal/html/frontend.cpp
+++ b/src/odr/internal/html/frontend.cpp
@@ -16,8 +16,11 @@ namespace odr::internal::html {
 
 namespace {
 
+/// Every page we write states its own body margin and background, rather than
+/// reading whatever the browser's default sheet says.
 constexpr std::string_view document_css = R"css(
 *{margin:0;position:relative}
+body{margin:0;background:#fff}
 x-p{display:block;font-size:0}
 x-s{display:inline}
 .odr-background{padding:0;background:#525659}
@@ -51,7 +54,7 @@ constexpr std::string_view spreadsheet_css = R"css(
 --odr-sheet-font:-apple-system,BlinkMacSystemFont,"Segoe UI",Roboto,"Helvetica Neue",Arial,sans-serif;
 }
 /* A sheet is not a page: past the last row and column is canvas. */
-body{background:var(--odr-sheet-canvas)}
+body{margin:0;background:var(--odr-sheet-canvas)}
 .odr-sheet{background:#fff}
 table{border-collapse:collapse;table-layout:fixed}
 td{vertical-align:bottom;height:inherit;padding:1px 6px}
@@ -120,8 +123,8 @@ constexpr std::string_view xml_css = R"css(
 --odr-xml-meta:#8250df;
 --odr-xml-mono:ui-monospace,SFMono-Regular,Menlo,Consolas,monospace;
 }
-body{background:#fff}
-.odr-xml{color:var(--odr-xml-text);font:13px/1.6 var(--odr-xml-mono);word-break:break-word;overflow-wrap:anywhere}
+body{margin:0;background:#fff}
+.odr-xml{padding:16px;color:var(--odr-xml-text);font:13px/1.6 var(--odr-xml-mono);word-break:break-word;overflow-wrap:anywhere}
 .odr-xml-line,.odr-xml summary{padding-left:1.5em}
 .odr-xml summary{display:block;position:relative;list-style:none;cursor:pointer}
 .odr-xml summary::-webkit-details-marker{display:none}
@@ -150,7 +153,7 @@ constexpr std::string_view filesystem_css = R"css(
 --odr-files-font:-apple-system,BlinkMacSystemFont,"Segoe UI",Roboto,"Helvetica Neue",Arial,sans-serif;
 --odr-files-mono:ui-monospace,SFMono-Regular,Menlo,Consolas,monospace;
 }
-body{background:#fff;color:#1f2328;font:13px/1.5 var(--odr-files-font)}
+body{margin:0;background:#fff;color:#1f2328;font:13px/1.5 var(--odr-files-font)}
 .odr-files{border-collapse:collapse;width:100%}
 .odr-files td{padding:5px 12px;border-top:1px solid var(--odr-files-line)}
 .odr-files tbody tr:hover>*{background-image:linear-gradient(rgba(0,0,0,.04),rgba(0,0,0,.04))}
@@ -165,7 +168,8 @@ body{background:#fff;color:#1f2328;font:13px/1.5 var(--odr-files-font)}
 )css";
 
 constexpr std::string_view media_css = R"css(
-.odr-media{display:flex;align-items:center;justify-content:center;margin:0;min-height:100vh;background:#000}
+body{margin:0;background:#000}
+.odr-media{display:flex;align-items:center;justify-content:center;min-height:100vh}
 .odr-media video{max-width:100%;max-height:100vh}
 .odr-media audio{width:100%;max-width:40rem;margin:0 1rem}
 )css";

--- a/src/odr/internal/html/image_file.cpp
+++ b/src/odr/internal/html/image_file.cpp
@@ -104,6 +104,9 @@ public:
     out.write_header_target("_blank");
     out.write_header_title("odr");
     write_viewport_meta(out, config(), true);
+    out.write_header_style_begin();
+    out.out() << "body{margin:0;background:#fff}";
+    out.write_header_style_end();
     out.write_header_end();
 
     out.write_body_begin();

--- a/test/data.cmake
+++ b/test/data.cmake
@@ -22,4 +22,4 @@ odr_test_data(
 odr_test_data(
         PATH "reference-output/odr-private"
         URL "https://github.com/opendocument-app/OpenDocument.test-private.output.git"
-        REVISION "8f7383f64c795602793a8c20a9c76bea197ad9c1")
+        REVISION "d1fdace052b45f7744f24a7c6bb84a82332d37bb")


### PR DESCRIPTION
🤖 Generated with [Claude Code](https://claude.com/claude-code)

Stacked on #682 — review that one first.

Follow-up to the text view: every view except the pdf one was reading the
browser's default sheet for the body box, so a file listing, a source view or an
image opened inset by an eight-pixel white border that is not ours.

Each stylesheet now states `body{margin:0;background:…}` itself, spelled out even
in `document.css`, where the `*{margin:0}` reset already covered it — the rule
should be legible where you look for it. `image.html` and `font.html` shipped no
body rule at all and now get one.

Two pages take the space back deliberately rather than losing it:

- the xml source view pads its own container by 16px, so folding a tree does not
  start against the window edge;
- the font specimen keeps its eight pixels, as padding it owns.

Backdrops that were a choice stay as they were: pdf and video on their dark
grounds, a sheet on its canvas, a paginated document on its grey.

`test/data.cmake` advances the private reference-output pin: the twelve font
specimen pages carry the new body rule. `otf`/`ttf` are the only outputs that
changed — the full suite is otherwise byte-identical on both repos.

Checked in Chrome: text, xml, file listing, image, sheet, paginated odt.