### PR TITLE
fix(open): honour the requested type for every document container

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,9 @@ The release run heads these entries with the version and opens a fresh
 
 ## Unreleased
 
+- `open(file, as)` no longer returns a container holding another document type
+  as the type that was asked for. An encrypted ooxml still opens as whichever
+  was asked - it names no inner type until it is decrypted.
 - `.fodt`, `.fodp`, `.fods` and `.fodg` open, render, edit and save like their
   packaged counterparts instead of decoding as an xml source view. An
   `office:binary-data` image now decodes in a package too.

--- a/src/odr/internal/open_strategy.cpp
+++ b/src/odr/internal/open_strategy.cpp
@@ -47,6 +47,14 @@ template <typename T> auto priority_comparator(const std::vector<T> &priority) {
   };
 }
 
+/// Whether @p file is the ooxml that was asked for. An encrypted one names no
+/// inner type until it is decrypted, so it answers for whichever was asked.
+bool is_the_requested_ooxml(const ooxml::OfficeOpenXmlFile &file,
+                            const FileType as) {
+  return file.file_type() == as ||
+         file.file_type() == FileType::office_open_xml_encrypted;
+}
+
 /// Decodes @p file as exactly @p as, or throws the format's "not a ..."
 /// exception (@ref UnsupportedFileType for a type we cannot decode at all).
 std::unique_ptr<abstract::DecodedFile>
