### PR TITLE
test(data): pin the reference output #719 and #724 render

### DIFF
--- a/test/data.cmake
+++ b/test/data.cmake
@@ -17,9 +17,9 @@ odr_test_data(
 odr_test_data(
         PATH "reference-output/odr-public"
         URL "https://github.com/opendocument-app/OpenDocument.test.output.git"
-        REVISION "e400d463fdb45eab82d51e030849ff42c405e4eb")
+        REVISION "d9cb5666399ab5873152953106dce53723fcbced")
 
 odr_test_data(
         PATH "reference-output/odr-private"
         URL "https://github.com/opendocument-app/OpenDocument.test-private.output.git"
-        REVISION "12dc988aea7ff6a8fa43df8db98e1dbc22f55356")
+        REVISION "a1150488e8e2b1ab0d6351373946a6be36858afb")


### PR DESCRIPTION
`#719` and `#724` changed the head of every emitted page — a declared
`--odr-fit`, a print-time zoom pin, and `resources/viewport.js` — but the
reference-output pins were never advanced. CI's compare therefore rendered the
new output against a tree with no `viewport.js` in it, and `txt/lorem
ipsum.txt-dark/text.html` came out different on the macOS runner.

Regenerated both sets from a full `odr_test` run on `1767ba5`. Every hunk is one
of four shapes and nothing else moved:

| change | public | private |
|---|---:|---:|
| `<script src="…/viewport.js">` | 265 | 1175 |
| `<style>:root{--odr-fit:auto}@media print{…}</style>` | 173 | 903 |
| `<style>@media print{…}</style>` | 92 | 272 |
| `img{max-width:calc(100% * var(--odr-zoom,1))}` | 8 | 0 |

No file added or removed. Both trees are byte-identical to a fresh run, and
`resources/viewport.js` is committed alongside so the reference renders what it
now links.

- opendocument-app/OpenDocument.test.output@d9cb566
- opendocument-app/OpenDocument.test-private.output@a115048

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_015d5RcmsA777vwXiuafjx6k