### PR TITLE
test(html): render an image, and one of them in the dark

### DIFF
--- a/test/data.cmake
+++ b/test/data.cmake
@@ -7,7 +7,7 @@
 odr_test_data(
         PATH "input/odr-public"
         URL "https://github.com/opendocument-app/OpenDocument.test.git"
-        REVISION "77ed98d72075bbd375be328b7232f40568a32563")
+        REVISION "1ad8965bfc65529a715d5b0e39743292e879329e")
 
 odr_test_data(
         PATH "input/odr-private"
@@ -17,7 +17,7 @@ odr_test_data(
 odr_test_data(
         PATH "reference-output/odr-public"
         URL "https://github.com/opendocument-app/OpenDocument.test.output.git"
-        REVISION "9f41493817bd7d33ea6aae8dc63011e46f87f1d6")
+        REVISION "cf8f1e19ae5d70f433114c5ca29716931c29ebfe")
 
 odr_test_data(
         PATH "reference-output/odr-private"

--- a/test/src/html_output_test.cpp
+++ b/test/src/html_output_test.cpp
@@ -275,14 +275,16 @@ std::vector<std::pair<std::string, ConfigVariant>> list_variant_cases() {
       // renders one.
       {"odr-private/pdf/978-3-030-65771-0.pdf", single},
 
-      // One file per view honoring a color scheme. The pdf view honors none,
-      // and no test file reaches the image view at all.
+      // One file per view honoring a color scheme. The pdf view honors none.
       {"odr-public/odt/style-various-1.odt", dark},
       {"odr-public/odp/style-various-1.odp", dark},
       {"odr-public/ods/style-border-1.ods", dark},
       {"odr-public/txt/lorem ipsum.txt", dark},
       {"odr-public/zip/small.zip", dark},
       {"odr-private/otf/OpenSans-Regular.otf", dark},
+      // The image view paints the ground the picture sits on and nothing else,
+      // so the file that shows it is one with transparency.
+      {"odr-public/png/tango-example-icons.png", dark},
       // `system` writes what `dark` writes, wrapped in a media query; one file
       // pins that wrapper.
       {"odr-public/txt/lorem ipsum.txt", system},

--- a/test/src/internal/magic_test.cpp
+++ b/test/src/internal/magic_test.cpp
@@ -8,6 +8,8 @@
 #include <gtest/gtest.h>
 
 #include <sstream>
+#include <string>
+#include <tuple>
 
 using namespace odr;
 using namespace odr::internal;
@@ -56,6 +58,45 @@ TEST(magic, wpd) {
 
   EXPECT_EQ(magic::mimetype(file.disk_path().value(), Logger::null()),
             "application/vnd.wordperfect");
+}
+
+/// What an encoder actually writes, rather than the signature a table says it
+/// should: a jpeg names itself with whichever application marker it happens to
+/// carry, and a webp only after its RIFF form tag.
+TEST(magic, images) {
+  for (const auto &[path, type, mimetype] :
+       {std::tuple{"odr-public/png/tango-example-icons.png",
+                   FileType::portable_network_graphics, "image/png"},
+        std::tuple{"odr-public/jpg/fantastic-landscape.jpg", FileType::jpeg,
+                   "image/jpeg"},
+        std::tuple{"odr-public/gif/knights-tour.gif",
+                   FileType::graphics_interchange_format, "image/gif"},
+        std::tuple{"odr-public/bmp/tango-example-icons.bmp",
+                   FileType::bitmap_image_file, "image/bmp"},
+        std::tuple{"odr-public/webp/lorine-niedecker.webp", FileType::webp,
+                   "image/webp"}}) {
+    const File file(TestData::test_file_path(path));
+
+    EXPECT_EQ(magic::file_type(*file.impl()), type) << path;
+    EXPECT_EQ(magic::mimetype(file.disk_path().value(), Logger::null()),
+              mimetype)
+        << path;
+  }
+}
+
+/// An svg carries no signature at all - it is named by parsing it, and only the
+/// open strategy does that.
+TEST(magic, svg) {
+  for (const std::string path :
+       {"odr-public/svg/rotating-snakes.svg",
+        "odr-public/svg/civitas-schinesghe-emblem.svg"}) {
+    const File file(TestData::test_file_path(path));
+
+    EXPECT_EQ(magic::file_type(*file.impl()), FileType::unknown) << path;
+    EXPECT_EQ(magic::mimetype(file.disk_path().value(), Logger::null()),
+              "image/svg+xml")
+        << path;
+  }
 }
 
 namespace {


### PR DESCRIPTION
🤖 Generated with [Claude Code](https://claude.com/claude-code)

Every png, jpg, gif, bmp, webp and svg goes out through one page — the image
view, `html/image_file.cpp` — and no test file was an image, so that page had
no reference output at all. The corpus-driven capability checks in `odr_test`
skipped every image type for want of a file too, which is what
`FileTypeCapabilities::color_scheme` for those types was resting on.

**Test data.** The public test data gains one file per format a browser paints
from a data url, each public domain or CC0 from Wikimedia Commons and recorded
with its file page in `index.csv`:

| file | format | source |
|------|--------|--------|
| `png/tango-example-icons.png` | png, with transparency | [Tango-example icons.png](https://commons.wikimedia.org/wiki/File:Tango-example_icons.png), public domain |
| `bmp/tango-example-icons.bmp` | bmp | the png above, converted with `sips` — Commons hosts no bmp |
| `jpg/fantastic-landscape.jpg` | jpeg | [Fantastic Landscape MET DT4562.jpg](https://commons.wikimedia.org/wiki/File:Fantastic_Landscape_MET_DT4562.jpg), CC0 |
| `gif/knights-tour.gif` | gif, animated | [Knight's tour anim 2.gif](https://commons.wikimedia.org/wiki/File:Knight%27s_tour_anim_2.gif), CC0 |
| `webp/lorine-niedecker.webp` | webp | [Lorine Niedecker reading by river.webp](https://commons.wikimedia.org/wiki/File:Lorine_Niedecker_reading_by_river.webp), public domain |
| `svg/rotating-snakes.svg` | svg, no xml declaration | [Rotating snakes illusion.svg](https://commons.wikimedia.org/wiki/File:Rotating_snakes_illusion.svg), public domain |
| `svg/civitas-schinesghe-emblem.svg` | svg, declaration + doctype | [Emblem of Civitas Schinesghe.svg](https://commons.wikimedia.org/wiki/File:Emblem_of_Civitas_Schinesghe.svg), CC0 |

The two svg cover the two ways one arrives: a bare `<svg>` root, which only a
parse can name, and an Illustrator export whose doctype names an external dtd
that must not be fetched.

**Dark.** The png is rendered a second time in the `dark` variant. The image
view's color scheme is the ground behind the picture and nothing else, so the
file that shows it is the one with transparency — hence the png rather than the
photograph.

**`magic`.** The same files as real input. Its image coverage was synthetic
signatures only, which cannot show that a jpeg names itself by whichever
application marker its encoder happened to write, or that an svg is named by
parsing rather than by its head.

Audio and video stay uncovered on purpose. So do the image types no browser
paints (`tiff`, `heic`, `avif`, `jp2`, `jxl`, `psd`, `wmf`, `emf`) — a
reference render of those would pin a broken-image box.

Pins advanced: [OpenDocument.test](https://github.com/opendocument-app/OpenDocument.test) and
[OpenDocument.test.output](https://github.com/opendocument-app/OpenDocument.test.output).
