### PR TITLE
fix(jni): require a jdk for the jar rather than shipping without it

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,9 @@ The release run heads these entries with the version and opens a fresh
 
 - A pdf that nests parentheses inside a string opens, and keeps its document
   metadata — `cairo` and `pdfTeX` write their `/Producer` that way.
+- A jni build that cannot find a JDK fails instead of shipping a package without
+  `odr-core-java.jar` in it. The new `ODR_JNI_JAR` (default `ON`) is what says
+  whether the jar is wanted; the AAR build turns it off and needs no JDK.
 
 ## v6.9.0 - 2026-08-18
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,9 +18,9 @@ The release run heads these entries with the version and opens a fresh
 
 - A pdf that nests parentheses inside a string opens, and keeps its document
   metadata — `cairo` and `pdfTeX` write their `/Producer` that way.
-- A jni build that cannot find a JDK fails instead of shipping a package without
-  `odr-core-java.jar` in it. The new `ODR_JNI_JAR` (default `ON`) is what says
-  whether the jar is wanted; the AAR build turns it off and needs no JDK.
+- A jni build without a JDK fails instead of shipping a package missing
+  `odr-core-java.jar`. `ODR_JNI_JAR=OFF` is how the AAR build asks for the
+  native half alone.
 
 ## v6.9.0 - 2026-08-18
 

--- a/android/build_native.py
+++ b/android/build_native.py
@@ -93,8 +93,7 @@ def build(architecture: str, conan: str, build_profile: str, output: Path) -> No
          # rather than shipped as a second .so the app would have to load
          "-DBUILD_SHARED_LIBS=OFF",
          "-DODR_JNI=ON",
-         # the AAR compiles `jni/java/` itself, so the native half is all we
-         # want out of cmake — and no JDK is needed to produce it
+         # the AAR compiles `jni/java/` itself, so no jar and no JDK here
          "-DODR_JNI_JAR=OFF",
          "-DODR_CLI=OFF",
          "-DODR_TEST=OFF",

--- a/android/build_native.py
+++ b/android/build_native.py
@@ -93,6 +93,9 @@ def build(architecture: str, conan: str, build_profile: str, output: Path) -> No
          # rather than shipped as a second .so the app would have to load
          "-DBUILD_SHARED_LIBS=OFF",
          "-DODR_JNI=ON",
+         # the AAR compiles `jni/java/` itself, so the native half is all we
+         # want out of cmake — and no JDK is needed to produce it
+         "-DODR_JNI_JAR=OFF",
          "-DODR_CLI=OFF",
          "-DODR_TEST=OFF",
          "-DODR_WITH_HTTP_SERVER=ON"])

--- a/jni/AGENTS.md
+++ b/jni/AGENTS.md
@@ -8,7 +8,7 @@ package `app.opendocument.core`. Mirrors the surface of the python bindings
 
 | Path | What |
 |------|------|
-| `CMakeLists.txt` | Builds `libodr_jni` + `odr-core-java.jar`; included from the root build via `ODR_JNI`, or standalone against an installed `odrcore`. |
+| `CMakeLists.txt` | Builds `libodr_jni` + `odr-core-java.jar`; included from the root build via `ODR_JNI`, or standalone against an installed `odrcore`. `ODR_JNI_JAR=OFF` builds the native half alone — what `../android` does; on it a JDK is `REQUIRED`, on android too. |
 | `pom.xml` | Maven distribution of the Java classes only (`app.opendocument:odr-core-java`); published to Maven Central (the `central` profile) and GitHub Packages on release via `.github/workflows/maven.yml`. Keep `--release`/`-Xlint` in sync with `CMAKE_JAVA_COMPILE_FLAGS`. |
 | `src/` | JNI sources, one `jni_*` unit per public-API area; `odr_jni.hpp` (strings, exceptions, handles) and `jni_convert.hpp` (struct/POJO marshalling) are the helpers. |
 | `java/app/opendocument/core/` | Java API: enums, POJOs (styles, metas, `HtmlConfig`), and handle-backed wrappers extending `NativeResource`. Also compiled as-is into the AAR (`../android`) — which is kotlin, but this stays java: `add_jar` below has no kotlin toolchain. |

