### PR TITLE
docs(changelog): move #694's entries to Unreleased

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,19 @@ The release run heads these entries with the version and opens a fresh
 
 ## Unreleased
 
+- A pdf whose fonts are not embedded sits where the file puts it: a recovered
+  word break was both written into the run and spanned by its offset, so every
+  word drifted another space right and a search hit landed on its neighbour.
+- A pdf's bold and italic text is bold and italic — a non-embedded font is
+  asked for by the name of that cut, not faked at the regular cut's widths.
+- A pdf line that mixes fonts or sizes puts each run at its own baseline
+  instead of against the metrics of whichever run opened the line. Subscripts
+  and superscripts sit where the file puts them, and the text after a bullet
+  no longer parts company with the highlight that selects it.
+- A search hit or a selection running across words in a pdf paints the word
+  gaps between them rather than leaving a sliver of white in each. A gap wider
+  than the text is left alone: it is a column of white, not a space.
+
 ## v6.7.0 - 2026-08-16
 
 - `odr.search()`, `searchNext()`, `searchPrevious()` and `resetSearch()` now
@@ -30,18 +43,6 @@ The release run heads these entries with the version and opens a fresh
 - A tap on a paged document reaches its text: a negative `z-index` painted the
   page behind its container, which took every tap. No caret, and no keyboard on
   ios.
-- A pdf whose fonts are not embedded sits where the file puts it: a recovered
-  word break was both written into the run and spanned by its offset, so every
-  word drifted another space right and a search hit landed on its neighbour.
-- A pdf's bold and italic text is bold and italic — a non-embedded font is
-  asked for by the name of that cut, not faked at the regular cut's widths.
-- A pdf line that mixes fonts or sizes puts each run at its own baseline
-  instead of against the metrics of whichever run opened the line. Subscripts
-  and superscripts sit where the file puts them, and the text after a bullet
-  no longer parts company with the highlight that selects it.
-- A search hit or a selection running across words in a pdf paints the word
-  gaps between them rather than leaving a sliver of white in each. A gap wider
-  than the text is left alone: it is a column of white, not a space.
 
 ## v6.6.0 - 2026-08-14
 


### PR DESCRIPTION
#694's changelog entries landed under the `## v6.7.0` heading rather than under `## Unreleased`: the branch was cut before the release run stamped the heading, so the merge put them where `## Unreleased` had been.

v6.7.0 was drafted from the stamp commit, so it shipped without that fix and its published notes never carried these entries. They belong to the next release, and `## Unreleased` has to be non-empty for a release run to start at all.

🤖 Generated with [Claude Code](https://claude.com/claude-code)