### PR TITLE
fix: let a tap reach the text on a paged document

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -25,6 +25,9 @@ The release run heads these entries with the version and opens a fresh
 - A keyword is found across the spans it happens to be written in — a pdf puts
   a word in each — and a space matches whichever kind the page carries. It
   still does not run across a line, a cell or a paragraph.
+- A tap on a paged document reaches its text: a negative `z-index` painted the
+  page behind its container, which took every tap. No caret, and no keyboard on
+  ios.
 
 ## v6.6.0 - 2026-08-14
 

--- a/src/odr/internal/html/frontend.cpp
+++ b/src/odr/internal/html/frontend.cpp
@@ -31,7 +31,10 @@ x-s{display:inline}
    of that width, so fitting the document to a phone screen leaves a gutter
    instead of going edge to edge. */
 .odr-pages{display:flex;flex-direction:column;align-items:center;gap:16px;padding:16px 0;width:max-content;min-width:100%}
-.odr-page-outer{display:flex;margin:0 16px;background:#fff;box-shadow:0 1px 4px rgba(0,0,0,.5);z-index:-1000}
+/* A stacking context, for the shape backgrounds a page holds at `z-index:-1`.
+   Not a negative `z-index`, which is one too but takes the page out of reach of
+   hit testing. */
+.odr-page-outer{display:flex;margin:0 16px;background:#fff;box-shadow:0 1px 4px rgba(0,0,0,.5);isolation:isolate}
 /* The label is text rather than a `::marker`, which no selection would copy.
    It hangs into the item's padding so wrapped lines align under the text. */
 .odr-list-item{padding-left:2em}


### PR DESCRIPTION
🤖 Generated with [Claude Code](https://claude.com/claude-code)

Stacked on #692 — both touch `document.css` and its reference copy. Base it on
main once that merges.

`.odr-page-outer` carried `z-index:-1000`, which paints the page and its whole
subtree behind its parent's in-flow content. It still looks right, because the
backdrop is the propagated canvas background rather than a box covering it —
but hit testing walks paint order backwards, so every tap on a document landed
on `.odr-pages` and never reached the text. No caret, and on ios no keyboard.
Android papered over the same rule by force-showing the soft keyboard when edit
mode starts.

What the rule was actually for is the **stacking context**: a shape's
background is a `z-index:-1` child (`translate_rect` / `translate_circle` /
`translate_line`), which needs the page to be one or it escapes to the root
context and paints behind the canvas. A negative `z-index` makes a stacking
context, so it worked — but any of them does, and this one also takes the page
out of reach. `isolation:isolate` is the same context without the paint-order
move.

It came in with #648, ported verbatim from OpenDocument.js (`9a7f522 "page
zindex"`, May 2025), where it had no stated reason either.

### Verification

- `elementFromPoint` over a run: `DIV.odr-pages` before, `X-S` after — same
  page, only the rule flipped.
- Rendering: `odr_test` run per side, every html file byte-identical and only
  `resources/document.css` differing, then `compare-html --driver chrome` over
  both — **334 public and 1225 private files all match**.
- CI's compare step covers `output/` only, so this needs no reference update;
  the pins move anyway to keep `resources/` in the reference tree honest.