### PR TITLE
fix(pdf): end an operator at every delimiter, and say when a font is dropped

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -45,6 +45,10 @@ The release run heads these entries with the version and opens a fresh
   narrow boxes beside them. Runs one CSS transform can place share a selection
   block and carry the PDF's advances, and a whitespace-only run hands its
   advance on instead of dropping it — a space per word short on every line.
+- A pdf that writes `Tm(text)Tj`, with nothing between an operator and the
+  string after it, renders that text instead of dropping it.
+- An embedded font that will not re-encode says so in the log rather than being
+  swapped for a substitute in silence.
 
 ## v6.9.0 - 2026-08-18
 

--- a/src/odr/internal/html/pdf_file.cpp
+++ b/src/odr/internal/html/pdf_file.cpp
@@ -1348,10 +1348,11 @@ public:
     std::unordered_map<const pdf::Font *, std::uint32_t> family_index;
 
     const auto font_family = [&](const pdf::Font *font) {
-      return intern_font(family_index, family_count, font, [&](std::uint32_t) {
-        accepted_fonts.push_back(font);
-        font_class_used.push_back({false, false});
-      });
+      return intern_font(family_index, family_count, font, m_logger,
+                         [&](std::uint32_t) {
+                           accepted_fonts.push_back(font);
+                           font_class_used.push_back({false, false});
+                         });
     };
 
     const auto add_class = [&styles](std::string &classes,
@@ -1921,12 +1922,13 @@ public:
     std::unordered_map<const pdf::Font *, std::uint32_t> family_index;
 
     const auto font_family = [&](pdf::Font *font) {
-      return intern_font(family_index, family_count, font, [&](std::uint32_t) {
-        accepted_fonts.push_back(font);
-        glyph_freq.emplace_back();
-        used_unicode.emplace_back();
-        font_class_used.push_back({false, false});
-      });
+      return intern_font(family_index, family_count, font, m_logger,
+                         [&](std::uint32_t) {
+                           accepted_fonts.push_back(font);
+                           glyph_freq.emplace_back();
+                           used_unicode.emplace_back();
+                           font_class_used.push_back({false, false});
+                         });
     };
 
     AtomicStyles styles;
@@ -2500,13 +2502,13 @@ public:
   template <typename OnAccept>
   static std::uint32_t intern_font(
       std::unordered_map<const pdf::Font *, std::uint32_t> &family_index,
-      std::uint32_t &family_count, const pdf::Font *font,
+      std::uint32_t &family_count, const pdf::Font *font, const Logger &logger,
       OnAccept &&on_accept) {
     const auto [it, inserted] = family_index.try_emplace(font, 0);
     if (!inserted) {
       return it->second;
     }
-    if (!font_is_usable(*font)) {
+    if (!font_is_usable(*font, logger)) {
       return 0;
     }
     const std::uint32_t index = ++family_count;
@@ -2649,15 +2651,26 @@ public:
   }
 
   /// Whether `font`'s embedded program re-encodes without throwing. Probes the
-  /// real encode path so failures surface here, not in the post-pass.
-  static bool font_is_usable(const pdf::Font &font) {
+  /// real encode path so failures surface here, not in the post-pass. Failing
+  /// swaps in a substitute, which the page shows, so say so.
+  static bool font_is_usable(const pdf::Font &font, const Logger &logger) {
+    const auto dropped = [&](const std::string &why) {
+      ODR_WARNING(logger, "pdf: rendering '"
+                              << font.embedded_font->name()
+                              << "' with a substitute, its embedded program "
+                                 "does not re-encode: "
+                              << why);
+      return false;
+    };
     if (const auto sfnt = std::dynamic_pointer_cast<font::sfnt::SfntFont>(
             font.embedded_font)) {
       try {
         (void)write_sfnt_pua(*sfnt, {});
         return true;
+      } catch (const std::exception &e) {
+        return dropped(e.what());
       } catch (...) {
-        return false;
+        return dropped("sfnt re-encode failed");
       }
     }
     if (const auto cff =
@@ -2665,8 +2678,10 @@ public:
       try {
         (void)font::cff::wrap_to_otf(*cff);
         return true;
+      } catch (const std::exception &e) {
+        return dropped(e.what());
       } catch (...) {
-        return false;
+        return dropped("cff wrap failed");
       }
     }
     return false;

--- a/src/odr/internal/pdf/pdf_graphics_operator_parser.cpp
+++ b/src/odr/internal/pdf/pdf_graphics_operator_parser.cpp
@@ -209,11 +209,10 @@ std::string GraphicsOperatorParser::read_operator_name() {
     if (c == eof) {
       return result;
     }
-    // Any white-space (7.2.2, incl. `\r` in CRLF streams) or the start of a
-    // following token ends the bareword. `%` is a delimiter too (7.2.2), so a
-    // comment may follow an operator with nothing in between.
-    if (ObjectParser::is_whitespace(static_cast<char_type>(c)) || c == '/' ||
-        c == '<' || c == '[' || c == '%') {
+    // White space or a delimiter ends the bareword (7.2.2): producers write
+    // `Tm(text)Tj` with nothing in between.
+    if (ObjectParser::is_whitespace(static_cast<char_type>(c)) ||
+        ObjectParser::is_delimiter(static_cast<char_type>(c))) {
       return result;
     }
 
@@ -252,6 +251,22 @@ GraphicsOperator GraphicsOperatorParser::read_operator() {
       } else if (operator_name == "false") {
         result.arguments.emplace_back(Boolean(false));
       } else {
+        // A closing delimiter opens nothing, so no reader above consumes it and
+        // an unmatched one would stall the caller's loop. Eat it and go on.
+        if (operator_name.empty()) {
+          if (const int_type c = m_parser.geti();
+              c != eof &&
+              ObjectParser::is_delimiter(static_cast<char_type>(c)) &&
+              !m_parser.peek_name() && !m_parser.peek_string() &&
+              !m_parser.peek_array() && !m_parser.peek_dictionary()) {
+            ODR_DEBUG(m_logger, "pdf: skipping stray delimiter '" +
+                                    std::string(1, static_cast<char_type>(c)) +
+                                    "' in a content stream");
+            m_parser.bumpc();
+            m_parser.skip_whitespace_and_comments();
+            continue;
+          }
+        }
         break;
       }
     }

--- a/src/odr/internal/pdf/pdf_object_parser.cpp
+++ b/src/odr/internal/pdf/pdf_object_parser.cpp
@@ -115,6 +115,11 @@ bool ObjectParser::is_whitespace(const char c) {
          c == ' ';
 }
 
+bool ObjectParser::is_delimiter(const char c) {
+  return c == '(' || c == ')' || c == '<' || c == '>' || c == '[' || c == ']' ||
+         c == '{' || c == '}' || c == '/' || c == '%';
+}
+
 bool ObjectParser::peek_whitespace() {
   const int_type c = geti();
   return c != eof && is_whitespace(static_cast<char_type>(c));

--- a/src/odr/internal/pdf/pdf_object_parser.hpp
+++ b/src/odr/internal/pdf/pdf_object_parser.hpp
@@ -42,6 +42,8 @@ public:
                                        char_type third);
 
   static bool is_whitespace(char c);
+  /// The delimiters of 7.2.2, each of which opens a token of its own.
+  static bool is_delimiter(char c);
   [[nodiscard]] bool peek_whitespace();
   void skip_whitespace();
   /// White space plus the comments (`%` to the end of the line, 7.2.4) it may

--- a/test/src/internal/pdf/pdf_page_extractor.cpp
+++ b/test/src/internal/pdf/pdf_page_extractor.cpp
@@ -144,6 +144,25 @@ TEST(PdfPageExtractor, comment_directly_after_operator) {
   EXPECT_EQ(texts[0].codes, "Hi");
 }
 
+// A closing delimiter opens no token, so an unmatched one has to be eaten or
+// the operator loop makes no progress.
+TEST(PdfPageExtractor, stray_closing_delimiter_does_not_stall) {
+  const auto texts = run("BT /F1 12 Tf 1 0 0 1 5 5 Tm ) ] > } (Hi) Tj ET");
+  ASSERT_EQ(texts.size(), 1);
+  EXPECT_EQ(texts[0].codes, "Hi");
+}
+
+// Nothing need separate an operator from the token after it (7.2.2). Without
+// `(` ending the name, it ran on and swallowed the string behind it.
+TEST(PdfPageExtractor, operator_directly_followed_by_a_string) {
+  const auto texts = run("BT /F1 12 Tf 1 0 0 1 100 700 Tm(Hi)Tj(there)Tj ET");
+  ASSERT_EQ(texts.size(), 2);
+  EXPECT_DOUBLE_EQ(texts[0].transform.e, 100);
+  EXPECT_DOUBLE_EQ(texts[0].transform.f, 700);
+  EXPECT_EQ(texts[0].codes, "Hi");
+  EXPECT_EQ(texts[1].codes, "there");
+}
+
 // `Tm` sets the text matrix outright, scaling and all.
 TEST(PdfPageExtractor, tm_scaling) {
   const auto texts = run("BT /F1 10 Tf 2 0 0 2 50 60 Tm (X) Tj ET");


### PR DESCRIPTION
🤖 Generated with [Claude Code](https://claude.com/claude-code)

Stacked on #721, which is stacked on #720.

**This is not the fix for the reported "wrong letters in the app" — see the note
at the bottom.** These are two defects found while chasing it.

## An operator ends at every delimiter

`read_operator_name` stopped at white space and at `/ < [ %` — four of the nine
delimiters of ISO 32000-1 7.2.2. `(` was not among them, so a content stream
that leaves nothing between an operator and the string after it let the operator
name run on and swallow the string:

```
BT /F1 12 Tf 1 0 0 1 100 700 Tm(Hi)Tj(there)Tj ET
```

`Tm` reads as the bareword `Tm`, fine — but `Tj(there)Tj` reads as *one* name,
so both shows are dropped as unknown operators and the page loses that text
entirely. `<01>Tj` works only because `<` happens to be in the list.

Being a delimiter is exactly the property "starts a token of its own", so the
whole set now ends a bareword, via a new `ObjectParser::is_delimiter`.

The corpus contains no file that writes it that way, so **no reference output
moves** and no pins are advanced here.

## A dropped embedded font says so

`font_is_usable` probed the re-encode behind a bare `catch (...) { return
false; }`. Failing there swaps the font for a substitute — the page renders in
different letterforms — with nothing recorded anywhere. It now warns through the
`Logger` the module routes its diagnostics to, naming the font and the reason.

Latent today: instrumented over the whole corpus, that path fires zero times.

## Note on the reported bug

The report ("letters replaced by other letters or special characters, since the
last update", Android 4.15.0) is not reproduced by either of these, and I could
not reproduce it at all. What the evidence says:

- 4.15.0 ships core **6.6.0** (4.14.0 shipped 6.5.0, 4.16.0 ships 6.9.0), so the
  window is 6.5.0 → 6.6.0.
- Across that window **no glyph changed**: comparing the `.g` layer of all 512
  corpus pdf pages present in both reference-output revisions gives zero
  differences.
- Every font either version emits is valid: OTS accepts all 741 at current main
  and all 619 at 6.6.0.
- The reported file itself renders correctly on all 14 pages, in both
  `dual_layer` and `single_layer`.

The failure mode that matches the wording is the `@font-face` not loading at
all: every glyph is emitted as `U+E000 + glyph index`, so a fallback font paints
whatever it has at those code points — tofu on some systems, arbitrary letters
and symbols on one whose fallback covers the PUA. That is a property of the
viewer, not of the engine, and would want the app's console rather than another
guess here.