--- a/jni/AGENTS.md
+++ b/jni/AGENTS.md
@@ -8,7 +8,7 @@ package `app.opendocument.core`. Mirrors the surface of the python bindings
 
 | Path | What |
 |------|------|
-| `CMakeLists.txt` | Builds `libodr_jni` + `odr-core-java.jar`; included from the root build via `ODR_JNI`, or standalone against an installed `odrcore`. `ODR_JNI_JAR=OFF` builds the native half alone — what `../android` does, and the only build that needs no JDK, since `find_package(JNI)` is skipped on android too. With the jar on, a JDK is `REQUIRED` on every platform. |
+| `CMakeLists.txt` | Builds `libodr_jni` + `odr-core-java.jar`; included from the root build via `ODR_JNI`, or standalone against an installed `odrcore`. `ODR_JNI_JAR=OFF` builds the native half alone — what `../android` does, and the only build needing no JDK. |
 | `pom.xml` | Maven distribution of the Java classes only (`app.opendocument:odr-core-java`); published to Maven Central (the `central` profile) and GitHub Packages on release via `.github/workflows/maven.yml`. Keep `--release`/`-Xlint` in sync with `CMAKE_JAVA_COMPILE_FLAGS`. |
 | `src/` | JNI sources, one `jni_*` unit per public-API area; `odr_jni.hpp` (strings, exceptions, handles) and `jni_convert.hpp` (struct/POJO marshalling) are the helpers. |
 | `java/app/opendocument/core/` | Java API: enums, POJOs (styles, metas, `HtmlConfig`), and handle-backed wrappers extending `NativeResource`. Also compiled as-is into the AAR (`../android`) — which is kotlin, but this stays java: `add_jar` below has no kotlin toolchain. |

--- a/jni/AGENTS.md
+++ b/jni/AGENTS.md
@@ -8,7 +8,7 @@ package `app.opendocument.core`. Mirrors the surface of the python bindings
 
 | Path | What |
 |------|------|
-| `CMakeLists.txt` | Builds `libodr_jni` + `odr-core-java.jar`; included from the root build via `ODR_JNI`, or standalone against an installed `odrcore`. `ODR_JNI_JAR=OFF` builds the native half alone — what `../android` does; on it a JDK is `REQUIRED`, on android too. |
+| `CMakeLists.txt` | Builds `libodr_jni` + `odr-core-java.jar`; included from the root build via `ODR_JNI`, or standalone against an installed `odrcore`. `ODR_JNI_JAR=OFF` builds the native half alone — what `../android` does, and the only build that needs no JDK, since `find_package(JNI)` is skipped on android too. With the jar on, a JDK is `REQUIRED` on every platform. |
 | `pom.xml` | Maven distribution of the Java classes only (`app.opendocument:odr-core-java`); published to Maven Central (the `central` profile) and GitHub Packages on release via `.github/workflows/maven.yml`. Keep `--release`/`-Xlint` in sync with `CMAKE_JAVA_COMPILE_FLAGS`. |
 | `src/` | JNI sources, one `jni_*` unit per public-API area; `odr_jni.hpp` (strings, exceptions, handles) and `jni_convert.hpp` (struct/POJO marshalling) are the helpers. |
 | `java/app/opendocument/core/` | Java API: enums, POJOs (styles, metas, `HtmlConfig`), and handle-backed wrappers extending `NativeResource`. Also compiled as-is into the AAR (`../android`) — which is kotlin, but this stays java: `add_jar` below has no kotlin toolchain. |

