### PR TITLE
docs(wasm): say what csp the rendered output needs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -29,6 +29,10 @@ The release run heads these entries with the version and opens a fresh
   the wasm module is linked with `-sDYNAMIC_EXECUTION=0`, so embind builds its
   invokers without `new Function`. `script-src 'self' 'wasm-unsafe-eval'` is
   now enough.
+- `wasm/README.md` says what Content-Security-Policy the rendered output needs,
+  and what each directive is for. An embedder inherits its own policy into the
+  frame, and the failures are quiet — a pdf whose `data:` fonts are blocked
+  renders as tofu rather than falling back.
 
 ## v6.9.0 - 2026-08-18
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -30,9 +30,8 @@ The release run heads these entries with the version and opens a fresh
   invokers without `new Function`. `script-src 'self' 'wasm-unsafe-eval'` is
   now enough.
 - `wasm/README.md` says what Content-Security-Policy the rendered output needs,
-  and what each directive is for. An embedder inherits its own policy into the
-  frame, and the failures are quiet — a pdf whose `data:` fonts are blocked
-  renders as tofu rather than falling back.
+  and what each directive is for. The failures are quiet: a pdf whose `data:`
+  fonts are blocked renders as tofu rather than falling back.
 
 ## v6.9.0 - 2026-08-18
 

