### PR TITLE
fix(filesystem): make the walker over a document or archive steerable

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,11 +22,9 @@ The release run heads these entries with the version and opens a fresh
   `odr-core-java.jar`. `ODR_JNI_JAR=OFF` is how the AAR build asks for the
   native half alone.
 - A `FileWalker` over a document or an archive can be steered: `flat_next()`,
-  `pop()` and `depth()` do what they say instead of nothing — `flat_next()` in
-  particular no longer turns the loop it exists for into an endless one.
+  `pop()` and `depth()` do what they say instead of nothing.
 - A directory a document or an archive only implies is one: `exists()` and
-  `is_directory()` answer for a path that files sit under even when the
-  container never named it, and for `/`.
+  `is_directory()` answer for `/` and for a path that files sit under.
 
 ## v6.9.0 - 2026-08-18
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,6 +21,12 @@ The release run heads these entries with the version and opens a fresh
 - A jni build without a JDK fails instead of shipping a package missing
   `odr-core-java.jar`. `ODR_JNI_JAR=OFF` is how the AAR build asks for the
   native half alone.
+- A `FileWalker` over a document or an archive can be steered: `flat_next()`,
+  `pop()` and `depth()` do what they say instead of nothing — `flat_next()` in
+  particular no longer turns the loop it exists for into an endless one.
+- A directory a document or an archive only implies is one: `exists()` and
+  `is_directory()` answer for a path that files sit under even when the
+  container never named it, and for `/`.
 
 ## v6.9.0 - 2026-08-18
 

