### PR TITLE
fix(html): put a frame where its style says, and keep its image inside

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,11 @@ The release run heads these entries with the version and opens a fresh
 
 ## Unreleased
 
+- An image stays inside its frame on a page read without the shipped stylesheet,
+  rather than covering the whole page.
+- A frame that names a side instead of an offset sits on that side, so a centred
+  image in an odt is centred.
+
 ## v6.5.0 - 2026-08-10
 
 - An xml file opens as xml and reads as a foldable, highlighted source view

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,7 +19,8 @@ The release run heads these entries with the version and opens a fresh
 - An image stays inside its frame on a page read without the shipped stylesheet,
   rather than covering the whole page.
 - A frame that names a side instead of an offset sits on that side, so a centred
-  image in an odt is centred.
+  image in an odt is centred. The side it names is `GraphicStyle`'s new
+  `horizontal_position`, carried by the python, java and objc bindings.
 
 ## v6.5.0 - 2026-08-10
 

--- a/apple/include/OdrCoreObjC/ODRStyle.h
+++ b/apple/include/OdrCoreObjC/ODRStyle.h
@@ -208,6 +208,8 @@ NS_SWIFT_NAME(GraphicStyle)
 @property(nonatomic, readonly, nullable) NSNumber *verticalAlign;
 /// `ODRTextWrap`, boxed.
 @property(nonatomic, readonly, nullable) NSNumber *textWrap;
+/// `ODRHorizontalAlign`, boxed.
+@property(nonatomic, readonly, nullable) NSNumber *horizontalPosition;
 
 - (instancetype)init NS_UNAVAILABLE;
 + (instancetype)new NS_UNAVAILABLE;

--- a/apple/src/ODRStyle.mm
+++ b/apple/src/ODRStyle.mm
@@ -232,6 +232,7 @@ NSString *_Nullable box_string(const std::optional<T> &value) {
   result->_fillColor = box(handle.fill_color);
   result->_verticalAlign = box_enum(handle.vertical_align);
   result->_textWrap = box_enum(handle.text_wrap);
+  result->_horizontalPosition = box_enum(handle.horizontal_position);
   return result;
 }
 

