### PR TITLE
fix(html): name a linked ooxml image relative to the document

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,10 @@ The release run heads these entries with the version and opens a fresh
 
 ## Unreleased
 
+- A linked image in a docx or xlsx (`embed_images = false`) is named relative
+  to the document, like odf, so a host serving the html under a mount point
+  resolves it.
+
 ## v6.10.0 - 2026-08-20
 
 - Html views take a zoom from their host: `odr.getZoom()`, `setZoom(value,

--- a/src/odr/internal/html/document_element.cpp
+++ b/src/odr/internal/html/document_element.cpp
@@ -5,6 +5,7 @@
 #include <odr/html.hpp>
 #include <odr/style.hpp>
 
+#include <odr/internal/common/path.hpp>
 #include <odr/internal/common/table_cursor.hpp>
 #include <odr/internal/html/common.hpp>
 #include <odr/internal/html/document_style.hpp>
@@ -498,9 +499,11 @@ void html::translate_image(const Element &element, const WritingState &state) {
   odr::HtmlResource resource;
   HtmlResourceLocation resource_location;
   if (image.is_internal()) {
-    resource =
-        HtmlResource::create(HtmlResourceType::image, "image/jpg", image.href(),
-                             image.href(), image.file(), false, false, true);
+    // the location is resolved against the document, so an engine naming the
+    // image by its absolute path in the container has to lose the root
+    const std::string path = Path(image.href()).make_relative().string();
+    resource = HtmlResource::create(HtmlResourceType::image, "image/jpg", path,
+                                    path, image.file(), false, false, true);
     resource_location =
         state.config().resource_locator(resource, state.config());
   } else {

--- a/test/src/html_test.cpp
+++ b/test/src/html_test.cpp
@@ -7,6 +7,8 @@
 
 #include <odr/exceptions.hpp>
 
+#include <odr/internal/common/path.hpp>
+
 #include <internal/pdf/pdf_test_file_builder.hpp>
 
 #include <test_util.hpp>
@@ -62,6 +64,52 @@ TEST(html, linked_resources_are_served) {
   check(
       DecodedFile(TestData::test_file_path("odr-public/pdf/empty.pdf"), logger),
       "document.html");
+}
+
+// Same for a document resource, which unlike a shipped one is named by the
+// engine: the reference output embeds every image, so nothing else renders the
+// linked form (opendocument-app/OpenDocument.droid#551).
+TEST(html, linked_images_are_served) {
+  const auto logger = Logger::create_stdio("odr-test", LogLevel::verbose);
+
+  const std::string cache_path =
+      (std::filesystem::current_path() / "images").string();
+
+  const auto check = [&](const std::string &path) {
+    const DecodedFile file(TestData::test_file_path(path), logger);
+
+    HtmlConfig config;
+    config.embed_images = false;
+
+    const HtmlService service = html::translate(file, cache_path, config);
+
+    std::ostringstream out;
+    const HtmlResources resources = service.list_views().at(0).write_html(out);
+
+    std::size_t linked = 0;
+    for (const auto &[resource, location] : resources) {
+      if (resource.type() != HtmlResourceType::image ||
+          !resource.is_accessible()) {
+        continue;
+      }
+      ASSERT_TRUE(location.has_value()) << resource.name();
+      ++linked;
+
+      // an absolute location would resolve against the server root rather than
+      // against the document
+      EXPECT_TRUE(Path(*location).relative()) << *location;
+      EXPECT_TRUE(service.exists(*location)) << *location;
+
+      std::ostringstream served;
+      service.write(*location, served);
+      EXPECT_FALSE(served.str().empty()) << *location;
+    }
+    EXPECT_GT(linked, 0) << path;
+  };
+
+  check("odr-public/odt/image-text-wrap.odt");
+  check("odr-public/docx/file-sample_100kB.docx");
+  check("odr-public/xlsx/sample.xlsx");
 }
 
 // The one archive the reference-output suite renders has no directory in it.


### PR DESCRIPTION
🤖 Generated with [Claude Code](https://claude.com/claude-code)

Closes opendocument-app/OpenDocument.droid#551.

Every image in a `.docx` / `.xlsx` renders as the broken-image placeholder when the host links images rather than embedding them. ODF is fine, which is what made it easy to miss.

### Cause

The engines disagree on what an image href is. `odf_document.cpp:935` returns the raw `xlink:href`, which is relative — `Pictures/x.png`. The ooxml ones resolve the relationship into an absolute container path — `ooxml_text_document.cpp:573` joins onto `AbsPath("/word")`, `ooxml_spreadsheet_document.cpp:416` onto the part's directory — and `translate_image` emitted whichever it got.

An absolute location cannot work. `resource_at` matches it against the request path by exact string, and the http route strips the leading `/`, so `/word/media/image1.jpeg` served under `/file/<prefix>/` misses either way. `bring_offline` is worse than a 404: it does `Path(output).join(RelPath(*location))` and `RelPath` throws on an absolute string, so `translate --embed-images=false` on a docx fails before writing anything.

Neither knob the downstream issue proposed helps. `relative_resource_paths` gates its rebase on `resource.is_shipped()`, and `HttpServer::prefix_pattern` is `([a-zA-Z0-9_-]+)`, so there is no root to mount at.

### Fix

Make the location relative where the resource is built, once, for every engine:

```cpp
const std::string path = Path(image.href()).make_relative().string();
```

`image_file()` and `image_is_internal()` already `make_absolute()` the href, so the engines stay as they are and `Image::href()` keeps its meaning.

### Tests

`html.linked_images_are_served` renders an odt, a docx and an xlsx with `embed_images = false` and asserts each image location is relative, exists on the service, and serves bytes. It fails on both ooxml paths without the change.

The reference output renders with `embed_images = true`, so it never exercised the linked form — that is the gap this closes. Its docx / xlsx / odt output is byte-identical after the change, since an embedded image carries no location.

### Not in scope

Two neighbours found while confirming this, each worth its own issue:

- `ooxml_text_parser.cpp:226` maps every `a:graphicData` to `ElementType::image`, so a chart, SmartArt or embedded OLE becomes an image with an empty href — the `src=""` seen in a handful of reference documents. `file-sample_100kB.docx` is one: a picture and a chart, and the chart is the empty one.
- `document_element.cpp:508` creates a non-internal image resource with `is_external = false`.