--- a/src/odr/internal/common/filesystem.cpp
+++ b/src/odr/internal/common/filesystem.cpp
@@ -147,14 +147,6 @@ bool SystemFilesystem::move(const AbsPath &from, const AbsPath &to) {
 }
 
 namespace {
-/// Component-wise, so that a subtree is contiguous and can be skipped by
-/// walking it. By string it is not: "/a" < "/a-b" < "/a/b".
-struct DepthFirstLess {
-  [[nodiscard]] bool operator()(const AbsPath &lhs, const AbsPath &rhs) const {
-    return std::ranges::lexicographical_compare(lhs, rhs);
-  }
-};
-
 class VirtualFileWalker final : public abstract::FileWalker {
 public:
   using Files = std::map<AbsPath, std::shared_ptr<abstract::File>>;
@@ -221,9 +213,15 @@ public:
   void flat_next() override { skip_subtree_(m_iterator->first); }
 
 private:
+  /// Ordered component-wise, so that a subtree is contiguous and can be
+  /// skipped by walking it. By string it is not: "/a" < "/a-b" < "/a/b".
+  using DepthFirstFiles =
+      std::map<AbsPath, std::shared_ptr<abstract::File>,
+               decltype(std::ranges::lexicographical_compare)>;
+
   AbsPath m_root;
-  std::map<AbsPath, std::shared_ptr<abstract::File>, DepthFirstLess> m_files;
-  decltype(m_files)::iterator m_iterator;
+  DepthFirstFiles m_files;
+  DepthFirstFiles::iterator m_iterator;
 
   void skip_subtree_(const AbsPath &path) {
     do {

--- a/src/odr/internal/common/filesystem.cpp
+++ b/src/odr/internal/common/filesystem.cpp
@@ -7,9 +7,11 @@
 #include <odr/internal/util/file_util.hpp>
 #include <odr/internal/util/stream_util.hpp>
 
+#include <algorithm>
 #include <filesystem>
 #include <fstream>
 #include <map>
+#include <ranges>
 #include <system_error>
 
 namespace odr::internal {
@@ -145,13 +147,24 @@ bool SystemFilesystem::move(const AbsPath &from, const AbsPath &to) {
 }
 
 namespace {
+/// Component-wise, so that a path's descendants follow it with nothing in
+/// between. Ordering the strings alone does not: any character below the
+/// separator sorts a sibling into the middle of a subtree - "/a" < "/a-b" <
+/// "/a/b" - and pop() and flat_next() below skip a subtree by walking it.
+struct DepthFirstLess {
+  [[nodiscard]] bool operator()(const AbsPath &lhs, const AbsPath &rhs) const {
+    return std::ranges::lexicographical_compare(lhs, rhs);
+  }
+};
+
 class VirtualFileWalker final : public abstract::FileWalker {
 public:
   using Files = std::map<AbsPath, std::shared_ptr<abstract::File>>;
 
-  VirtualFileWalker(const AbsPath &root, const Files &files) {
+  VirtualFileWalker(AbsPath root, const Files &files)
+      : m_root{std::move(root)} {
     for (const auto &[path, file] : files) {
-      if (path.descendant_of(root)) {
+      if (path.descendant_of(m_root)) {
         m_files[path] = file;
       }
     }
@@ -160,7 +173,8 @@ public:
   }
 
   /// The iterator has to be re-seated into the copied map.
-  VirtualFileWalker(const VirtualFileWalker &other) : m_files{other.m_files} {
+  VirtualFileWalker(const VirtualFileWalker &other)
+      : m_root{other.m_root}, m_files{other.m_files} {
     m_iterator = other.m_iterator == std::end(other.m_files)
                      ? std::end(m_files)
                      : m_files.find(other.m_iterator->first);
@@ -186,8 +200,11 @@ public:
     return m_iterator == std::end(m_files);
   }
 
+  /// 0 for an entry sitting directly in the walked root, as with
+  /// `std::filesystem::recursive_directory_iterator`.
   [[nodiscard]] std::uint32_t depth() const override {
-    return 0; // TODO
+    const RelPath relative = m_iterator->first.rebase(m_root);
+    return static_cast<std::uint32_t>(std::ranges::distance(relative)) - 1;
   }
 
   [[nodiscard]] AbsPath path() const override { return m_iterator->first; }
@@ -198,24 +215,31 @@ public:
 
   [[nodiscard]] bool is_directory() const override { return !is_file(); }
 
-  void pop() override {
-    // TODO
-  }
+  /// Leaves the directory the current entry sits in, landing on whatever
+  /// follows it. At depth 0 that is the end - the parent is the walked root.
+  void pop() override { skip_subtree_(m_iterator->first.parent()); }
 
   void next() override { ++m_iterator; }
 
-  void flat_next() override {
-    // TODO
-  }
+  /// The next entry that is not under the current one.
+  void flat_next() override { skip_subtree_(m_iterator->first); }
 
 private:
-  Files m_files;
-  Files::iterator m_iterator;
+  AbsPath m_root;
+  std::map<AbsPath, std::shared_ptr<abstract::File>, DepthFirstLess> m_files;
+  decltype(m_files)::iterator m_iterator;
+
+  void skip_subtree_(const AbsPath &path) {
+    do {
+      ++m_iterator;
+    } while (m_iterator != std::end(m_files) &&
+             m_iterator->first.descendant_of(path));
+  }
 };
 } // namespace
 
 bool VirtualFilesystem::exists(const AbsPath &path) const {
-  return m_files.contains(path);
+  return is_file(path) || is_directory(path);
 }
 
 bool VirtualFilesystem::is_file(const AbsPath &path) const {
@@ -227,11 +251,19 @@ bool VirtualFilesystem::is_file(const AbsPath &path) const {
 }
 
 bool VirtualFilesystem::is_directory(const AbsPath &path) const {
-  const auto file_it = m_files.find(path);
-  if (file_it == std::end(m_files)) {
-    return false;
+  if (path.root()) {
+    return true;
   }
-  return !static_cast<bool>(file_it->second);
+  const auto file_it = m_files.find(path);
+  if (file_it != std::end(m_files)) {
+    return !static_cast<bool>(file_it->second);
+  }
+  // An intermediate directory need not be an entry of its own - a zip may name
+  // only its files - so what something else sits under is a directory too,
+  // which is what the walker reports for it as well.
+  return std::ranges::any_of(m_files, [&path](const auto &entry) {
+    return entry.first.descendant_of(path);
+  });
 }
 
 std::unique_ptr<abstract::FileWalker>

--- a/src/odr/internal/common/filesystem.cpp
+++ b/src/odr/internal/common/filesystem.cpp
@@ -147,10 +147,8 @@ bool SystemFilesystem::move(const AbsPath &from, const AbsPath &to) {
 }
 
 namespace {
-/// Component-wise, so that a path's descendants follow it with nothing in
-/// between. Ordering the strings alone does not: any character below the
-/// separator sorts a sibling into the middle of a subtree - "/a" < "/a-b" <
-/// "/a/b" - and pop() and flat_next() below skip a subtree by walking it.
+/// Component-wise, so that a subtree is contiguous and can be skipped by
+/// walking it. By string it is not: "/a" < "/a-b" < "/a/b".
 struct DepthFirstLess {
   [[nodiscard]] bool operator()(const AbsPath &lhs, const AbsPath &rhs) const {
     return std::ranges::lexicographical_compare(lhs, rhs);
@@ -200,8 +198,7 @@ public:
     return m_iterator == std::end(m_files);
   }
 
-  /// 0 for an entry sitting directly in the walked root, as with
-  /// `std::filesystem::recursive_directory_iterator`.
+  /// 0 directly in the walked root, as `recursive_directory_iterator`.
   [[nodiscard]] std::uint32_t depth() const override {
     const RelPath relative = m_iterator->first.rebase(m_root);
     return static_cast<std::uint32_t>(std::ranges::distance(relative)) - 1;
@@ -215,8 +212,7 @@ public:
 
   [[nodiscard]] bool is_directory() const override { return !is_file(); }
 
-  /// Leaves the directory the current entry sits in, landing on whatever
-  /// follows it. At depth 0 that is the end - the parent is the walked root.
+  /// At depth 0 this ends the walk - the parent is the walked root.
   void pop() override { skip_subtree_(m_iterator->first.parent()); }
 
   void next() override { ++m_iterator; }
@@ -259,8 +255,7 @@ bool VirtualFilesystem::is_directory(const AbsPath &path) const {
     return !static_cast<bool>(file_it->second);
   }
   // An intermediate directory need not be an entry of its own - a zip may name
-  // only its files - so what something else sits under is a directory too,
-  // which is what the walker reports for it as well.
+  // only its files.
   return std::ranges::any_of(m_files, [&path](const auto &entry) {
     return entry.first.descendant_of(path);
   });
@@ -286,9 +281,8 @@ VirtualFilesystem::create_file(const AbsPath & /*path*/) {
 }
 
 bool VirtualFilesystem::create_directory(const AbsPath &path) {
-  // An entry of its own, not `exists()`: a directory this filesystem merely
-  // implies still has to become one, or an archive that names `a/b.txt` before
-  // `a/` would lose `a/` from the walk.
+  // Not `exists()`: a merely implied directory still has to become an entry,
+  // or an archive naming `a/b.txt` before `a/` would lose `a/` from the walk.
   if (m_files.contains(path)) {
     return false;
   }

--- a/src/odr/internal/common/filesystem.cpp
+++ b/src/odr/internal/common/filesystem.cpp
@@ -286,7 +286,10 @@ VirtualFilesystem::create_file(const AbsPath & /*path*/) {
 }
 
 bool VirtualFilesystem::create_directory(const AbsPath &path) {
-  if (exists(path)) {
+  // An entry of its own, not `exists()`: a directory this filesystem merely
+  // implies still has to become one, or an archive that names `a/b.txt` before
+  // `a/` would lose `a/` from the walk.
+  if (m_files.contains(path)) {
     return false;
   }
   m_files[path] = nullptr;
@@ -309,7 +312,7 @@ bool VirtualFilesystem::copy(const AbsPath &from, const AbsPath &to) {
   if (from_it == std::end(m_files)) {
     return false;
   }
-  if (exists(to)) {
+  if (m_files.contains(to)) {
     return false;
   }
   m_files[to] = from_it->second;
@@ -325,7 +328,7 @@ VirtualFilesystem::copy(const abstract::File & /*from*/,
 std::shared_ptr<abstract::File>
 VirtualFilesystem::copy(std::shared_ptr<abstract::File> from,
                         const AbsPath &to) {
-  if (exists(to)) {
+  if (m_files.contains(to)) {
     return {};
   }
   m_files[to] = from;

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -46,6 +46,7 @@ add_executable(odr_test
 
         "src/internal/cfb/cfb_archive_test.cpp"
 
+        "src/internal/common/filesystem_test.cpp"
         "src/internal/common/list_numbering_test.cpp"
         "src/internal/common/path_test.cpp"
         "src/internal/common/table_cursor_test.cpp"

--- a/test/src/internal/common/filesystem_test.cpp
+++ b/test/src/internal/common/filesystem_test.cpp
@@ -128,6 +128,25 @@ TEST(VirtualFilesystem, pop_at_depth_zero_ends_the_walk) {
   EXPECT_TRUE(walker->end());
 }
 
+/// An archive names its entries in its own order, and `as_filesystem()`
+/// inserts them in it. A directory that arrives after what it holds is still an
+/// entry of its own, or the walk would not offer it to `flat_next()`.
+TEST(VirtualFilesystem,
+     a_directory_entry_survives_arriving_after_its_children) {
+  VirtualFilesystem filesystem;
+  filesystem.copy(std::make_shared<MemoryFile>(std::string()),
+                  AbsPath("/a/b.txt"));
+  EXPECT_TRUE(filesystem.create_directory(AbsPath("/a")));
+
+  EXPECT_EQ(walk(filesystem, AbsPath("/")),
+            (std::vector<std::string>{"/a", "/a/b.txt"}));
+
+  const auto walker = filesystem.file_walker(AbsPath("/"));
+  EXPECT_TRUE(walker->is_directory());
+  walker->flat_next();
+  EXPECT_TRUE(walker->end());
+}
+
 TEST(VirtualFilesystem, an_intermediate_directory_is_a_directory) {
   const VirtualFilesystem filesystem = filesystem_of({"/a/c/d.txt"});
 

--- a/test/src/internal/common/filesystem_test.cpp
+++ b/test/src/internal/common/filesystem_test.cpp
@@ -1,0 +1,144 @@
+#include <odr/internal/common/filesystem.hpp>
+
+#include <odr/internal/abstract/filesystem.hpp>
+#include <odr/internal/common/file.hpp>
+#include <odr/internal/common/path.hpp>
+
+#include <gtest/gtest.h>
+
+#include <memory>
+#include <string>
+#include <vector>
+
+using namespace odr::internal;
+
+namespace {
+
+/// The paths a walk over `paths` visits, in order.
+std::vector<std::string> walk(const abstract::ReadableFilesystem &filesystem,
+                              const AbsPath &root) {
+  std::vector<std::string> result;
+  for (const auto walker = filesystem.file_walker(root); !walker->end();
+       walker->next()) {
+    result.push_back(walker->path().string());
+  }
+  return result;
+}
+
+VirtualFilesystem
+filesystem_of(const std::vector<std::string> &files,
+              const std::vector<std::string> &directories = {}) {
+  VirtualFilesystem result;
+  for (const std::string &directory : directories) {
+    result.create_directory(AbsPath(directory));
+  }
+  for (const std::string &file : files) {
+    result.copy(std::make_shared<MemoryFile>(std::string()), AbsPath(file));
+  }
+  return result;
+}
+
+} // namespace
+
+TEST(VirtualFilesystem, walker_reports_the_depth_of_every_entry) {
+  const VirtualFilesystem filesystem =
+      filesystem_of({"/mimetype", "/a/b.txt", "/a/c/d.txt"});
+
+  const auto walker = filesystem.file_walker(AbsPath("/"));
+
+  EXPECT_EQ(walker->path().string(), "/a/b.txt");
+  EXPECT_EQ(walker->depth(), 1);
+  walker->next();
+  EXPECT_EQ(walker->path().string(), "/a/c/d.txt");
+  EXPECT_EQ(walker->depth(), 2);
+  walker->next();
+  EXPECT_EQ(walker->path().string(), "/mimetype");
+  EXPECT_EQ(walker->depth(), 0);
+}
+
+TEST(VirtualFilesystem, walker_depth_is_relative_to_the_walked_root) {
+  const VirtualFilesystem filesystem = filesystem_of({"/a/c/d.txt"});
+
+  const auto walker = filesystem.file_walker(AbsPath("/a"));
+
+  EXPECT_EQ(walker->depth(), 1);
+}
+
+TEST(VirtualFilesystem, flat_next_skips_the_subtree_and_terminates) {
+  const VirtualFilesystem filesystem =
+      filesystem_of({"/a/b.txt", "/a/c/d.txt", "/e.txt"});
+
+  const auto walker = filesystem.file_walker(AbsPath("/"));
+
+  EXPECT_EQ(walker->path().string(), "/a/b.txt");
+  walker->flat_next();
+  EXPECT_EQ(walker->path().string(), "/a/c/d.txt");
+  walker->flat_next();
+  EXPECT_EQ(walker->path().string(), "/e.txt");
+  walker->flat_next();
+  EXPECT_TRUE(walker->end());
+}
+
+/// The loop flat_next() exists for; it never terminated while flat_next() did
+/// not advance.
+TEST(VirtualFilesystem, flat_next_over_a_directory_skips_what_is_under_it) {
+  const VirtualFilesystem filesystem =
+      filesystem_of({"/a/b.txt", "/a/c.txt", "/e.txt"}, {"/a"});
+
+  const auto walker = filesystem.file_walker(AbsPath("/"));
+
+  EXPECT_EQ(walker->path().string(), "/a");
+  EXPECT_TRUE(walker->is_directory());
+  walker->flat_next();
+  EXPECT_EQ(walker->path().string(), "/e.txt");
+}
+
+/// "/a-b" sorts between "/a" and "/a/b" by string, so a subtree is only
+/// contiguous in a component-wise order.
+TEST(VirtualFilesystem, flat_next_skips_a_subtree_a_sibling_sorts_into) {
+  const VirtualFilesystem filesystem =
+      filesystem_of({"/a/b.txt", "/a-b.txt", "/e.txt"}, {"/a"});
+
+  EXPECT_EQ(walk(filesystem, AbsPath("/")),
+            (std::vector<std::string>{"/a", "/a/b.txt", "/a-b.txt", "/e.txt"}));
+
+  const auto walker = filesystem.file_walker(AbsPath("/"));
+  walker->flat_next();
+  EXPECT_EQ(walker->path().string(), "/a-b.txt");
+}
+
+TEST(VirtualFilesystem, pop_leaves_the_directory) {
+  const VirtualFilesystem filesystem =
+      filesystem_of({"/a/b.txt", "/a/c.txt", "/e.txt"});
+
+  const auto walker = filesystem.file_walker(AbsPath("/"));
+
+  EXPECT_EQ(walker->path().string(), "/a/b.txt");
+  walker->pop();
+  EXPECT_EQ(walker->path().string(), "/e.txt");
+}
+
+TEST(VirtualFilesystem, pop_at_depth_zero_ends_the_walk) {
+  const VirtualFilesystem filesystem = filesystem_of({"/a.txt", "/b.txt"});
+
+  const auto walker = filesystem.file_walker(AbsPath("/"));
+
+  EXPECT_EQ(walker->depth(), 0);
+  walker->pop();
+  EXPECT_TRUE(walker->end());
+}
+
+TEST(VirtualFilesystem, an_intermediate_directory_is_a_directory) {
+  const VirtualFilesystem filesystem = filesystem_of({"/a/c/d.txt"});
+
+  EXPECT_TRUE(filesystem.exists(AbsPath("/")));
+  EXPECT_TRUE(filesystem.is_directory(AbsPath("/")));
+  EXPECT_TRUE(filesystem.exists(AbsPath("/a")));
+  EXPECT_TRUE(filesystem.is_directory(AbsPath("/a")));
+  EXPECT_TRUE(filesystem.exists(AbsPath("/a/c")));
+  EXPECT_TRUE(filesystem.is_directory(AbsPath("/a/c")));
+
+  EXPECT_FALSE(filesystem.is_file(AbsPath("/a")));
+  EXPECT_FALSE(filesystem.exists(AbsPath("/b")));
+  EXPECT_FALSE(filesystem.is_directory(AbsPath("/a/c/d.txt")));
+}

--- a/test/src/internal/common/filesystem_test.cpp
+++ b/test/src/internal/common/filesystem_test.cpp
@@ -79,8 +79,7 @@ TEST(VirtualFilesystem, flat_next_skips_the_subtree_and_terminates) {
   EXPECT_TRUE(walker->end());
 }
 
-/// The loop flat_next() exists for; it never terminated while flat_next() did
-/// not advance.
+/// The loop flat_next() exists for; it never terminated before.
 TEST(VirtualFilesystem, flat_next_over_a_directory_skips_what_is_under_it) {
   const VirtualFilesystem filesystem =
       filesystem_of({"/a/b.txt", "/a/c.txt", "/e.txt"}, {"/a"});
@@ -93,8 +92,7 @@ TEST(VirtualFilesystem, flat_next_over_a_directory_skips_what_is_under_it) {
   EXPECT_EQ(walker->path().string(), "/e.txt");
 }
 
-/// "/a-b" sorts between "/a" and "/a/b" by string, so a subtree is only
-/// contiguous in a component-wise order.
+/// "/a-b" sorts between "/a" and "/a/b" by string.
 TEST(VirtualFilesystem, flat_next_skips_a_subtree_a_sibling_sorts_into) {
   const VirtualFilesystem filesystem =
       filesystem_of({"/a/b.txt", "/a-b.txt", "/e.txt"}, {"/a"});
@@ -128,9 +126,8 @@ TEST(VirtualFilesystem, pop_at_depth_zero_ends_the_walk) {
   EXPECT_TRUE(walker->end());
 }
 
-/// An archive names its entries in its own order, and `as_filesystem()`
-/// inserts them in it. A directory that arrives after what it holds is still an
-/// entry of its own, or the walk would not offer it to `flat_next()`.
+/// An archive names its entries in its own order. A directory arriving after
+/// what it holds is still an entry of its own, or `flat_next()` never sees it.
 TEST(VirtualFilesystem,
      a_directory_entry_survives_arriving_after_its_children) {
   VirtualFilesystem filesystem;


### PR DESCRIPTION
🤖 Generated with [Claude Code](https://claude.com/claude-code)

Closes #639.

`VirtualFileWalker::flat_next()`, `pop()` and `depth()` were `// TODO` no-ops — on every document and every archive filesystem, i.e. everything `Document::as_filesystem()` and `Archive::as_filesystem()` hand out, and reachable from every binding. `src/odr/filesystem.hpp` declares them beside `next()` with no distinction, so a caller had no way to know. `flat_next()` was the trap: it did not advance, so the loop it exists for never terminated.

## What they do now

All three follow from the path alone, which is all the flat map holds:

- **`depth()`** — components below the walked root, `0` for an entry sitting directly in it, like `std::filesystem::recursive_directory_iterator`.
- **`flat_next()`** — the next entry that is not under the current one.
- **`pop()`** — leaves the directory the current entry sits in. At depth 0 that is the end, again matching `recursive_directory_iterator`.

Both skips walk past a subtree, which needs the subtree to be contiguous — so the walker's own copy of the map is ordered **component-wise** rather than by string. Ordering the strings alone does not do it: any character below the separator sorts a sibling into the middle of a subtree, `"/a" < "/a-b" < "/a/b"`. There is a test for exactly that shape. The visit order is unchanged for every path set that does not contain one.

## The second half of the issue

The same "only explicit map entries exist" is why `exists()` and `is_directory()` returned `false` for `/` and for `/Configurations2`, while the walker reported `/Configurations2/floater` as a directory. An intermediate directory need not be an entry of its own — a zip may name only its files — so a path that entries sit under is now a directory too, and so is the root. That makes `Filesystem` agree with its own walker.

## Verified

Eight new tests in `test/src/internal/common/filesystem_test.cpp`, built on hand-made `VirtualFilesystem`s (no fixtures), covering each method, the sibling-sorts-into-the-subtree case, and the directory visibility:

```
[==========] 8 tests from VirtualFilesystem ran. (0 ms total)
[  PASSED  ] 8 tests.
```

Full suite: 948 passed, 8 skipped, 1 failed — `odr_public_pdf_opendocument_app_website_pdf`, which fails identically on `main` and is unrelated.