### PR TITLE
refactor(html): aim the sheet's cell styling at the sheet's own cells

### DIFF
--- a/src/odr/internal/html/frontend.cpp
+++ b/src/odr/internal/html/frontend.cpp
@@ -55,11 +55,13 @@ constexpr std::string_view spreadsheet_css = R"css(
 }
 /* A sheet is not a page: past the last row and column is canvas. */
 body{margin:0;background:var(--odr-sheet-canvas)}
-.odr-sheet{background:#fff}
-table{border-collapse:collapse;table-layout:fixed}
-td{vertical-align:bottom;height:inherit;padding:1px 6px}
-x-p{font-family:var(--odr-sheet-font);font-size:10pt}
-td x-p{height:inherit}
+.odr-sheet{background:#fff;border-collapse:collapse;table-layout:fixed}
+/* The sheet's own cells, not a table the document itself drew inside one. */
+.odr-sheet>tbody>tr>td{vertical-align:bottom;height:inherit;padding:1px 6px}
+.odr-sheet>tbody>tr>td>x-p{height:inherit}
+/* Sheet-wide, not cell-only: a shape's text would otherwise fall to the
+   `font-size:0` a page carries. */
+.odr-sheet x-p{font-family:var(--odr-sheet-font);font-size:10pt}
 /* Sticky cells in a collapsed border model do not repaint their borders in
    Chrome or WebKit, so the ruler uses inset shadows. */
 .odr-sheet th{position:sticky;background:var(--odr-sheet-ruler);color:var(--odr-sheet-ruler-text);font:500 12px/1.6 var(--odr-sheet-font);text-align:center;vertical-align:middle;padding:0 4px;white-space:nowrap;user-select:none}


### PR DESCRIPTION
Found while auditing the stylesheets for the same pattern as #685.

Three rules in `spreadsheet_css` named every element of their kind on the page rather than the sheet's own, while every rule around them is `.odr-sheet`-scoped:

```css
table{border-collapse:collapse;table-layout:fixed}
td{vertical-align:bottom;height:inherit;padding:1px 6px}
td x-p{height:inherit}
```

A table the document itself drew inside a cell would have taken the ruler's collapsed borders, fixed layout and cell padding. Now the cell-geometry rules use child combinators from `.odr-sheet`, and the `table` properties merge into the `.odr-sheet` rule that was already there.

The font default deliberately does **not** become cell-only:

```css
.odr-sheet x-p{font-family:var(--odr-sheet-font);font-size:10pt}
```

A sheet holds 98 `td > div > x-p` — text in a shape anchored in a cell. Those spans size the text themselves, and one that names no size falls back to the `x-p{font-size:0}` every page carries (which is there so an empty paragraph is exactly as tall as the empty `<x-s>` written for it in `document_element.cpp:331`). Scoping the font to cells only would have rendered such text at zero. Descendant scoping is enough here anyway: all 713038 `x-p` on a spreadsheet page are inside `.odr-sheet`, none outside.

## Verification

Rendered both sides of the whole public corpus in Chrome and compared pixels: **all 228 pages identical**, apart from `xls/file_example_XLS_5000.xls/sheet0.html`, which shows the *same* 140-pixel difference at the *same* bounding box when the tree is compared against itself — nondeterministic sticky-header rendering, not this change.

**Correction to an earlier claim in this PR.** I first verified with `htmlcmp`, which reported all 332 + 1062 files matching. That result was empty: `compare-html` short-circuits byte-identical files without rendering them, and this PR changes only CSS, so every html file was identical and nothing was ever rendered. CI's compare step has the same blind spot. See #685 for the same correction.

No reference-output update needed. Neither corpus contains a table nested inside a sheet — checked all 1144 pages — so this is preventive: it keeps one styled correctly when it does turn up.


Independent of #685; both touch `frontend.cpp` but different sheets.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
