### PR TITLE
refactor(pdf, font): take read-only array parameters as spans

### DIFF
--- a/src/odr/internal/font/cff_builder.cpp
+++ b/src/odr/internal/font/cff_builder.cpp
@@ -94,7 +94,7 @@ std::string build_index(const std::vector<std::string> &members) {
 namespace odr::internal::font {
 
 std::string cff::build_cff(const std::string_view name,
-                           const std::vector<BuilderGlyph> &glyphs,
+                           const std::span<const BuilderGlyph> glyphs,
                            const double default_width,
                            const double nominal_width, const FontBBox bbox) {
   // CharStrings INDEX (one Type2 charstring per glyph).

--- a/src/odr/internal/font/cff_builder.hpp
+++ b/src/odr/internal/font/cff_builder.hpp
@@ -2,9 +2,9 @@
 
 #include <odr/font.hpp>
 
+#include <span>
 #include <string>
 #include <string_view>
-#include <vector>
 
 namespace odr::internal::font::cff {
 
@@ -28,7 +28,7 @@ struct BuilderGlyph {
 /// default); a non-default matrix is a follow-up. Top DICT offsets use the
 /// fixed-width 5-byte integer form so the layout resolves in a single pass.
 [[nodiscard]] std::string build_cff(std::string_view name,
-                                    const std::vector<BuilderGlyph> &glyphs,
+                                    std::span<const BuilderGlyph> glyphs,
                                     double default_width, double nominal_width,
                                     FontBBox bbox);
 

--- a/src/odr/internal/font/type1_charstring.cpp
+++ b/src/odr/internal/font/type1_charstring.cpp
@@ -90,7 +90,8 @@ void emit_num(std::string &out, const double v) {
 /// `callsubr`), emitting a Type2 charstring.
 class Translator {
 public:
-  explicit Translator(const std::vector<std::string> &subrs) : m_subrs(subrs) {}
+  explicit Translator(const std::span<const std::string> subrs)
+      : m_subrs(subrs) {}
 
   Type2Charstring run(const std::string_view charstring) {
     execute(charstring, 0);
@@ -411,7 +412,7 @@ private:
     double y;
   };
 
-  const std::vector<std::string> &m_subrs;
+  std::span<const std::string> m_subrs;
   std::string m_out;
   std::vector<double> m_stack;
   std::vector<double> m_ps_stack;
@@ -433,8 +434,9 @@ private:
 
 namespace odr::internal::font {
 
-type1::Type2Charstring type1::to_type2(const std::string_view type1,
-                                       const std::vector<std::string> &subrs) {
+type1::Type2Charstring
+type1::to_type2(const std::string_view type1,
+                const std::span<const std::string> subrs) {
   return Translator(subrs).run(type1);
 }
 

--- a/src/odr/internal/font/type1_charstring.hpp
+++ b/src/odr/internal/font/type1_charstring.hpp
@@ -1,9 +1,9 @@
 #pragma once
 
 #include <cstdint>
+#include <span>
 #include <string>
 #include <string_view>
-#include <vector>
 
 namespace odr::internal::font::type1 {
 
@@ -27,6 +27,6 @@ struct Type2Charstring {
 /// quality, not glyph shape), and unknown operators are skipped. Throws
 /// `std::runtime_error` on a charstring that ends mid-operand.
 [[nodiscard]] Type2Charstring to_type2(std::string_view type1,
-                                       const std::vector<std::string> &subrs);
+                                       std::span<const std::string> subrs);
 
 } // namespace odr::internal::font::type1

--- a/src/odr/internal/pdf/pdf_color.cpp
+++ b/src/odr/internal/pdf/pdf_color.cpp
@@ -82,7 +82,7 @@ std::shared_ptr<ColorSpaceDef> space_from_name(const std::string &name,
 } // namespace
 
 std::array<double, 3>
-ColorSpaceDef::to_rgb(const std::vector<double> &c) const {
+ColorSpaceDef::to_rgb(const std::span<const double> c) const {
   const auto at = [&](const std::size_t i) {
     return i < c.size() ? c[i] : 0.0;
   };
@@ -141,7 +141,7 @@ ColorSpaceDef::to_rgb(const std::vector<double> &c) const {
       const double v = clamp01(1 - at(0));
       return {v, v, v};
     }
-    return alternate->to_rgb(tint->eval(c));
+    return alternate->to_rgb(tint->eval({c.begin(), c.end()}));
   }
   case ColorSpaceKind::pattern:
     // An uncoloured pattern (`/PaintType 2`) carries its colour in the Pattern

--- a/src/odr/internal/pdf/pdf_color.hpp
+++ b/src/odr/internal/pdf/pdf_color.hpp
@@ -6,6 +6,7 @@
 #include <cstdint>
 #include <functional>
 #include <memory>
+#include <span>
 #include <string>
 #include <vector>
 
@@ -56,7 +57,7 @@ struct ColorSpaceDef {
   /// Convert `components` of this space to sRGB in [0, 1]. A short/empty input
   /// yields the space's default colour.
   [[nodiscard]] std::array<double, 3>
-  to_rgb(const std::vector<double> &components) const;
+  to_rgb(std::span<const double> components) const;
 
   /// The initial colour value of the space (ISO 32000-1 8.6.3): all-zero
   /// components, except Indexed (index 0) and Separation/DeviceN (tint 1.0).

--- a/src/odr/internal/pdf/pdf_function.cpp
+++ b/src/odr/internal/pdf/pdf_function.cpp
@@ -53,7 +53,7 @@ public:
         m_c1{std::move(c1)}, m_n{n} {}
 
 protected:
-  std::vector<double> compute(const std::vector<double> &in) const override {
+  std::vector<double> compute(const std::span<const double> in) const override {
     const double x = in.empty() ? 0.0 : in[0];
     const double xn = std::pow(x, m_n);
     // `/C0` and `/C1` must be equally long; a malformed file may disagree.
@@ -83,7 +83,7 @@ public:
         m_encode{std::move(encode)} {}
 
 protected:
-  std::vector<double> compute(const std::vector<double> &in) const override {
+  std::vector<double> compute(const std::span<const double> in) const override {
     if (m_functions.empty()) {
       return {};
     }
@@ -132,7 +132,7 @@ public:
         m_decode{std::move(decode)}, m_samples{std::move(samples)} {}
 
 protected:
-  std::vector<double> compute(const std::vector<double> &in) const override {
+  std::vector<double> compute(const std::span<const double> in) const override {
     const std::size_t m = m_size.size();
     const std::size_t n = output_arity();
     if (m == 0 || n == 0) {
@@ -267,7 +267,7 @@ public:
         m_program{std::move(program)} {}
 
 protected:
-  std::vector<double> compute(const std::vector<double> &in) const override {
+  std::vector<double> compute(const std::span<const double> in) const override {
     std::vector<Item> stack;
     stack.reserve(in.size());
     for (const double x : in) {

--- a/src/odr/internal/pdf/pdf_function.hpp
+++ b/src/odr/internal/pdf/pdf_function.hpp
@@ -3,6 +3,7 @@
 #include <cstddef>
 #include <functional>
 #include <memory>
+#include <span>
 #include <string>
 #include <vector>
 
@@ -35,7 +36,7 @@ protected:
       : m_domain{std::move(domain)}, m_range{std::move(range)} {}
 
   [[nodiscard]] virtual std::vector<double>
-  compute(const std::vector<double> &in) const = 0;
+  compute(std::span<const double> in) const = 0;
 
   std::vector<double> m_domain; // [min0 max0 min1 max1 ...]
   std::vector<double> m_range;  // [min0 max0 ...], possibly empty

--- a/src/odr/internal/pdf/pdf_graphics_operator_parser.cpp
+++ b/src/odr/internal/pdf/pdf_graphics_operator_parser.cpp
@@ -297,7 +297,7 @@ GraphicsOperator GraphicsOperatorParser::read_operator() {
 }
 
 Dictionary GraphicsOperatorParser::read_inline_image_dictionary(
-    const std::vector<Object> &arguments) {
+    const std::span<const Object> arguments) {
   // The inline dictionary is a flat run of name/value pairs (8.9.7).
   // Abbreviated keys are normalized to their long forms downstream.
   Dictionary dictionary;

--- a/src/odr/internal/pdf/pdf_graphics_operator_parser.hpp
+++ b/src/odr/internal/pdf/pdf_graphics_operator_parser.hpp
@@ -4,8 +4,8 @@
 
 #include <odr/logger.hpp>
 
+#include <span>
 #include <string>
-#include <vector>
 
 namespace odr::internal::pdf {
 
@@ -29,7 +29,7 @@ private:
   // Fold an inline image's flat name/value argument run into a dictionary
   // (8.9.7); abbreviated keys are normalized to long forms downstream.
   [[nodiscard]] static Dictionary
-  read_inline_image_dictionary(const std::vector<Object> &arguments);
+  read_inline_image_dictionary(std::span<const Object> arguments);
 
   // Read the binary image data of an inline image, from just after the `ID`
   // keyword up to (excluding) its `EI` terminator (8.9.7), leaving the cursor

--- a/src/odr/internal/pdf/pdf_image.cpp
+++ b/src/odr/internal/pdf/pdf_image.cpp
@@ -91,12 +91,12 @@ void unpremultiply(std::string &samples, const std::int32_t components,
 /// A decoded JPEG 2000 raster as a PNG, through the image's own colour space
 /// when the count matches and a device space of its component count otherwise
 /// (ISO 32000-1 8.9.5.1: `/ColorSpace` is optional for `JPXDecode`).
-std::optional<EncodedImage> encode_jpx(const std::string &data,
-                                       const ColorSpaceDef *color_space,
-                                       const std::vector<double> &decode_array,
-                                       const std::vector<std::uint8_t> &alpha,
-                                       const std::vector<double> &color_key,
-                                       const std::int32_t smask_in_data) {
+std::optional<EncodedImage>
+encode_jpx(const std::string &data, const ColorSpaceDef *color_space,
+           const std::span<const double> decode_array,
+           const std::span<const std::uint8_t> alpha,
+           const std::span<const double> color_key,
+           const std::int32_t smask_in_data) {
   std::optional<JpxImage> image = decode_jpx(data);
   if (!image.has_value()) {
     return std::nullopt;
@@ -131,7 +131,8 @@ std::optional<EncodedImage> encode_jpx(const std::string &data,
 
   const std::string png = encode_image_png(
       image->samples, image->width, image->height, 8, space, decode_array,
-      alpha.empty() ? image->alpha : alpha, color_key);
+      alpha.empty() ? std::span<const std::uint8_t>{image->alpha} : alpha,
+      color_key);
   if (png.empty()) {
     return std::nullopt;
   }
@@ -190,9 +191,9 @@ std::string pdf::encode_image_png(const std::string &samples,
                                   const std::int32_t height,
                                   const std::int32_t bits_per_component,
                                   const ColorSpaceDef &color_space,
-                                  const std::vector<double> &decode,
-                                  const std::vector<std::uint8_t> &alpha,
-                                  const std::vector<double> &color_key) {
+                                  const std::span<const double> decode,
+                                  const std::span<const std::uint8_t> alpha,
+                                  const std::span<const double> color_key) {
   const std::int32_t components = color_space.components;
   if (width <= 0 || height <= 0 || components <= 0 || bits_per_component <= 0 ||
       bits_per_component > 16) {
@@ -275,7 +276,7 @@ std::string pdf::encode_image_png(const std::string &samples,
 std::vector<std::uint8_t> pdf::decode_mask_alpha(
     const std::string &samples, const std::int32_t width,
     const std::int32_t height, const std::int32_t bits_per_component,
-    const std::vector<double> &decode, const bool stencil,
+    const std::span<const double> decode, const bool stencil,
     const std::int32_t base_width, const std::int32_t base_height) {
   if (width <= 0 || height <= 0 || base_width <= 0 || base_height <= 0 ||
       bits_per_component <= 0 || bits_per_component > 16) {
@@ -333,7 +334,7 @@ std::string pdf::encode_stencil_png(const std::string &samples,
                                     const std::int32_t width,
                                     const std::int32_t height,
                                     const std::array<double, 3> &color,
-                                    const std::vector<double> &decode) {
+                                    const std::span<const double> decode) {
   if (width <= 0 || height <= 0) {
     return {};
   }
@@ -369,9 +370,9 @@ std::optional<pdf::EncodedImage> pdf::encode_image(
     std::string raw, const Object &filter, const Object &decode_parms,
     const std::int32_t width, const std::int32_t height,
     const std::int32_t bits_per_component, const ColorSpaceDef *color_space,
-    const std::vector<double> &decode_array,
-    const std::vector<std::uint8_t> &alpha,
-    const std::vector<double> &color_key, const std::int32_t smask_in_data,
+    const std::span<const double> decode_array,
+    const std::span<const std::uint8_t> alpha,
+    const std::span<const double> color_key, const std::int32_t smask_in_data,
     const DecodeOptions &options) {
   const std::optional<std::string> terminal = terminal_image_codec(filter);
 

--- a/src/odr/internal/pdf/pdf_image.hpp
+++ b/src/odr/internal/pdf/pdf_image.hpp
@@ -5,6 +5,7 @@
 #include <array>
 #include <cstdint>
 #include <optional>
+#include <span>
 #include <string>
 #include <vector>
 
@@ -34,9 +35,9 @@ std::optional<EncodedImage>
 encode_image(std::string raw, const Object &filter, const Object &decode_parms,
              std::int32_t width, std::int32_t height,
              std::int32_t bits_per_component, const ColorSpaceDef *color_space,
-             const std::vector<double> &decode,
-             const std::vector<std::uint8_t> &alpha = {},
-             const std::vector<double> &color_key = {},
+             std::span<const double> decode,
+             std::span<const std::uint8_t> alpha = {},
+             std::span<const double> color_key = {},
              std::int32_t smask_in_data = 0, const DecodeOptions &options = {});
 
 /// Assemble decoded image samples (ISO 32000-1 8.9.5: MSB-first, rows padded
@@ -50,9 +51,9 @@ std::string encode_image_png(const std::string &samples, std::int32_t width,
                              std::int32_t height,
                              std::int32_t bits_per_component,
                              const ColorSpaceDef &color_space,
-                             const std::vector<double> &decode,
-                             const std::vector<std::uint8_t> &alpha = {},
-                             const std::vector<double> &color_key = {});
+                             std::span<const double> decode,
+                             std::span<const std::uint8_t> alpha = {},
+                             std::span<const double> color_key = {});
 
 /// Resolve a `/SMask` or stencil `/Mask` sub-image into a coverage plane sized
 /// to the *base* image, nearest-neighbour resampled — the two resolutions need
@@ -62,7 +63,7 @@ std::string encode_image_png(const std::string &samples, std::int32_t width,
 std::vector<std::uint8_t>
 decode_mask_alpha(const std::string &samples, std::int32_t width,
                   std::int32_t height, std::int32_t bits_per_component,
-                  const std::vector<double> &decode, bool stencil,
+                  std::span<const double> decode, bool stencil,
                   std::int32_t base_width, std::int32_t base_height);
 
 /// Wrap 8-bit pixels (row-major, unpadded) into a PNG: single `IDAT`, no
@@ -77,6 +78,6 @@ std::string write_png(const std::string &pixels, std::int32_t width,
 std::string encode_stencil_png(const std::string &samples, std::int32_t width,
                                std::int32_t height,
                                const std::array<double, 3> &color,
-                               const std::vector<double> &decode);
+                               std::span<const double> decode);
 
 } // namespace odr::internal::pdf

--- a/test/src/internal/font/type1_charstring.cpp
+++ b/test/src/internal/font/type1_charstring.cpp
@@ -2,6 +2,7 @@
 
 #include <gtest/gtest.h>
 
+#include <array>
 #include <string>
 #include <vector>
 
@@ -81,7 +82,8 @@ TEST(Type1CharstringTest, FlattensCallSubr) {
   op(t1, 10); // callsubr 0
   op(t1, 14); // endchar
 
-  const Type2Charstring out = to_type2(t1, {subr0});
+  const std::array<std::string, 1> subrs = {subr0};
+  const Type2Charstring out = to_type2(t1, subrs);
 
   // The subr's rlineto is inlined; expect width(0) rmoveto, then rlineto, then
   // endchar.

--- a/test/src/internal/pdf/pdf_color.cpp
+++ b/test/src/internal/pdf/pdf_color.cpp
@@ -35,25 +35,32 @@ ColorSpaceDef device(const ColorSpaceKind kind, const int components) {
   return def;
 }
 
+/// `ColorSpaceDef::to_rgb` over a braced component list, which its `std::span`
+/// does not take.
+std::array<double, 3> to_rgb(const ColorSpaceDef &def,
+                             const std::vector<double> &components) {
+  return def.to_rgb(components);
+}
+
 } // namespace
 
 // The device spaces convert as expected. CMYK follows Adobe's transform, so no
 // ink is white, full key is a dark neutral rather than `#000`, and full cyan is
 // a process cyan.
 TEST(PdfColor, device_spaces) {
-  EXPECT_EQ(device(ColorSpaceKind::device_gray, 1).to_rgb({0.5}),
+  EXPECT_EQ(to_rgb(device(ColorSpaceKind::device_gray, 1), {0.5}),
             (std::array<double, 3>{0.5, 0.5, 0.5}));
-  EXPECT_EQ(device(ColorSpaceKind::device_rgb, 3).to_rgb({0.2, 0.4, 0.6}),
+  EXPECT_EQ(to_rgb(device(ColorSpaceKind::device_rgb, 3), {0.2, 0.4, 0.6}),
             (std::array<double, 3>{0.2, 0.4, 0.6}));
-  EXPECT_EQ(device(ColorSpaceKind::device_cmyk, 4).to_rgb({0, 0, 0, 0}),
+  EXPECT_EQ(to_rgb(device(ColorSpaceKind::device_cmyk, 4), {0, 0, 0, 0}),
             (std::array<double, 3>{1, 1, 1}));
   const std::array<double, 3> key =
-      device(ColorSpaceKind::device_cmyk, 4).to_rgb({0, 0, 0, 1});
+      to_rgb(device(ColorSpaceKind::device_cmyk, 4), {0, 0, 0, 1});
   EXPECT_NEAR(key[0], 0.17, 0.01);
   EXPECT_NEAR(key[1], 0.18, 0.01);
   EXPECT_NEAR(key[2], 0.21, 0.01);
   const std::array<double, 3> cyan =
-      device(ColorSpaceKind::device_cmyk, 4).to_rgb({1, 0, 0, 0});
+      to_rgb(device(ColorSpaceKind::device_cmyk, 4), {1, 0, 0, 0});
   EXPECT_NEAR(cyan[0], 0.0, 0.01);
   EXPECT_NEAR(cyan[1], 0.72, 0.01);
   EXPECT_NEAR(cyan[2], 0.95, 0.01);
@@ -63,11 +70,11 @@ TEST(PdfColor, device_spaces) {
 // (D65) white point.
 TEST(PdfColor, lab_extremes) {
   ColorSpaceDef lab = device(ColorSpaceKind::lab, 3);
-  const std::array<double, 3> white = lab.to_rgb({100, 0, 0});
+  const std::array<double, 3> white = to_rgb(lab, {100, 0, 0});
   EXPECT_NEAR(white[0], 1.0, 0.02);
   EXPECT_NEAR(white[1], 1.0, 0.02);
   EXPECT_NEAR(white[2], 1.0, 0.02);
-  const std::array<double, 3> black = lab.to_rgb({0, 0, 0});
+  const std::array<double, 3> black = to_rgb(lab, {0, 0, 0});
   EXPECT_NEAR(black[0], 0.0, 0.02);
   EXPECT_NEAR(black[1], 0.0, 0.02);
   EXPECT_NEAR(black[2], 0.0, 0.02);
@@ -85,7 +92,7 @@ TEST(PdfColor, iccbased_by_component_count) {
   ASSERT_NE(def, nullptr);
   EXPECT_EQ(def->kind, ColorSpaceKind::icc_based);
   EXPECT_EQ(def->components, 3);
-  EXPECT_EQ(def->to_rgb({0.2, 0.4, 0.6}),
+  EXPECT_EQ(to_rgb(*def, {0.2, 0.4, 0.6}),
             (std::array<double, 3>{0.2, 0.4, 0.6}));
 }
 
@@ -101,8 +108,8 @@ TEST(PdfColor, indexed_palette) {
       parse_color_space(Object(Array(std::move(array))), context());
   ASSERT_NE(def, nullptr);
   EXPECT_EQ(def->kind, ColorSpaceKind::indexed);
-  EXPECT_EQ(def->to_rgb({0}), (std::array<double, 3>{1, 0, 0}));
-  EXPECT_EQ(def->to_rgb({1}), (std::array<double, 3>{0, 1, 0}));
+  EXPECT_EQ(to_rgb(*def, {0}), (std::array<double, 3>{1, 0, 0}));
+  EXPECT_EQ(to_rgb(*def, {1}), (std::array<double, 3>{0, 1, 0}));
 }
 
 // Separation samples its tint transform, then converts through the alternate.
@@ -124,9 +131,9 @@ TEST(PdfColor, separation_tint_transform) {
   EXPECT_EQ(def->kind, ColorSpaceKind::separation);
   EXPECT_EQ(def->components, 1);
   // full tint -> C1 = red
-  EXPECT_EQ(def->to_rgb({1.0}), (std::array<double, 3>{1, 0, 0}));
+  EXPECT_EQ(to_rgb(*def, {1.0}), (std::array<double, 3>{1, 0, 0}));
   // half tint -> (1, 0.5, 0.5)
-  const std::array<double, 3> half = def->to_rgb({0.5});
+  const std::array<double, 3> half = to_rgb(*def, {0.5});
   EXPECT_NEAR(half[0], 1.0, 1e-9);
   EXPECT_NEAR(half[1], 0.5, 1e-9);
   EXPECT_NEAR(half[2], 0.5, 1e-9);

--- a/test/src/internal/pdf/pdf_font.cpp
+++ b/test/src/internal/pdf/pdf_font.cpp
@@ -9,6 +9,7 @@
 
 #include <gtest/gtest.h>
 
+#include <array>
 #include <cstdint>
 #include <memory>
 #include <string>
@@ -197,12 +198,14 @@ TEST(PdfFont, simple_font_glyph_for_code_via_font_charset) {
   // A subset producer names its glyphs `gidNNNNN`: only the font program's
   // own charset reaches them (ISO 32000-1 9.6.6.2).
   const std::string endchar("\x0e", 1);
+  const std::array<font::cff::BuilderGlyph, 3> glyphs = {
+      font::cff::BuilderGlyph{".notdef", endchar},
+      font::cff::BuilderGlyph{"gid00046", endchar},
+      font::cff::BuilderGlyph{"gid00133", endchar}};
   Font font;
   font.embedded_font =
       std::make_shared<font::cff::CffFont>(font::cff::build_cff(
-          "Subset",
-          {{".notdef", endchar}, {"gid00046", endchar}, {"gid00133", endchar}},
-          /*default_width=*/0, /*nominal_width=*/0,
+          "Subset", glyphs, /*default_width=*/0, /*nominal_width=*/0,
           odr::FontBBox{0, -200, 600, 800}));
 
   font.encoding.emplace(pdf::BaseEncoding::standard);

--- a/test/src/internal/pdf/pdf_image.cpp
+++ b/test/src/internal/pdf/pdf_image.cpp
@@ -3,6 +3,7 @@
 #include <odr/internal/crypto/crypto_util.hpp>
 #include <odr/internal/pdf/pdf_color.hpp>
 
+#include <array>
 #include <cstdint>
 #include <string>
 #include <vector>
@@ -227,8 +228,9 @@ TEST(PdfImage, encode_gray_4bpc) {
 TEST(PdfImage, encode_honours_decode_array) {
   // DeviceGray with /Decode [1 0] inverts: sample 0 -> white, 255 -> black.
   const std::string samples = bytes({0, 255});
+  const std::array<double, 2> decode = {1.0, 0.0};
   const DecodedPng png =
-      decode_png(encode_image_png(samples, 2, 1, 8, device_gray(), {1.0, 0.0}));
+      decode_png(encode_image_png(samples, 2, 1, 8, device_gray(), decode));
   EXPECT_EQ(rgb_pixel(png.rgb, 2, 0, 0), bytes({255, 255, 255}));
   EXPECT_EQ(rgb_pixel(png.rgb, 2, 1, 0), bytes({0, 0, 0}));
 }
@@ -283,8 +285,9 @@ TEST(PdfImage, encode_stencil_paints_fill_colour_through_mask) {
 TEST(PdfImage, encode_stencil_decode_inverts) {
   // /Decode [1 0] swaps which sample paints: now the 1 paints, the 0 is clear.
   const std::string samples = bytes({0b01000000});
+  const std::array<double, 2> decode = {1.0, 0.0};
   const DecodedPngRgba png = decode_png_rgba(
-      encode_stencil_png(samples, 2, 1, {0.0, 0.0, 1.0}, {1.0, 0.0}));
+      encode_stencil_png(samples, 2, 1, {0.0, 0.0, 1.0}, decode));
   EXPECT_EQ(static_cast<std::uint8_t>(rgba_pixel(png.rgba, 2, 0, 0)[3]), 0);
   EXPECT_EQ(rgba_pixel(png.rgba, 2, 1, 0), bytes({0, 0, 255, 255}));
 }


### PR DESCRIPTION
🤖 Generated with [Claude Code](https://claude.com/claude-code)

Closes #736.

The nine internal parameters the issue lists only read their argument in order, so a caller holding an array, a subrange or a `std::span` had to materialise a vector first. `std::span<const T>` says the same thing and takes all three.

| | |
|---|---|
| `pdf/pdf_color.hpp` | `ColorSpaceDef::to_rgb` — `components` |
| `pdf/pdf_function.hpp` | `Function::compute` — `in`; virtual, so all four overrides move with it |
| `pdf/pdf_image.hpp` | `encode_image` / `encode_image_png` — `decode`, `alpha`, `color_key` |
| `pdf/pdf_image.hpp` | `decode_mask_alpha`, `encode_stencil_png` — `decode` |
| `pdf/pdf_graphics_operator_parser.hpp` | `read_inline_image_dictionary` — `arguments` |
| `font/cff_builder.hpp` | `build_cff` — `glyphs` |
| `font/type1_charstring.hpp` | `to_type2` — `subrs` |

The `= {}` defaults on `alpha` and `color_key` carry over unchanged: `std::span<const T> = {}` is an empty span. The file-local `encode_jpx` helper in `pdf_image.cpp` moves with the parameters it forwards, and `Translator` in `type1_charstring.cpp` held its subrs by reference — a span replaces that with a value member.

The two public-API cases the issue flags (`Logger::create_tee`, `html.hpp`'s `views`) are left alone, as it says: changing them ripples into the python, JNI, wasm and apple bindings.

### Call sites

Production callers all pass a named vector and are unchanged, except one: `to_rgb` fed its span to `Function::eval`, which takes its input by value and mutates it, so it now spells the vector at that call.

`std::span` has no `initializer_list` constructor before C++26, so test arguments written as a braced list stop compiling. `{}` still works — that is the default constructor, not a list — so only the non-empty ones moved:

- `pdf_color`'s twelve `to_rgb({…})` calls go through a local helper, following `string_util_test`'s precedent for `utf16_offsets`; stating the components inline is the whole point of those cases.
- `pdf_image`, `pdf_font` and `type1_charstring` name the one argument each that was a list.

### Testing

- `odr_test` in full: 1166 passed, 8 skipped (the same ones as on `main` — missing test data). The `HtmlOutputTests` comparison against the pinned reference output is unchanged, so nothing about the rendered PDF or font output moved.
- `clang-format` clean.