--- a/jni/CMakeLists.txt
+++ b/jni/CMakeLists.txt
@@ -26,12 +26,10 @@ if (NOT ANDROID)
     find_package(JNI REQUIRED)
 endif ()
 
-# The jar is not an android-vs-not question: the android odrcore package ships
-# `odr-core-java.jar` next to `libodr_jni.so` and OpenDocument.droid takes both
-# out of it. Only `android/` (the AAR) wants the native half alone, with the
-# android toolchain compiling `java/` itself, and says so — so a missing JDK
-# fails the build that asked for a jar instead of quietly shipping half a
-# package.
+# Android is no reason to skip the jar — the android odrcore package ships it
+# next to `libodr_jni.so` for OpenDocument.droid. Only the AAR build wants the
+# native half alone, and asks for it, so a missing JDK fails rather than
+# quietly shipping half a package.
 option(ODR_JNI_JAR "Build the java half, `odr-core-java.jar`" ON)
 if (ODR_JNI_JAR)
     find_package(Java 11 REQUIRED COMPONENTS Development)

--- a/jni/CMakeLists.txt
+++ b/jni/CMakeLists.txt
@@ -21,18 +21,20 @@ else ()
 endif ()
 
 # On android the NDK sysroot ships `jni.h` and the JNI symbols come from the
-# runtime, so there is nothing to find or link against. A JDK stays optional
-# there rather than unused: the android odrcore package ships
-# `odr-core-java.jar` next to `libodr_jni.so` and OpenDocument.droid takes both
-# out of it, while `android/` (the AAR) builds the native half alone, with the
-# android toolchain compiling `java/` itself.
-if (ANDROID)
-    find_package(Java 11 COMPONENTS Development)
-else ()
-    find_package(Java 11 REQUIRED COMPONENTS Development)
+# runtime, so there is nothing to find or link against.
+if (NOT ANDROID)
     find_package(JNI REQUIRED)
 endif ()
-if (Java_FOUND)
+
+# The jar is not an android-vs-not question: the android odrcore package ships
+# `odr-core-java.jar` next to `libodr_jni.so` and OpenDocument.droid takes both
+# out of it. Only `android/` (the AAR) wants the native half alone, with the
+# android toolchain compiling `java/` itself, and says so — so a missing JDK
+# fails the build that asked for a jar instead of quietly shipping half a
+# package.
+option(ODR_JNI_JAR "Build the java half, `odr-core-java.jar`" ON)
+if (ODR_JNI_JAR)
+    find_package(Java 11 REQUIRED COMPONENTS Development)
     include(UseJava)
 endif ()
 
@@ -56,7 +58,7 @@ endif ()
 
 install(TARGETS odr_jni LIBRARY DESTINATION "${CMAKE_INSTALL_LIBDIR}" COMPONENT jni)
 
-if (NOT Java_FOUND)
+if (NOT ODR_JNI_JAR)
     return()
 endif ()
 

--- a/jni/README.md
+++ b/jni/README.md
@@ -71,15 +71,11 @@ This produces `build/jni/libodr_jni.dylib` (or `.so`) and
 `build/jni/odr-core-java.jar`. `jni/CMakeLists.txt` can also be configured
 standalone against an installed `odrcore` package.
 
-`ODR_JNI_JAR=OFF` builds the native library alone, without the java half. That
-is what the AAR build (`android/build_native.py`) asks for, since it compiles
-`jni/java/` with the android toolchain instead — and on android that build needs
-no JDK at all, because the NDK sysroot ships `jni.h`. Everywhere else
-`find_package(JNI REQUIRED)` still runs and still wants a JDK for the headers,
-whatever `ODR_JNI_JAR` says.
-
-With the jar on — the default — a missing JDK fails the configure step rather
-than producing a package without `odr-core-java.jar` in it.
+`ODR_JNI_JAR=OFF` builds the native library alone. That is what the AAR build
+(`android/build_native.py`) asks for, since it compiles `jni/java/` with the
+android toolchain instead, and it is the only build needing no JDK — on android
+the headers come from the NDK sysroot. Otherwise a missing JDK fails the
+configure step rather than producing a package without the jar in it.
 
 ## Runtime data
 