--- a/apple/swift/Style+Optionals.swift
+++ b/apple/swift/Style+Optionals.swift
@@ -54,6 +54,9 @@ extension GraphicStyle {
   public var fill: Color? { fillColor?.asColor }
   public var vertical: VerticalAlign? { verticalAlign?.asEnum(VerticalAlign.self) }
   public var wrap: TextWrap? { textWrap?.asEnum(TextWrap.self) }
+  public var horizontal: HorizontalAlign? {
+    horizontalPosition?.asEnum(HorizontalAlign.self)
+  }
 }
 
 extension PageLayout {

--- a/jni/java/app/opendocument/core/GraphicStyle.java
+++ b/jni/java/app/opendocument/core/GraphicStyle.java
@@ -7,13 +7,20 @@ public final class GraphicStyle {
   public final Color fillColor;
   public final VerticalAlign verticalAlign;
   public final TextWrap textWrap;
+  public final HorizontalAlign horizontalPosition;
 
   GraphicStyle(
-      Measure strokeWidth, Color strokeColor, Color fillColor, int verticalAlign, int textWrap) {
+      Measure strokeWidth,
+      Color strokeColor,
+      Color fillColor,
+      int verticalAlign,
+      int textWrap,
+      int horizontalPosition) {
     this.strokeWidth = strokeWidth;
     this.strokeColor = strokeColor;
     this.fillColor = fillColor;
     this.verticalAlign = VerticalAlign.fromNative(verticalAlign);
     this.textWrap = TextWrap.fromNative(textWrap);
+    this.horizontalPosition = HorizontalAlign.fromNative(horizontalPosition);
   }
 }

--- a/jni/src/jni_style.cpp
+++ b/jni/src/jni_style.cpp
@@ -245,10 +245,11 @@ jobject make_graphic_style(JNIEnv *env, const odr::GraphicStyle &style) {
   return new_object(
       env, "app/opendocument/core/GraphicStyle",
       "(Lapp/opendocument/core/Measure;Lapp/opendocument/core/Color;"
-      "Lapp/opendocument/core/Color;II)V",
+      "Lapp/opendocument/core/Color;III)V",
       make_measure(env, style.stroke_width),
       make_color(env, style.stroke_color), make_color(env, style.fill_color),
-      enum_code(style.vertical_align), enum_code(style.text_wrap));
+      enum_code(style.vertical_align), enum_code(style.text_wrap),
+      enum_code(style.horizontal_position));
 }
 
 jobject make_page_layout(JNIEnv *env, const odr::PageLayout &layout) {

--- a/python/src/bind_style.cpp
+++ b/python/src/bind_style.cpp
@@ -175,7 +175,9 @@ void odr_python::bind_style(py::module_ &m) {
       .def_readwrite("stroke_color", &odr::GraphicStyle::stroke_color)
       .def_readwrite("fill_color", &odr::GraphicStyle::fill_color)
       .def_readwrite("vertical_align", &odr::GraphicStyle::vertical_align)
-      .def_readwrite("text_wrap", &odr::GraphicStyle::text_wrap);
+      .def_readwrite("text_wrap", &odr::GraphicStyle::text_wrap)
+      .def_readwrite("horizontal_position",
+                     &odr::GraphicStyle::horizontal_position);
 
   py::class_<odr::PageLayout>(m, "PageLayout")
       .def(py::init<>())

--- a/src/odr/internal/html/document_style.cpp
+++ b/src/odr/internal/html/document_style.cpp
@@ -402,8 +402,10 @@ std::string html::translate_frame_properties(const Frame &frame) {
   }
 
   // a side, but only where no offset already places the frame
-  const std::optional<HorizontalAlign> horizontal_position =
-      frame.x().has_value() ? std::nullopt : style.horizontal_position;
+  auto horizontal_position = HorizontalAlign::left;
+  if (!frame.x().has_value() && style.horizontal_position.has_value()) {
+    horizontal_position = *style.horizontal_position;
+  }
 
   // The frame says it positions itself: read without the stylesheet's
   // `*{position:relative}`, its image would fill the viewport instead.

--- a/src/odr/internal/html/document_style.cpp
+++ b/src/odr/internal/html/document_style.cpp
@@ -394,16 +394,26 @@ std::string html::translate_drawing_style(const GraphicStyle &graphic_style) {
 }
 
 std::string html::translate_frame_properties(const Frame &frame) {
+  const GraphicStyle style = frame.style();
+
   auto text_wrap = TextWrap::run_through;
-  if (const GraphicStyle style = frame.style(); style.text_wrap.has_value()) {
+  if (style.text_wrap.has_value()) {
     text_wrap = *style.text_wrap;
   }
 
+  // a side, but only where no offset already places the frame
+  const std::optional<HorizontalAlign> horizontal_position =
+      frame.x().has_value() ? std::nullopt : style.horizontal_position;
+
+  // The frame says it positions itself: read without the stylesheet's
+  // `*{position:relative}`, its image would fill the viewport instead.
   std::string result;
   if (const AnchorType anchor_type = frame.anchor_type();
       anchor_type == AnchorType::as_char) {
+    result += "position:relative;";
     result += "display:inline-block;";
   } else if (text_wrap == TextWrap::before) {
+    result += "position:relative;";
     result += "display:block;";
     result += "float:right;clear:both;";
     result += "shape-outside:content-box;";
@@ -413,12 +423,15 @@ std::string html::translate_frame_properties(const Frame &frame) {
     if (const std::optional<Measure> y = frame.y(); y.has_value()) {
       result += "margin-top:" + y->to_string() + ";";
     }
-    result += "margin-right:calc(100% - ";
-    result += frame.x().value_or(Measure(0, DynamicUnit("in"))).to_string();
-    result += " - ";
-    result += frame.width()->to_string();
-    result += ");";
+    if (const std::optional<Measure> width = frame.width(); width.has_value()) {
+      result += "margin-right:calc(100% - ";
+      result += frame.x().value_or(Measure(0, DynamicUnit("in"))).to_string();
+      result += " - ";
+      result += width->to_string();
+      result += ");";
+    }
   } else if (text_wrap == TextWrap::after) {
+    result += "position:relative;";
     result += "display:block;";
     result += "float:left;clear:both;";
     result += "shape-outside:content-box;";
@@ -429,9 +442,15 @@ std::string html::translate_frame_properties(const Frame &frame) {
       result += "margin-top:" + y->to_string() + ";";
     }
   } else if (text_wrap == TextWrap::none) {
+    result += "position:relative;";
     result += "display:block;";
     if (const std::optional<Measure> x = frame.x(); x.has_value()) {
       result += "margin-left:" + x->to_string() + ";";
+    }
+    if (horizontal_position == HorizontalAlign::center) {
+      result += "margin-left:auto;margin-right:auto;";
+    } else if (horizontal_position == HorizontalAlign::right) {
+      result += "margin-left:auto;";
     }
     if (const std::optional<Measure> y = frame.y(); y.has_value()) {
       result += "margin-top:" + y->to_string() + ";";
@@ -441,6 +460,11 @@ std::string html::translate_frame_properties(const Frame &frame) {
     result += "position:absolute;";
     if (const std::optional<Measure> x = frame.x(); x.has_value()) {
       result += "left:" + x->to_string() + ";";
+    }
+    if (horizontal_position == HorizontalAlign::center) {
+      result += "left:0;right:0;margin-left:auto;margin-right:auto;";
+    } else if (horizontal_position == HorizontalAlign::right) {
+      result += "right:0;";
     }
     if (const std::optional<Measure> y = frame.y(); y.has_value()) {
       result += "top:" + y->to_string() + ";";

--- a/src/odr/internal/odf/odf_style.cpp
+++ b/src/odr/internal/odf/odf_style.cpp
@@ -529,10 +529,11 @@ void Style::resolve_graphic_style_(const pugi::xml_node node,
           read_text_wrap(graphic_properties.attribute("style:wrap"))) {
     result.text_wrap = text_wrap;
   }
-  if (const std::optional<HorizontalAlign> horizontal_position =
-          read_horizontal_position(
-              graphic_properties.attribute("style:horizontal-pos"))) {
-    result.horizontal_position = horizontal_position;
+  // assigned even when it reads as none, so a `from-*` overrides an inherited
+  // side rather than keeping it
+  if (const pugi::xml_attribute attribute =
+          graphic_properties.attribute("style:horizontal-pos")) {
+    result.horizontal_position = read_horizontal_position(attribute);
   }
 }
 

--- a/src/odr/internal/odf/odf_style.cpp
+++ b/src/odr/internal/odf/odf_style.cpp
@@ -147,6 +147,25 @@ std::optional<TextWrap> read_text_wrap(const pugi::xml_attribute attribute) {
   return {};
 }
 
+/// `from-*` names no side - the offset places those frames.
+std::optional<HorizontalAlign>
+read_horizontal_position(const pugi::xml_attribute attribute) {
+  if (!attribute) {
+    return {};
+  }
+  const char *value = attribute.value();
+  if (std::strcmp("left", value) == 0 || std::strcmp("inside", value) == 0) {
+    return HorizontalAlign::left;
+  }
+  if (std::strcmp("center", value) == 0) {
+    return HorizontalAlign::center;
+  }
+  if (std::strcmp("right", value) == 0 || std::strcmp("outside", value) == 0) {
+    return HorizontalAlign::right;
+  }
+  return {};
+}
+
 std::optional<PrintOrientation>
 read_print_orientation(const pugi::xml_attribute attribute) {
   if (!attribute) {
@@ -509,6 +528,11 @@ void Style::resolve_graphic_style_(const pugi::xml_node node,
   if (const std::optional<TextWrap> text_wrap =
           read_text_wrap(graphic_properties.attribute("style:wrap"))) {
     result.text_wrap = text_wrap;
+  }
+  if (const std::optional<HorizontalAlign> horizontal_position =
+          read_horizontal_position(
+              graphic_properties.attribute("style:horizontal-pos"))) {
+    result.horizontal_position = horizontal_position;
   }
 }
 

--- a/src/odr/style.cpp
+++ b/src/odr/style.cpp
@@ -95,6 +95,7 @@ void GraphicStyle::override(const GraphicStyle &other) {
   override_if_set(fill_color, other.fill_color);
   override_if_set(vertical_align, other.vertical_align);
   override_if_set(text_wrap, other.text_wrap);
+  override_if_set(horizontal_position, other.horizontal_position);
 }
 
 } // namespace odr

--- a/src/odr/style.hpp
+++ b/src/odr/style.hpp
@@ -201,6 +201,8 @@ struct GraphicStyle final {
   std::optional<Color> fill_color;
   std::optional<VerticalAlign> vertical_align;
   std::optional<TextWrap> text_wrap;
+  /// The side a frame sits on; unset where its offset decides instead.
+  std::optional<HorizontalAlign> horizontal_position;
 
   void override(const GraphicStyle &other);
 };

--- a/test/data.cmake
+++ b/test/data.cmake
@@ -17,9 +17,9 @@ odr_test_data(
 odr_test_data(
         PATH "reference-output/odr-public"
         URL "https://github.com/opendocument-app/OpenDocument.test.output.git"
-        REVISION "40c457831835a8e9437bfe6494cb96b4c6159fab")
+        REVISION "26c71049d2cbdc32ca3ea982fb814bddbc90c5fe")
 
 odr_test_data(
         PATH "reference-output/odr-private"
         URL "https://github.com/opendocument-app/OpenDocument.test-private.output.git"
-        REVISION "d1fdace052b45f7744f24a7c6bb84a82332d37bb")
+        REVISION "372fb6ed9733047835ff17d6056518e6482eea3c")


### PR DESCRIPTION
`about.odt` rendered as a full-page cow: the image covered the whole page instead of sitting in the text.

## What was wrong

A frame's `<img>` is written as `position:absolute;left:0;top:0;width:100%;height:100%`, but nothing in the frame's own markup made it a containing block — that came only from `*{position:relative}` in the shipped `document.css`. Read without that sheet (externalized resources, page moved away from its `resources/` dir), the image resolved against the initial containing block: top left of the page, full viewport size. Every image in the document landed there, stacked.

Separately, ODF places a frame either by an offset (`svg:x`) or by naming a side (`style:horizontal-pos`). Only the offset was read, so a centred image — the letterhead logo in `style-various-2.odt` — sat hard left where LibreOffice centres it.

## What changed

- A frame states `position:relative` itself, so it is a containing block regardless of the stylesheet.
- `style:horizontal-pos` is read into a new `GraphicStyle::horizontal_position` and applied as auto margins (block frames) or `left:0;right:0` (absolute frames), only where no `svg:x` already places the frame.
- Drive-by in the same function: `frame.width()->to_string()` was an unchecked optional dereference in the wrap-`before` branch while the block below it guards the same optional.

## Verification

`about.odt` measured as img rect vs. its frame rect, in all four combinations of `text_document_margin` and stylesheet:

| | before | after |
|---|---|---|
| margin on, no stylesheet | img `0,0 1200x900`, frame at `495,977` | img `495,977 171x171` = frame |
| margin off, no stylesheet | img `0,0 1200x900`, frame at `419,766` | img `419,766 171x171` = frame |
| margin on, with stylesheet | `690,993` | `690,993` — unchanged |
| margin off, with stylesheet | `411,758` | `411,758` — unchanged |

Where the stylesheet loads, geometry is untouched. Full suite green (861 tests); of all regenerated output, 41 files differ and every one is accounted for by the added `position:relative` and the auto margins — no other rendering moved. Reference output regenerated and the pins advanced.

Not addressed here: WMF/EMF images are still inlined as `data:image/wmf`, which no browser decodes, so they render as a broken-image icon (`style-various-2.odt`, `journal_Word_template.docx`, `15-MB-docx-file-download.docx`, `sample.xlsx`). That needs a metafile decoder, like SVM already has.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01QJ7vyWPCg1oaGoQ1dirNYT