### PR TITLE
fix(html): give a paragraph its own font, and an empty one a line break

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,13 @@ The release run heads these entries with the version and opens a fresh
 
 ## Unreleased
 
+- A paragraph states its own font, so a run that names none of its own is read
+  at that font instead of at nothing. Slides whose text was there but invisible
+  now show it.
+- An empty paragraph keeps the height its font implies, whether or not the file
+  names a size for it, and copying across one yields a blank line.
+- A sheet's cells read in the font the file names, falling back to the sheet's
+  own only where it names none.
 - An image stays inside its frame on a page read without the shipped stylesheet,
   rather than covering the whole page.
 - A frame that names a side instead of an offset sits on that side, so a centred

--- a/src/odr/internal/html/document_element.cpp
+++ b/src/odr/internal/html/document_element.cpp
@@ -300,6 +300,36 @@ void html::translate_line_break(const Element &element,
   state.out().write_element_end("x-s");
 }
 
+namespace {
+
+/// Whether a reader sees anything. A bookmark marks a place rather than filling
+/// one, and a span or a link is a style around what it holds, so a paragraph
+/// holding only those is still an empty line.
+bool has_content(const ElementRange &children) {
+  for (const Element child : children) {
+    switch (child.type()) {
+    case ElementType::bookmark:
+      break;
+    case ElementType::span:
+    case ElementType::link:
+      if (has_content(child.children())) {
+        return true;
+      }
+      break;
+    case ElementType::text:
+      if (!child.as_text().content().empty()) {
+        return true;
+      }
+      break;
+    default:
+      return true;
+    }
+  }
+  return false;
+}
+
+} // namespace
+
 void html::translate_paragraph(const Element &element,
                                const WritingState &state,
                                const std::string &marker) {
@@ -308,34 +338,29 @@ void html::translate_paragraph(const Element &element,
   state.out().write_element_begin(
       "x-p",
       HtmlElementOptions().set_inline(true).set_style(
-          "display:block;" + translate_paragraph_style(paragraph.style())));
+          "display:block;" + translate_paragraph_style(paragraph.style()) +
+          translate_block_font_style(paragraph.text_style())));
   if (!marker.empty()) {
     state.out().write_element_begin(
         "x-s", HtmlElementOptions()
                    .set_inline(true)
                    .set_class("odr-list-marker")
                    .set_style(translate_text_style(paragraph.text_style())));
-    // The tab separates label from text once copied; `x-p` collapses to
-    // `font-size:0`, so the marker has to carry the item's text style itself.
+    // The tab separates label from text once copied.
     state.out().out() << escape_text(marker) << "&#9;";
     state.out().write_element_end("x-s");
   }
   translate_children(paragraph.children(), state);
-  if (paragraph.first_child()) {
-    // TODO if element is content (e.g. bookmark does not count)
-
-    // TODO example `encrypted-exception-3$aabbcc$.odt` at the very bottom
-    // TODO has a missing line break after "As the result of the project we ..."
-
-    // TODO example `style-missing+image-1.odt` first paragraph has no height
-  } else {
+  if (marker.empty() && !has_content(paragraph.children())) {
+    // A line break, not a break opportunity: only a break is copied, so a blank
+    // line between two paragraphs survives being pasted somewhere else.
     state.out().write_element_begin(
-        "x-s", HtmlElementOptions().set_inline(true).set_style(
-                   translate_text_style(paragraph.text_style())));
-    state.out().write_element_end("x-s");
+        "br", HtmlElementOptions().set_close_type(HtmlCloseType::none));
+  } else {
+    // A paragraph whose content is all out of flow has no line box of its own.
+    state.out().write_element_begin(
+        "wbr", HtmlElementOptions().set_close_type(HtmlCloseType::none));
   }
-  state.out().write_element_begin(
-      "wbr", HtmlElementOptions().set_close_type(HtmlCloseType::none));
   state.out().write_element_end("x-p");
 }
 

--- a/src/odr/internal/html/document_style.cpp
+++ b/src/odr/internal/html/document_style.cpp
@@ -194,6 +194,21 @@ std::string html::translate_text_style(const TextStyle &text_style) {
   return result;
 }
 