@@ -60,7 +68,11 @@ open_file_as(const std::shared_ptr<abstract::File> &file, const FileType as,
     try {
       auto zip_file = std::make_unique<zip::ZipFile>(file);
       auto filesystem = zip_file->archive()->as_filesystem();
-      return std::make_unique<odf::OpenDocumentFile>(filesystem);
+      auto odf_file = std::make_unique<odf::OpenDocumentFile>(filesystem);
+      if (odf_file->file_type() == as) {
+        return odf_file;
+      }
+      ODR_VERBOSE(logger, "odf is a different document type");
     } catch (...) {
       ODR_VERBOSE(logger, "failed to open as odf");
     }
@@ -87,14 +99,22 @@ open_file_as(const std::shared_ptr<abstract::File> &file, const FileType as,
     try {
       auto zip_file = std::make_unique<zip::ZipFile>(file);
       auto filesystem = zip_file->archive()->as_filesystem();
-      return std::make_unique<ooxml::OfficeOpenXmlFile>(filesystem);
+      auto ooxml_file = std::make_unique<ooxml::OfficeOpenXmlFile>(filesystem);
+      if (is_the_requested_ooxml(*ooxml_file, as)) {
+        return ooxml_file;
+      }
+      ODR_VERBOSE(logger, "ooxml zip is a different document type");
     } catch (...) {
       ODR_VERBOSE(logger, "failed to open as ooxml zip");
     }
     try {
       auto cfb_file = std::make_unique<cfb::CfbFile>(file);
       auto filesystem = cfb_file->archive()->as_filesystem();
-      return std::make_unique<ooxml::OfficeOpenXmlFile>(filesystem);
+      auto ooxml_file = std::make_unique<ooxml::OfficeOpenXmlFile>(filesystem);
+      if (is_the_requested_ooxml(*ooxml_file, as)) {
+        return ooxml_file;
+      }
+      ODR_VERBOSE(logger, "ooxml cfb is a different document type");
     } catch (...) {
       ODR_VERBOSE(logger, "failed to open as ooxml cfb");
     }
@@ -108,7 +128,12 @@ open_file_as(const std::shared_ptr<abstract::File> &file, const FileType as,
     try {
       auto cfb_file = std::make_unique<cfb::CfbFile>(file);
       auto filesystem = cfb_file->archive()->as_filesystem();
-      return std::make_unique<oldms::LegacyMicrosoftFile>(filesystem);
+      auto oldms_file =
+          std::make_unique<oldms::LegacyMicrosoftFile>(filesystem);
+      if (oldms_file->file_type() == as) {
+        return oldms_file;
+      }
+      ODR_VERBOSE(logger, "legacy ms is a different document type");
     } catch (...) {
       ODR_VERBOSE(logger, "failed to open as legacy ms");
     }

--- a/test/src/file_test.cpp
+++ b/test/src/file_test.cpp
@@ -28,6 +28,62 @@ TEST(File, from_disk_matches_the_path_constructor) {
   EXPECT_EQ(file.size(), File(path).size());
 }
 
+/// `open(file, as)` decodes as exactly what it is asked for. A container
+/// names its own document type, and `as` is a claim about what is inside it -
+/// so a claim the container contradicts is no reading of the file at all.
+TEST(File, opening_as_the_wrong_document_type_throws) {
+  const struct {
+    const char *path;
+    FileType is;
+    FileType is_not;
+  } cases[]{
+      {"odr-public/odt/about.odt", FileType::opendocument_text,
+       FileType::opendocument_graphics},
+      {"odr-public/docx/file-sample_100kB.docx",
+       FileType::office_open_xml_document,
+       FileType::office_open_xml_presentation},
+      {"odr-public/doc/file-sample_100kB.doc", FileType::legacy_word_document,
+       FileType::legacy_excel_worksheets},
+  };
+
+  for (const auto &[path, is, is_not] : cases) {
+    const std::string file_path = TestData::test_file_path(path);
+
+    EXPECT_EQ(DecodedFile(file_path, is).file_type(), is) << path;
+    EXPECT_THROW(std::ignore = DecodedFile(file_path, is_not), UnknownFileType)
+        << path;
+  }
+}
+
+/// The one reading that is not its own container's: an encrypted ooxml names
+/// no inner type until it is decrypted, so it stands in for the one asked for.
+TEST(File, an_encrypted_ooxml_opens_as_the_type_asked_for) {
+  const DecodedFile file(
+      TestData::test_file_path("odr-public/docx/encrypted.docx"),
+      FileType::office_open_xml_document);
+
+  EXPECT_EQ(file.file_type(), FileType::office_open_xml_encrypted);
+  EXPECT_TRUE(file.password_encrypted());
+}
+
+/// The same claim about the same document in its other encoding answers the
+/// same way - which is what this fix is about.
+TEST(File, a_flat_document_and_a_package_answer_a_wrong_type_alike) {
+  const std::string flat =
+      R"(<?xml version="1.0" encoding="UTF-8"?>)"
+      R"(<office:document office:mimetype=")"
+      R"(application/vnd.oasis.opendocument.text">)"
+      R"(<office:body><office:text/></office:body></office:document>)";
+
+  EXPECT_THROW(std::ignore = DecodedFile(File::from_memory(flat),
+                                         FileType::opendocument_graphics),
+               UnknownFileType);
+  EXPECT_THROW(std::ignore = DecodedFile(
+                   TestData::test_file_path("odr-public/odt/about.odt"),
+                   FileType::opendocument_graphics),
+               UnknownFileType);
+}
+
 TEST(File, from_memory_holds_its_bytes) {
   const File file = File::from_memory("hello");
 


### PR DESCRIPTION
🤖 Generated with [Claude Code](https://claude.com/claude-code)

Stacked on #731 — review it after that one, and the base will retarget to `main` when #731 merges.

## Why

A local review of #731 flagged that its new flat-odf branch is the only one in `open_file_as` that checks what it decoded against what was asked for:

```cpp
open(packaged_odt_bytes, FileType::opendocument_graphics)  // -> a text document
open(flat_odt_bytes,     FileType::opendocument_graphics)  // -> throws
```

Same document, two encodings, two answers. The looseness is older than #731 — it sits in the odf, ooxml and legacy-MS branches alike — but #731 is what makes it visible, so this fixes all three rather than relaxing the new one. `open_file_as` already documents itself as decoding "as exactly `as`", and the probing path in `open_file` treats a throw as "not this type, try the next", so tightening costs it nothing and makes probing more accurate.

## What

- The odf, ooxml (zip and cfb) and legacy-MS branches check `file_type() == as` before returning, mirroring what the flat branch does.
- **One exception, deliberate:** an encrypted ooxml names no inner type until it is decrypted, so `is_the_requested_ooxml` lets it answer for whichever type was asked for. `html_output_test` relies on this for every encrypted docx and xlsx in the reference set — the first cut without it failed exactly those two.

## Tests

`File.opening_as_the_wrong_document_type_throws` covers odt/docx/doc, `File.a_flat_document_and_a_package_answer_a_wrong_type_alike` pins the asymmetry itself, and `File.an_encrypted_ooxml_opens_as_the_type_asked_for` pins the exception. All three wrong-type cases were verified to fail against the branch without the fix.

Full suite: **1005 passed, 0 failed** (reference output included).