### PR TITLE
docs(html): deprecate the html config options nothing reads

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -29,6 +29,9 @@ The release run heads these entries with the version and opens a fresh
   short values is still a csv. One record is a line, not a table.
 - A large text file appears at once: sizing the line numbers laid the page out
   once per line. A megabyte took 38s and now takes under a second.
+- **Deprecated** `HtmlConfig::embed_outline`, `no_drm`,
+  `background_image_format` and `background_image_dpi`. Nothing has read them
+  for a while; they still store and return what is set.
 
 ## v6.7.1 - 2026-08-16
 

--- a/apple/include/OdrCoreObjC/ODRHtml.h
+++ b/apple/include/OdrCoreObjC/ODRHtml.h
@@ -100,7 +100,9 @@ NS_SWIFT_NAME(HtmlConfig)
 @property(nonatomic) uint8_t htmlIndent;
 @property(nonatomic, copy) NSString *htmlIndentString;
 
+/// @deprecated Inert.
 @property(nonatomic, copy) NSString *backgroundImageFormat;
+/// @deprecated Inert.
 @property(nonatomic) double backgroundImageDpi;
 
 /// Render only pages `[begin, end)`, 0-based. `nil` end means to the last page.
@@ -111,7 +113,9 @@ NS_SWIFT_NAME(HtmlConfig)
 @property(nonatomic, copy) NSArray<NSString *> *pdfDualLayerFallbackFonts;
 @property(nonatomic) double pdfDualLayerFallbackFontSizeAdjust;
 
+/// @deprecated Inert.
 @property(nonatomic) BOOL noDrm;
+/// @deprecated Inert.
 @property(nonatomic) BOOL embedOutline;
 
 @property(nonatomic, copy, nullable) NSString *outputPath;

--- a/jni/java/app/opendocument/core/HtmlConfig.java
+++ b/jni/java/app/opendocument/core/HtmlConfig.java
@@ -42,8 +42,11 @@ public final class HtmlConfig {
   public int htmlIndent = 1;
   public String htmlIndentString = "\t";
 
-  public String backgroundImageFormat = "png";
-  public double backgroundImageDpi = 144.0;
+  /** @deprecated Inert. */
+  @Deprecated public String backgroundImageFormat = "png";
+
+  /** @deprecated Inert. */
+  @Deprecated public double backgroundImageDpi = 144.0;
 
   public int pageRangeBegin = 0;
   /** {@code null} renders to the end of the document. */
@@ -55,9 +58,11 @@ public final class HtmlConfig {
   };
   public double pdfDualLayerFallbackFontSizeAdjust = 0.5;
 
-  public boolean noDrm = false;
+  /** @deprecated Inert. */
+  @Deprecated public boolean noDrm = false;
 
-  public boolean embedOutline = false;
+  /** @deprecated Inert. */
+  @Deprecated public boolean embedOutline = false;
 
   /** {@code null} keeps output in the cache directory. */
   public String outputPath;

--- a/python/src/bind_html.cpp
+++ b/python/src/bind_html.cpp
@@ -94,9 +94,11 @@ void odr_python::bind_html(py::module_ &m) {
       .def_readwrite("html_indent", &odr::HtmlConfig::html_indent)
       .def_readwrite("html_indent_string", &odr::HtmlConfig::html_indent_string)
       .def_readwrite("background_image_format",
-                     &odr::HtmlConfig::background_image_format)
+                     &odr::HtmlConfig::background_image_format,
+                     "Deprecated and inert.")
       .def_readwrite("background_image_dpi",
-                     &odr::HtmlConfig::background_image_dpi)
+                     &odr::HtmlConfig::background_image_dpi,
+                     "Deprecated and inert.")
       .def_readwrite("page_range_begin", &odr::HtmlConfig::page_range_begin)
       .def_readwrite("page_range_end", &odr::HtmlConfig::page_range_end)
       .def_readwrite("pdf_text_mode", &odr::HtmlConfig::pdf_text_mode)
@@ -104,8 +106,10 @@ void odr_python::bind_html(py::module_ &m) {
                      &odr::HtmlConfig::pdf_dual_layer_fallback_fonts)
       .def_readwrite("pdf_dual_layer_fallback_font_size_adjust",
                      &odr::HtmlConfig::pdf_dual_layer_fallback_font_size_adjust)
-      .def_readwrite("no_drm", &odr::HtmlConfig::no_drm)
-      .def_readwrite("embed_outline", &odr::HtmlConfig::embed_outline)
+      .def_readwrite("no_drm", &odr::HtmlConfig::no_drm,
+                     "Deprecated and inert.")
+      .def_readwrite("embed_outline", &odr::HtmlConfig::embed_outline,
+                     "Deprecated and inert.")
       .def_readwrite("output_path", &odr::HtmlConfig::output_path)
       .def_readwrite("resource_locator", &odr::HtmlConfig::resource_locator);
 

--- a/src/odr/html.hpp
+++ b/src/odr/html.hpp
@@ -155,8 +155,9 @@ struct HtmlConfig {
   std::uint8_t html_indent{1};
   std::string html_indent_string{"\t"};
 
-  // background image
+  /// @deprecated Inert: no view renders a background image to a file.
   std::string background_image_format{"png"};
+  /// @deprecated See @ref background_image_format.
   double background_image_dpi{144.0};
 
   // Paged-document page range (currently honored by the PDF pipeline): render
@@ -177,10 +178,10 @@ struct HtmlConfig {
       "Arial", "Helvetica", "Liberation Sans", "DejaVu Sans", "Nimbus Sans"};
   double pdf_dual_layer_fallback_font_size_adjust{0.5};
 
-  // drm options
+  /// @deprecated Inert: no output carries a restriction to lift.
   bool no_drm{false};
 
-  // outline options
+  /// @deprecated Inert: an outline is never written.
   bool embed_outline{false};
 
   std::optional<std::string> output_path;

--- a/wasm/js/index.d.ts
+++ b/wasm/js/index.d.ts
@@ -74,9 +74,13 @@ export interface HtmlConfig {
   editable?: boolean;
   textDocumentMargin?: boolean;
   formatHtml?: boolean;
+  /** @deprecated Inert. */
   embedOutline?: boolean;
+  /** @deprecated Inert. */
   noDrm?: boolean;
+  /** @deprecated Inert. */
   backgroundImageFormat?: string;
+  /** @deprecated Inert. */
   backgroundImageDpi?: number;
   pageRangeBegin?: number;
   pageRangeEnd?: number;


### PR DESCRIPTION
Four `HtmlConfig` options are read nowhere in the library:

| Option | State |
|---|---|
| `embed_outline` | no outline is ever written |
| `no_drm` | no output carries a restriction to lift |
| `background_image_format` | no view renders a background image to a file |
| `background_image_dpi` | same |

`grep -rn 'embed_outline\|no_drm\|background_image' src` finds only their declarations in `html.hpp`. Setting one has done nothing for a while, which the header did not say. Noticed while surveying which config toggles the reference output covers (#699) — these are the ones there is nothing to cover.

Marked `@deprecated` in the header and in the four binding surfaces that carry them: python docstrings, the wasm `.d.ts`, `@Deprecated` on the Java fields, and doc comments on the ObjC properties.

They keep storing and returning what is set, and the bindings keep carrying them, so no caller breaks. Removing them is a later, breaking change — the same treatment `GlobalParams::odr_core_data_path` and `libmagic_database_path` already got.

Verified: `bind_html.cpp` compiles against pybind11, and the Java package compiles clean under `-Xlint:deprecation` (nothing in the repo reads the fields from Java).

🤖 Generated with [Claude Code](https://claude.com/claude-code)