+std::string html::translate_block_font_style(const TextStyle &text_style) {
+  std::string result;
+  if (const std::optional<std::string_view> font_name = text_style.font_name;
+      font_name.has_value()) {
+    result.append("font-family:")
+        .append(escape_attribute(std::string(*font_name)))
+        .append(";");
+  }
+  if (const std::optional<Measure> font_size = text_style.font_size;
+      font_size.has_value()) {
+    result.append("font-size:").append(font_size->to_string()).append(";");
+  }
+  return result;
+}
+
 std::string
 html::translate_paragraph_style(const ParagraphStyle &paragraph_style) {
   std::string result;

--- a/src/odr/internal/html/document_style.hpp
+++ b/src/odr/internal/html/document_style.hpp
@@ -38,6 +38,8 @@ std::string translate_outer_page_style(const PageLayout &page_layout);
 std::string translate_outer_flowing_page_style(const PageLayout &page_layout);
 std::string translate_inner_page_style(const PageLayout &page_layout);
 std::string translate_text_style(const TextStyle &text_style);
+/// The part of a text style a block may carry: what paints belongs on the run.
+std::string translate_block_font_style(const TextStyle &text_style);
 std::string translate_paragraph_style(const ParagraphStyle &paragraph_style);
 std::string translate_table_style(const TableStyle &table_style);
 std::string

--- a/src/odr/internal/html/frontend.cpp
+++ b/src/odr/internal/html/frontend.cpp
@@ -23,7 +23,7 @@ body{margin:0;background:#fff}
 /* What the formats anchor against: a page for shapes, a paragraph or a cell
    for frames. */
 x-p,td,.odr-page-outer{position:relative}
-x-p{display:block;font-size:0}
+x-p{display:block}
 x-s{display:inline}
 .odr-background{padding:0;background:#525659}
 /* The page column, sized to the widest page so pages of differing width centre
@@ -61,9 +61,9 @@ body{margin:0;background:var(--odr-sheet-canvas)}
 /* The sheet's own cells, not a table the document itself drew inside one. */
 .odr-sheet>tbody>tr>td{vertical-align:bottom;height:inherit;padding:1px 6px}
 .odr-sheet>tbody>tr>td>x-p{height:inherit}
-/* Sheet-wide, not cell-only: a shape's text would otherwise fall to the
-   `font-size:0` a page carries. */
-.odr-sheet x-p{font-family:var(--odr-sheet-font);font-size:10pt}
+/* The font anything in a cell falls back to, a shape's text included, where the
+   file names none of its own. */
+.odr-sheet>tbody>tr>td x-p{font-family:var(--odr-sheet-font);font-size:10pt}
 /* Sticky cells in a collapsed border model do not repaint their borders in
    Chrome or WebKit, so the ruler uses inset shadows. */
 .odr-sheet th{position:sticky;background:var(--odr-sheet-ruler);color:var(--odr-sheet-ruler-text);font:500 12px/1.6 var(--odr-sheet-font);text-align:center;vertical-align:middle;padding:0 4px;white-space:nowrap;user-select:none}

--- a/test/data.cmake
+++ b/test/data.cmake
@@ -17,9 +17,9 @@ odr_test_data(
 odr_test_data(
         PATH "reference-output/odr-public"
         URL "https://github.com/opendocument-app/OpenDocument.test.output.git"
-        REVISION "26c71049d2cbdc32ca3ea982fb814bddbc90c5fe")
+        REVISION "1964c34c2a6bd84d8178d9586ba59a04f172b7f2")
 
 odr_test_data(
         PATH "reference-output/odr-private"
         URL "https://github.com/opendocument-app/OpenDocument.test-private.output.git"
-        REVISION "372fb6ed9733047835ff17d6056518e6482eea3c")
+        REVISION "5e5f035f8a6e6c86ad5d978887607e8b9167c019")

--- a/test/src/internal/html/document_style_test.cpp
+++ b/test/src/internal/html/document_style_test.cpp
@@ -35,3 +35,24 @@ TEST(html_document_style, outer_flowing_page_style_without_height) {
   EXPECT_EQ(ihtml::translate_outer_flowing_page_style(page_layout),
             "width:21cm;");
 }
+
+TEST(html_document_style, block_font_style_carries_the_font) {
+  TextStyle text_style;
+  text_style.font_name = "Arial";
+  text_style.font_size = Measure("14pt");
+  EXPECT_EQ(ihtml::translate_block_font_style(text_style),
+            "font-family:Arial;font-size:14pt;");
+}
+
+TEST(html_document_style, block_font_style_leaves_what_paints_to_the_run) {
+  TextStyle text_style;
+  text_style.font_size = Measure("14pt");
+  text_style.font_weight = FontWeight::bold;
+  text_style.background_color = Color(0xff, 0xff, 0x00);
+  text_style.font_underline = true;
+  EXPECT_EQ(ihtml::translate_block_font_style(text_style), "font-size:14pt;");
+}
+
+TEST(html_document_style, block_font_style_of_a_style_naming_no_font) {
+  EXPECT_EQ(ihtml::translate_block_font_style(TextStyle()), "");
+}


### PR DESCRIPTION
Stacked on #686. Implements the empty-paragraph rework we measured out, and fixes a live bug it exposed.

## The mechanism it replaces

`x-p` collapsed to `font-size:0` and every empty paragraph carried an empty `<x-s>` to stand in for its height. Removing each piece in turn shows both were load-bearing — a 14pt line is 22px:

| markup | height |
|---|---|
| native one line of 14pt (target) | 22 |
| `<x-p><x-s style="font-size:14pt"></x-s><wbr></x-p>` (before) | 22 |
| …minus the `<wbr>` | 0 |
| …minus the empty `<x-s>` | 0 |

## The bug it caused

`font-size:0` is inherited, so a run naming no size of its own computed to `0px`. Walking every run in the corpus for its effective size, then confirming in the browser: **11 pages of `pptx/2025-09-11.15_35_15.pptx` rendered text that was there but invisible** — the reference output blessed eleven blank slides. Now visible.

## What this does instead

The paragraph states its own font (`translate_block_font_style`), which sizes the line it gives an empty paragraph and is inherited by a run that names none. Only the font travels: a background painted on a block covers 756px of line where the run covers 42px, so anything that paints stays on the run.

An empty paragraph ends in `<br>` rather than `<wbr>`, because only a break is copied:

| | empty paragraph visible | copied text |
|---|---|---|
| before | 22px ✓ | `"Alpha\nBeta"` — blank line lost |
| `<wbr>` | 22px ✓ | `"Alpha\nBeta"` — blank line lost |
| `<br>` | 22px ✓ | `"Alpha\n\nBeta"` ✓ |
| both together | **44px** ✗ | ✓ |

On real documents: `about.odt` goes from 1 to 9 blank lines in a select-all copy (10 empty paragraphs), `15KB.docx` from 0 to 9 (12), with every empty paragraph still visible at unchanged height.

A bookmark does not count as content, which is what `// TODO if element is content (e.g. bookmark does not count)` asked for. Both TODO examples are fixed: `style-missing+image-1.odt`'s first paragraph goes 0 → 18px, and the "missing line break" in `encrypted-exception-3$aabbcc$.odt` was an empty paragraph collapsed to 0, now 16px.

No JS is needed for the `<br>`: typing into an empty paragraph makes Chrome remove it (`<br>` → `X`, still 22px), and deleting a paragraph's text makes Chrome insert one — `<br>` is the filler engines already use for an empty editable line. Verified in Chrome only.

## Verification

Note `compare-html` cannot verify the CSS half of this: it short-circuits byte-identical files without rendering them (see the correction in #685). The pptx fix is exactly such a case — its html is unchanged and only the stylesheet makes the text appear. So both sides were rendered and compared as pixels.

Of 228 public pages, 40 differ. All are the intended change or known noise:

- **pptx (11 pages)** — text that was invisible now renders.
- **odt/docx page heights** (`about.odt` 2408 → 2415, `file-sample_500kB.odt` 3721 → 3952) — empty paragraphs that collapsed to 0 now occupy their line.
- **ods (many)** — a sub-pixel baseline shift: dy −0.78px on the header with ink identical to the byte, dy −0.83px and +0.5% ink on data rows. Cells whose runs name no font now take the file's paragraph font, so the strut metrics change; row heights and glyphs do not. Two sheets change height, both `overflow.ods`-style fixtures whose overlapping text stack is slightly shorter.
- **pdf (4 pages) and 2 xls pages** — nondeterministic: rendering the same tree twice reproduces them at the same bounding boxes.

Reference output regenerated and pinned: [`1964c34`](https://github.com/opendocument-app/OpenDocument.test.output/commit/1964c34c2a6bd84d8178d9586ba59a04f172b7f2) (185 files over two commits) and the private equivalent `5e5f035` (301 files). Pre-existing resource drift from #679/#682/#683 was left alone rather than swept in, so `resources/` moves only in `document.css` and `spreadsheet.css`.

`translate_block_font_style` gets three unit tests next to the existing inline-expectation ones; 864 tests pass.

## Worth a second opinion

The sheet baseline shift is the one judgement call. Emitting `font-size` alone and leaving `font-family` off would keep sheets pixel-identical, but the strut's height depends on font metrics, so the family is part of getting an empty paragraph's height right. Say the word and I'll narrow it.

## Review follow-ups

Both P2 findings from the Codex review are addressed in the amended commit.

- **Emptiness is now read recursively**, through the wrappers a file leaves behind — a bookmark, or a span/link holding nothing or only empty text. 52 output files move from `<wbr>` to `<br>`; `encrypted-exception-3$aabbcc$.odt` goes from 91 to 92 blank lines in a select-all copy with every empty paragraph still visible at unchanged height.
- **The sheet font fallback reaches shape text.** It is a descendant rule now (`.odr-sheet>tbody>tr>td x-p`), with `height:inherit` left child-scoped where it belongs. All 98 shape paragraphs in the corpus name their own font, so no output moved; verified against the emitted stylesheet with a synthetic cell instead — a cell paragraph and a shape paragraph naming no font both resolve to 10pt/13.333px, where the shape one had fallen back to the browser default.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