--- a/jni/README.md
+++ b/jni/README.md
@@ -71,11 +71,15 @@ This produces `build/jni/libodr_jni.dylib` (or `.so`) and
 `build/jni/odr-core-java.jar`. `jni/CMakeLists.txt` can also be configured
 standalone against an installed `odrcore` package.
 
-`ODR_JNI_JAR=OFF` builds the native library alone and needs no JDK. That is what
-the AAR build (`android/build_native.py`) asks for, since it compiles
-`jni/java/` with the android toolchain instead. With it on — the default — a
-missing JDK fails the configure step rather than producing a package without the
-jar in it.
+`ODR_JNI_JAR=OFF` builds the native library alone, without the java half. That
+is what the AAR build (`android/build_native.py`) asks for, since it compiles
+`jni/java/` with the android toolchain instead — and on android that build needs
+no JDK at all, because the NDK sysroot ships `jni.h`. Everywhere else
+`find_package(JNI REQUIRED)` still runs and still wants a JDK for the headers,
+whatever `ODR_JNI_JAR` says.
+
+With the jar on — the default — a missing JDK fails the configure step rather
+than producing a package without `odr-core-java.jar` in it.
 
 ## Runtime data
 

--- a/jni/README.md
+++ b/jni/README.md
@@ -71,6 +71,12 @@ This produces `build/jni/libodr_jni.dylib` (or `.so`) and
 `build/jni/odr-core-java.jar`. `jni/CMakeLists.txt` can also be configured
 standalone against an installed `odrcore` package.
 
+`ODR_JNI_JAR=OFF` builds the native library alone and needs no JDK. That is what
+the AAR build (`android/build_native.py`) asks for, since it compiles
+`jni/java/` with the android toolchain instead. With it on — the default — a
+missing JDK fails the configure step rather than producing a package without the
+jar in it.
+
 ## Runtime data
 
 There is none. The renderer's CSS/JS are part of the library and detection needs


### PR DESCRIPTION
🤖 Generated with [Claude Code](https://claude.com/claude-code)

Closes #637.

`jni/CMakeLists.txt` looked for a JDK without `REQUIRED` on android, so that the AAR build — which compiles `jni/java/` with the android toolchain — would not need one. The cost was that a build machine with no `javac` produced an android odrcore package with `libodr_jni.so` and **no** `odr-core-java.jar`, even though the option asked for was `with_jni=True`. OpenDocument.droid takes the jar out of that package, so the failure surfaced much later as a `FileNotFoundError` on the deployer's path.

The jar is not an android-vs-not question, so this asks it directly:

- `ODR_JNI_JAR` (default `ON`) says whether the java half is wanted. With it on, `find_package(Java 11 REQUIRED COMPONENTS Development)` runs everywhere, android included.
- `android/build_native.py` passes `-DODR_JNI_JAR=OFF` — it is the one build that genuinely wants the native half alone, and it now needs no JDK at all rather than relying on one being optional.
- `find_package(JNI REQUIRED)` stays behind `if (NOT ANDROID)`: the NDK sysroot ships `jni.h` and the symbols come from the runtime.

So "no jar" is something a caller asked for rather than something the environment decided.

## Verified

Configured against the repo with a `PATH`/`JAVA_HOME` carrying no JDK:

| configure | before | after |
|---|---|---|
| android, `ODR_JNI_JAR=OFF` (the AAR build) | ok | ok — no `find_package(Java)` at all |
| android, default (`with_jni=True`) | ok, package missing the jar | `Could NOT find Java`, configure fails |
| host build, default | `Could NOT find Java` | `Could NOT find Java` |

And with a JDK present, `cmake --build … --target odr_java` still produces `odr-core-java.jar`.