### PR TITLE
perf(text): size the line numbers in one layout, not one per line

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,8 @@ The release run heads these entries with the version and opens a fresh
 - Prose is no longer read as a csv. A separator that every field follows with a
   space, in fields long enough to be sentences, is punctuation; `a, b, c` with
   short values is still a csv. One record is a line, not a table.
+- A large text file appears at once: sizing the line numbers laid the page out
+  once per line. A megabyte took 38s and now takes under a second.
 
 ## v6.7.1 - 2026-08-16
 

--- a/src/odr/internal/html/frontend.cpp
+++ b/src/odr/internal/html/frontend.cpp
@@ -800,12 +800,19 @@ constexpr std::string_view text_js = R"js(
 
   // The measured height is fractional; `offsetHeight` would round it per line
   // and the numbers would walk away from the lines they belong to.
+  //
+  // Every height is read before any is written: interleaving them makes each
+  // read force the layout the write before it invalidated, one per line.
   TextEditor.prototype.updateLineNumberHeight = function () {
     var nrCells = this.textNr.querySelectorAll("div");
     var textCells = this.textBody.querySelectorAll("div");
-    for (var i = 0; i < textCells.length && i < nrCells.length; ++i) {
-      nrCells[i].style.height =
-        textCells[i].getBoundingClientRect().height + "px";
+    var count = Math.min(textCells.length, nrCells.length);
+    var heights = new Array(count);
+    for (var i = 0; i < count; ++i) {
+      heights[i] = textCells[i].getBoundingClientRect().height;
+    }
+    for (var j = 0; j < count; ++j) {
+      nrCells[j].style.height = heights[j] + "px";
     }
   };
 


### PR DESCRIPTION
A megabyte of plain text took **38 seconds** to appear in a WebView, of which **37.6 seconds** was spent inside one function.

## The bug

`text.js`'s `updateLineNumberHeight` interleaves a write and a read:

```js
for (var i = 0; i < textCells.length && i < nrCells.length; ++i) {
  nrCells[i].style.height =
    textCells[i].getBoundingClientRect().height + "px";
}
```

Setting `style.height` invalidates layout; the `getBoundingClientRect()` on the next iteration forces it again. With one gutter cell per line that is one full layout of the entire document per line.

Every height is read first, then written. Same output, one layout.

## Numbers

Measured in a WebView on a Pixel 9 Pro emulator, timing wall clock to a stable DOM and accumulating the time spent inside this function. 1 MB of plain text, 7,823 lines:

| | ready | in `updateLineNumberHeight` |
|---|---|---|
| as served | 38.2s | 37.6s |
| batched | **0.26s** | 6ms |
| gutter script removed entirely | 0.25s | — |

Batching is indistinguishable from not doing the work at all. Repeated back to back to rule out warm-up: 29.1s / 0.19s / 30.2s.

Cost is linear in line count from here, and what remains is the browser, not this function:

| text | html | elements | fetch | parse + layout | ready |
|---|---|---|---|---|---|
| 1 MB | 1.2 MB | 15,661 | 33ms | 264ms | 0.46s |
| 10 MB | 12 MB | 155,229 | 71ms | 1.5s | 3.0s |
| 25 MB | 30 MB | 386,343 | 192ms | 6.7s | 6.7s |

## Not in this PR

Two elements per line, half of them the gutter, costs roughly 4.6–5.4 KB of renderer memory each. At 50 MB and 100 MB the renderer is killed by the low-memory killer (2.7 GB RSS) and takes the app process with it — the engine itself is fine there, writing 121 MB of html in 2.5s. Replacing the parallel gutter column with a CSS counter would halve both the element count and the memory and remove this script; virtualising the line list is what would actually lift the ceiling. Neither is here.

## Test

No test: this is a rendering performance fix with identical output, and the reference-output suite compares rendered pages. Verified by the measurements above.

🤖 Generated with [Claude Code](https://claude.com/claude-code)