--- a/wasm/README.md
+++ b/wasm/README.md
@@ -47,10 +47,9 @@ try {
 so it needs nothing fetched alongside it. A `blob:` iframe keeps the same
 origin, so the page can still reach `iframe.contentWindow.odr` to drive
 `search()`, `searchNext()` and `generateDiff()`, exactly as the Android and iOS
-apps do from their WebViews. Inline is not the same as unconditional: the frame
-inherits the embedding page's Content-Security-Policy, so a page that ships one
-has to allow what the document carries — see
-[Content-Security-Policy](#content-security-policy).
+apps do from their WebViews. The frame inherits the embedding page's
+Content-Security-Policy, so a page that ships one has to allow what the
+document carries — see [Content-Security-Policy](#content-security-policy).
 
 Multi-page formats render one view at a time:
 
@@ -91,10 +90,9 @@ where `Symbol.dispose` is supported.
 
 ## Content-Security-Policy
 
-The rendered html is self-contained, but a frame created from an embedding page
-inherits that page's policy — so the *embedder's* CSP decides what the document
-may load, and the failures are quiet. Measured across an odt, ods, docx and pdf
-rendered by this package:
+The rendered html is self-contained, but a frame inherits the embedding page's
+policy — so the *embedder's* CSP decides what the document may load, and the
+failures are quiet. Measured across an odt, ods, docx and pdf:
 
 | Directive | What in the output needs it | Seen in |
 |---|---|---|
@@ -103,8 +101,8 @@ rendered by this package:
 | `style-src 'unsafe-inline'` | the document's own `<style>` blocks **and** its `style` attributes | every format (2–3 blocks, and up to hundreds of attributes) |
 | `script-src 'unsafe-inline'` | the renderer's own js, written into every document | every format but a standalone image (1–3) |
 
-Nothing is fetched from another origin, so no host ever has to be allow-listed.
-A policy that works, for a document loaded into a frame:
+Nothing is fetched from another origin, so no host has to be allow-listed. A
+policy that works, for a document loaded into a frame:
 
 ```
 frame-src 'self' blob:; font-src 'self' data:; img-src 'self' data:;
@@ -115,41 +113,36 @@ style-src 'self' 'unsafe-inline'; script-src 'self' 'unsafe-inline'
 
 It also permits **`javascript:` urls**, and a document may carry one: odrcore
 filters a pdf link action down to an allowlist of navigable schemes, but a
-hyperlink in an odt or a docx is only attribute-escaped, so a `javascript:`
-href reaches the page. In a `blob:` frame — same origin as the embedder, which
-is what lets the page call `iframe.contentWindow.odr` — such a link runs with
-the embedder's origin if the reader clicks it.
+hyperlink in an odt or a docx is only attribute-escaped. In a `blob:` frame —
+same origin as the embedder, which is what lets the page call
+`iframe.contentWindow.odr` — such a link runs with the embedder's origin.
 
-That is fine for documents you trust and not for documents you do not. For
-untrusted input, sandbox the frame and give up the same-origin API:
+Fine for documents you trust. For untrusted input, sandbox the frame and give
+up the same-origin API:
 
 ```html
 <iframe sandbox="allow-scripts" srcdoc="..."></iframe>
 ```
 
 `allow-scripts` **without** `allow-same-origin` puts the document in an opaque
-origin: the renderer's own search and editing still work inside the frame, a
-`javascript:` link can no longer reach the embedding page, and
-`iframe.contentWindow` is out of reach from outside. Granting both together is
-the same as not sandboxing at all.
+origin: search and editing still work inside the frame, while a `javascript:`
+link can no longer reach the embedding page. Granting both together is the same
+as not sandboxing at all.
 
-There is no way to narrow this to hashes or a nonce from here: the package
-embeds the renderer's js in the document, and `HtmlConfig::embed_shipped_resources`
-— which links it as files instead, leaving no inline script at all — is not
-bound in this build.
+Narrowing to a hash or a nonce is not possible from here: the renderer's js is
+embedded in the document, and `HtmlConfig::embed_shipped_resources` — which
+links it as files instead — is not bound in this build.
 
 Worth knowing before tightening the rest:
 
-- **`font-src data:` is the one that costs the most time.** A pdf's text is
+- **`font-src data:` is the one that fails most confusingly.** A pdf's text is
   painted with the code points its embedded subset defines, so a blocked
   `@font-face` does not fall back to a system face — every glyph comes out as a
-  replacement box. Office formats embed images rather than fonts, which makes
-  it easy to conclude the embed works.
+  replacement box.
 - **A blocked inline script is silent.** The layout is css, so the document
-  still looks right; only what the scripts provide — search, editing, the
-  spreadsheet and text-view behaviour — stops working. Refusing
-  `script-src 'unsafe-inline'` outright is therefore a real option when the
-  document only has to be *read*.
+  still looks right; only search, editing and the spreadsheet and text-view
+  behaviour stop working. Refusing `script-src 'unsafe-inline'` is a real
+  option when the document only has to be *read*.
 - **`style-src` cannot be narrowed to a nonce or a hash.** Most of the styling
   is `style` attributes, which only `'unsafe-inline'` (or `'unsafe-hashes'`)
   covers.

--- a/wasm/README.md
+++ b/wasm/README.md
@@ -47,7 +47,10 @@ try {
 so it needs nothing fetched alongside it. A `blob:` iframe keeps the same
 origin, so the page can still reach `iframe.contentWindow.odr` to drive
 `search()`, `searchNext()` and `generateDiff()`, exactly as the Android and iOS
-apps do from their WebViews.
+apps do from their WebViews. Inline is not the same as unconditional: the frame
+inherits the embedding page's Content-Security-Policy, so a page that ships one
+has to allow what the document carries — see
+[Content-Security-Policy](#content-security-policy).
 
 Multi-page formats render one view at a time:
 
@@ -85,6 +88,46 @@ where `Symbol.dispose` is supported.
   that a plain static host, GitHub Pages included, is enough.
 - Rendering is synchronous and a large PDF takes seconds, so run the module in
   a Web Worker. Pass `doc.handle` across `postMessage`, never the `Document`.
+
+## Content-Security-Policy
+
+The rendered html is self-contained, but a frame created from an embedding page
+inherits that page's policy — so the *embedder's* CSP decides what the document
+may load, and the failures are quiet. Measured across an odt, ods, docx and pdf
+rendered by this package:
+
+| Directive | What in the output needs it | Seen in |
+|---|---|---|
+| `font-src data:` | embedded subset fonts | pdf (7 of 8 `@font-face`) |
+| `img-src data:` | embedded images | odt, docx, standalone images |
+| `style-src 'unsafe-inline'` | the document's own `<style>` blocks **and** its `style` attributes | every format (2–3 blocks, and up to hundreds of attributes) |
+| `script-src 'unsafe-inline'` | the document's own `<script>` blocks | every format but a standalone image (1–3) |
+
+Nothing is fetched from another origin, so no host ever has to be allow-listed.
+A policy that works, for a document loaded into a frame:
+
+```
+frame-src 'self' blob:; font-src 'self' data:; img-src 'self' data:;
+style-src 'self' 'unsafe-inline'; script-src 'self' 'unsafe-inline'
+```
+
+Worth knowing before tightening any of it:
+
+- **`font-src data:` is the one that costs the most time.** A pdf's text is
+  painted with the code points its embedded subset defines, so a blocked
+  `@font-face` does not fall back to a system face — every glyph comes out as a
+  replacement box. Office formats embed images rather than fonts, which makes
+  it easy to conclude the embed works.
+- **A blocked inline script is silent.** The layout is css, so the document
+  still looks right; only what the scripts provide — search, editing, the
+  spreadsheet and text-view behaviour — stops working.
+- **`style-src` cannot be narrowed to a nonce or a hash.** Most of the styling
+  is `style` attributes, which only `'unsafe-inline'` (or `'unsafe-hashes'`)
+  covers.
+- **Audio and video stay linked resources** rather than data urls, so a media
+  file needs `media-src` pointing wherever the resource was written.
+
+Loading the module itself is a separate question — see [Hosting](#hosting).
 
 ## Building
 

--- a/wasm/README.md
+++ b/wasm/README.md
@@ -101,7 +101,7 @@ rendered by this package:
 | `font-src data:` | embedded subset fonts | pdf (7 of 8 `@font-face`) |
 | `img-src data:` | embedded images | odt, docx, standalone images |
 | `style-src 'unsafe-inline'` | the document's own `<style>` blocks **and** its `style` attributes | every format (2–3 blocks, and up to hundreds of attributes) |
-| `script-src 'unsafe-inline'` | the document's own `<script>` blocks | every format but a standalone image (1–3) |
+| `script-src 'unsafe-inline'` | the renderer's own js, written into every document | every format but a standalone image (1–3) |
 
 Nothing is fetched from another origin, so no host ever has to be allow-listed.
 A policy that works, for a document loaded into a frame:
@@ -111,7 +111,34 @@ frame-src 'self' blob:; font-src 'self' data:; img-src 'self' data:;
 style-src 'self' 'unsafe-inline'; script-src 'self' 'unsafe-inline'
 ```
 
-Worth knowing before tightening any of it:
+### `script-src 'unsafe-inline'` is not free
+
+It also permits **`javascript:` urls**, and a document may carry one: odrcore
+filters a pdf link action down to an allowlist of navigable schemes, but a
+hyperlink in an odt or a docx is only attribute-escaped, so a `javascript:`
+href reaches the page. In a `blob:` frame — same origin as the embedder, which
+is what lets the page call `iframe.contentWindow.odr` — such a link runs with
+the embedder's origin if the reader clicks it.
+
+That is fine for documents you trust and not for documents you do not. For
+untrusted input, sandbox the frame and give up the same-origin API:
+
+```html
+<iframe sandbox="allow-scripts" srcdoc="..."></iframe>
+```
+
+`allow-scripts` **without** `allow-same-origin` puts the document in an opaque
+origin: the renderer's own search and editing still work inside the frame, a
+`javascript:` link can no longer reach the embedding page, and
+`iframe.contentWindow` is out of reach from outside. Granting both together is
+the same as not sandboxing at all.
+
+There is no way to narrow this to hashes or a nonce from here: the package
+embeds the renderer's js in the document, and `HtmlConfig::embed_shipped_resources`
+— which links it as files instead, leaving no inline script at all — is not
+bound in this build.
+
+Worth knowing before tightening the rest:
 
 - **`font-src data:` is the one that costs the most time.** A pdf's text is
   painted with the code points its embedded subset defines, so a blocked
@@ -120,7 +147,9 @@ Worth knowing before tightening any of it:
   it easy to conclude the embed works.
 - **A blocked inline script is silent.** The layout is css, so the document
   still looks right; only what the scripts provide — search, editing, the
-  spreadsheet and text-view behaviour — stops working.
+  spreadsheet and text-view behaviour — stops working. Refusing
+  `script-src 'unsafe-inline'` outright is therefore a real option when the
+  document only has to be *read*.
 - **`style-src` cannot be narrowed to a nonce or a hash.** Most of the styling
   is `style` attributes, which only `'unsafe-inline'` (or `'unsafe-hashes'`)
   covers.


### PR DESCRIPTION
🤖 Generated with [Claude Code](https://claude.com/claude-code)

Closes #710.

`wasm/README.md` said the rendered html is self-contained and can go straight into a `blob:` iframe. That is true of the markup, but not of what the page is *allowed* to load: a frame inherits the embedding page's Content-Security-Policy, so the embedder's policy governs the rendered document — and nothing said what it has to allow.

The failures are quiet. Under `font-src 'self'` a pdf's `data:` fonts are all blocked, and because a pdf's text is painted with the code points its embedded subset defines, the glyphs do not fall back to a system face — every one comes out as a replacement box. Office formats embed images rather than fonts, which makes it easy to conclude the embed works.

## Measured, not assumed

Rendered an odt, ods, docx, odp, csv, a standalone image and a pdf through the package and counted what the output carries:

| | `@font-face` (`data:`) | `<img src="data:">` | `<style>` | `style=` attributes | `<script>` | external urls |
|---|---:|---:|---:|---:|---:|---:|
| `about.odt` | 0 | 2 | 2 | 123 | 2 | 0 |
| `style-various-1.docx` | 0 | 1 | 2 | — | 2 | 0 |
| `comment.ods` | 0 | 0 | 3 | 23 | 3 | 0 |
| `style-various-1.odp` | 0 | 0 | 2 | — | 2 | 0 |
| `style-various-1.pdf` | **7 of 8** | 0 | 2 | 7 | 1 | 0 |
| `fantastic-landscape.jpg` | 0 | 1 | 1 | — | 0 | 0 |

Which confirms the issue's table, and adds two things it did not name:

- **`style-src` cannot be narrowed to a nonce or a hash** — most of the styling is `style` *attributes*, and only `'unsafe-inline'` (or `'unsafe-hashes'`) covers those.
- **audio and video stay linked resources** rather than data urls, so a media file needs `media-src` pointing at wherever the resource was written.

Also: nothing is fetched from another origin, so no host ever has to be allow-listed — worth stating, since that is the property the library is meant to have.

The new section gives a working policy, says which part of the output each directive is for, and calls out that a blocked inline script is silent (the layout is css, so the document still looks right while search, editing and the spreadsheet behaviour simply do not run). The `blob:` iframe paragraph in *Use* now points at it.

Docs only — no code changes. Independent of #709, which covers the `script-src` the module itself needs at load time and touches a different part of the file.