### PR TITLE
test(http-server): guard the prompt stop after a kept-alive request

### DIFF
--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -112,6 +112,9 @@ if (ODR_WITH_HTTP_SERVER)
             PRIVATE
             "src/http_server_test.cpp"
     )
+    # a client to make a request with, so the server can be tested serving one
+    find_package(httplib REQUIRED)
+    target_link_libraries(odr_test PRIVATE httplib::httplib)
 endif ()
 target_include_directories(odr_test
         PRIVATE

--- a/test/src/http_server_test.cpp
+++ b/test/src/http_server_test.cpp
@@ -22,6 +22,31 @@ void wait_until_running(const HttpServer &server) {
   }
 }
 
+/// Stops the server and joins the thread however the test leaves - a fatal
+/// assertion returns, and a joinable `std::thread` destructor would take the
+/// whole test binary down with `std::terminate` instead of reporting it.
+class ListenGuard {
+public:
+  ListenGuard(const HttpServer &server, std::thread thread)
+      : m_server{&server}, m_thread{std::move(thread)} {}
+
+  ~ListenGuard() {
+    m_server->stop();
+    if (m_thread.joinable()) {
+      m_thread.join();
+    }
+  }
+
+  ListenGuard(const ListenGuard &) = delete;
+  ListenGuard &operator=(const ListenGuard &) = delete;
+  ListenGuard(ListenGuard &&) = delete;
+  ListenGuard &operator=(ListenGuard &&) = delete;
+
+private:
+  const HttpServer *m_server;
+  std::thread m_thread;
+};
+
 } // namespace
 
 TEST(HttpServer, bind_reports_the_port_it_got) {
@@ -161,7 +186,8 @@ TEST(HttpServer, stop_is_prompt_after_serving_a_kept_alive_request) {
   const HttpServer server;
 
   const std::uint32_t port = server.bind("127.0.0.1", 0);
-  std::thread thread{[&server] { server.listen(); }};
+  // stops and joins whatever happens below, including a fatal assertion
+  const ListenGuard guard{server, std::thread{[&server] { server.listen(); }}};
   wait_until_running(server);
 
   // alive across the stop() below, so the connection it holds is open there
@@ -174,8 +200,6 @@ TEST(HttpServer, stop_is_prompt_after_serving_a_kept_alive_request) {
   const auto before = std::chrono::steady_clock::now();
   server.stop();
   const auto elapsed = std::chrono::steady_clock::now() - before;
-
-  thread.join();
 
   EXPECT_LT(elapsed, 2s)
       << "stop() took "

--- a/test/src/http_server_test.cpp
+++ b/test/src/http_server_test.cpp
@@ -1,6 +1,8 @@
 #include <odr/exceptions.hpp>
 #include <odr/http_server.hpp>
 
+#include <httplib/httplib.h>
+
 #include <gtest/gtest.h>
 
 #include <atomic>
@@ -149,4 +151,34 @@ TEST(HttpServer, listen_after_stop_returns) {
   // a listen thread that starts late finds the server stopped; there is nothing
   // to serve, but nothing went wrong either
   EXPECT_NO_THROW(server.listen());
+}
+
+/// A kept-alive connection used to hold the accept loop until it idled out, so
+/// stop() spanned cpp-httplib's 5 s keep-alive timeout - the whole of it, on
+/// the path every consumer takes (#641). Fixed upstream in 0.47.0, where the
+/// keep-alive wait watches the listening socket; this is what says so.
+TEST(HttpServer, stop_is_prompt_after_serving_a_kept_alive_request) {
+  const HttpServer server;
+
+  const std::uint32_t port = server.bind("127.0.0.1", 0);
+  std::thread thread{[&server] { server.listen(); }};
+  wait_until_running(server);
+
+  // alive across the stop() below, so the connection it holds is open there
+  httplib::Client client{"127.0.0.1", static_cast<int>(port)};
+  client.set_keep_alive(true);
+  const httplib::Result response = client.Get("/");
+  ASSERT_TRUE(response);
+  EXPECT_EQ(response->status, 200);
+
+  const auto before = std::chrono::steady_clock::now();
+  server.stop();
+  const auto elapsed = std::chrono::steady_clock::now() - before;
+
+  thread.join();
+
+  EXPECT_LT(elapsed, 2s)
+      << "stop() took "
+      << std::chrono::duration_cast<std::chrono::milliseconds>(elapsed).count()
+      << " ms";
 }


### PR DESCRIPTION
🤖 Generated with [Claude Code](https://claude.com/claude-code)

Closes #641 — **already fixed**, this is the test that says so.

#641 reported `HttpServer::stop()` blocking ~5 s after any request had been served: the accept loop sat in cpp-httplib's keep-alive wait until the client's connection idled out, and `stop()` waits for `listen()` to return (rightly — that wait is what makes destruction safe, #633).

The bump to cpp-httplib 0.47.0 in #653 fixed it upstream. In 0.47.0 `detail::keep_alive()` polls the listening socket and breaks as soon as it is closed, so `Server::stop()` ends the wait instead of outliving it. That PR measured the same thing from the other side: "serving a rendered view takes 5.03 s on 0.16.3 and 0.03 s on 0.47.0".

Nothing in the suite covered it, so nothing would notice it coming back — a dependency bump or a `set_keep_alive_timeout` call could reintroduce it silently. This adds the missing coverage:

- `stop_is_prompt_after_serving_a_kept_alive_request` serves a request from an `httplib::Client` that keeps the connection open (and stays alive across the `stop()`, so the connection really is open there), then times `stop()`.
- `odr_test` links `httplib::httplib` for the client.

## Verified

```
[ RUN      ] HttpServer.stop_is_prompt_after_serving_a_kept_alive_request
[       OK ] HttpServer.stop_is_prompt_after_serving_a_kept_alive_request (12 ms)
[  PASSED  ] 11 tests.
```

12 ms against the 5.01 s the issue measured; the bound is 2 s, well clear of both.