### PR TITLE
refactor(html): name the boxes a frame anchors against, not every element

### DIFF
--- a/src/odr/internal/html/document_style.cpp
+++ b/src/odr/internal/html/document_style.cpp
@@ -407,8 +407,7 @@ std::string html::translate_frame_properties(const Frame &frame) {
     horizontal_position = *style.horizontal_position;
   }
 
-  // The frame says it positions itself: read without the stylesheet's
-  // `*{position:relative}`, its image would fill the viewport instead.
+  // The frame is what its image sizes against.
   std::string result;
   if (const AnchorType anchor_type = frame.anchor_type();
       anchor_type == AnchorType::as_char) {

--- a/src/odr/internal/html/frontend.cpp
+++ b/src/odr/internal/html/frontend.cpp
@@ -19,8 +19,10 @@ namespace {
 /// Every page we write states its own body margin and background, rather than
 /// reading whatever the browser's default sheet says.
 constexpr std::string_view document_css = R"css(
-*{margin:0;position:relative}
 body{margin:0;background:#fff}
+/* What the formats anchor against: a page for shapes, a paragraph or a cell
+   for frames. */
+x-p,td,.odr-page-outer{position:relative}
 x-p{display:block;font-size:0}
 x-s{display:inline}
 .odr-background{padding:0;background:#525659}
@@ -75,7 +77,7 @@ td x-p{height:inherit}
 .odr-sheet tbody tr.odr-sheet-pinned>*{background-image:linear-gradient(var(--odr-sheet-wash-pinned),var(--odr-sheet-wash-pinned))}
 .odr-sheet tbody tr:hover>th,.odr-sheet tbody tr.odr-sheet-pinned>th{background-image:linear-gradient(var(--odr-sheet-wash-ruler),var(--odr-sheet-wash-ruler))}
 .odr-sheet .odr-sheet-pinned-cell{outline:2px solid var(--odr-sheet-focus);outline-offset:-2px}
-/* `*{position:relative}` already makes the header a containing block. */
+/* The header's `position:sticky` already makes it a containing block. */
 .odr-sheet-sort{position:absolute;top:1px;right:1px;bottom:1px;width:17px;display:flex;align-items:center;justify-content:center;border-radius:2px;opacity:0;cursor:pointer}
 .odr-sheet-column-header:hover .odr-sheet-sort,.odr-sheet-sort-asc,.odr-sheet-sort-desc{opacity:1}
 .odr-sheet-sort:hover{background:var(--odr-sheet-wash-ruler)}


### PR DESCRIPTION
Follow-up to #684, now rebased on main.

`*{position:relative}` in the shipped stylesheet made **every** element a containing block, so every absolutely positioned frame and shape resolved against its direct parent by accident rather than against the box the file actually anchors it to.

Auditing all 1144 reference-output pages for absolutely positioned elements with no positioned ancestor in their own markup, exactly three boxes were doing that work:

| container | elements relying on it | formats |
|---|---|---|
| `.odr-page-outer` | 2022 | odg, odp, ppt, pptx |
| `td` | 184 | ods, xlsx |
| `x-p` | 26 | odt |

Those three state it; the blanket rule goes. Two things it turned out *not* to be holding up: `.odr-sheet-sort`, whose header is already `position:sticky` (the comment claiming otherwise is corrected here), and the PDF frontend, which links no `document.css` and declares `.p{position:relative}` itself.

`*{margin:0}` goes with it. Of the elements this sheet reaches — `div`, `table`/`tr`/`td`/`th`/`col`, `img`, `svg`, `x-p`, `x-s`, `mark`, `span`, `br`/`wbr` — only `body` carries a margin from the browser's own sheet, and `body{margin:0}` on the next line already covers it. (`<p>`/`<h1>` appear only in `font_file.cpp`, which writes its own inline `<style>`.)

Being a containing block is also what a page-anchored frame has to get past to reach its page: `frame_anchor_type` reads all four ODF anchor types, but `translate_frame_properties` only branches on `as_char`, so a page-anchored frame lands against its paragraph. That stays unfixable while every ancestor is an anchor, and becomes fixable now.

## Verification

Rendered both sides of the whole public corpus in Chrome and compared pixels.

**Correction to an earlier claim in this PR.** I first verified with `htmlcmp`, which reported all 332 + 1062 files matching. That result was empty: `compare-html` short-circuits byte-identical files without rendering them, and this PR changes only CSS, so every html file was identical and nothing was ever rendered. CI's compare step has the same blind spot. Both were re-run with a renderer that screenshots each page from either tree regardless.

Of 228 public pages, **226 are pixel-identical**. Two differ:

- `docx/sample1.docx/document.html` — 2943 px
- `docx/sample3.docx/document.html` — 1891 px

Both are one line of text moving **exactly 1 pixel down** (ink centroid dx +0.000, dy +0.999, ink identical to the byte). Layout is unchanged: every element's top and height match to 0.01px. Injecting the two dropped rules back one at a time isolates the cause to `*{position:relative}` alone (`*{margin:0}` has no effect) — a line whose baseline falls on a fractional pixel snaps to a different whole pixel when its spans are positioned boxes. The new result is consistent with every other unpositioned line on the page.

Reproduced across repeated runs with identical bounding boxes, and a control rendering the same tree twice shows the pdf/xls pages are nondeterministic while these two are not.


🤖 Generated with [Claude Code](https://claude.com/claude-code)
