### PR TITLE
fix(text): stop reading a binary as text

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,10 @@ The release run heads these entries with the version and opens a fresh
 
 ## Unreleased
 
+- **Breaking** Bytes that do not read as text no longer come back as
+  `text_file` and render as nonsense - `decode` throws `UnknownFileType` and
+  `list_file_types` comes back empty. A file is text when it is empty, or its
+  encoding can be named and it carries no NUL outside utf-16 and utf-32.
 - `open(file, as)` no longer returns a container holding another document type
   as the type that was asked for. An encrypted ooxml still opens as whichever
   was asked - it names no inner type until it is decrypted.

--- a/src/odr/internal/encoding/detect.cpp
+++ b/src/odr/internal/encoding/detect.cpp
@@ -38,6 +38,13 @@ TextEncoding encoding_by_bom(const std::string_view probe) {
   return TextEncoding::unknown;
 }
 
+/// Whether NUL bytes are ordinary characters in @p encoding.
+bool encoding_holds_nul(const TextEncoding encoding) {
+  return encoding == TextEncoding::utf16le ||
+         encoding == TextEncoding::utf16be ||
+         encoding == TextEncoding::utf32le || encoding == TextEncoding::utf32be;
+}
+
 } // namespace
 
 std::string encoding::read_probe(std::istream &in,
@@ -62,6 +69,20 @@ TextEncoding encoding::detect(const std::string_view probe) {
 
   const auto *row = text_encoding_table::find_by_name(name);
   return row == nullptr ? TextEncoding::unknown : row->encoding;
+}
+
+bool encoding::is_text(const std::string_view probe,
+                       const TextEncoding encoding) {
+  // an empty file is an empty text file
+  if (probe.empty()) {
+    return true;
+  }
+  if (encoding == TextEncoding::unknown) {
+    return false;
+  }
+  // uchardet names nul padding utf-8, so the encoding alone does not decide
+  return encoding_holds_nul(encoding) ||
+         probe.find('\0') == std::string_view::npos;
 }
 
 } // namespace odr::internal

--- a/src/odr/internal/encoding/detect.hpp
+++ b/src/odr/internal/encoding/detect.hpp
@@ -22,4 +22,8 @@ read_probe(std::istream &in, std::size_t max_bytes = default_probe_size);
 /// only, so an encoding invisible in an ASCII prefix is missed.
 [[nodiscard]] TextEncoding detect(std::string_view probe);
 
+/// Whether @p probe, detected as @p encoding, reads as text: named, and no NUL
+/// outside utf-16 and utf-32 — the test `file(1)` and git use. Empty is text.
+[[nodiscard]] bool is_text(std::string_view probe, TextEncoding encoding);
+
 } // namespace odr::internal::encoding

--- a/src/odr/internal/open_strategy.cpp
+++ b/src/odr/internal/open_strategy.cpp
@@ -258,9 +258,14 @@ open_file_as(const std::shared_ptr<abstract::File> &file, const FileType as,
 
   if (as == FileType::markdown) {
     ODR_VERBOSE(logger, "open as markdown");
-    // Nothing rejects: md4c is total, so there is no detection to fail here.
-    auto text = std::make_shared<text::TextFile>(file);
-    return std::make_unique<markdown::MarkdownFile>(std::move(text));
+    // md4c is total, so only the text reading can fail here
+    try {
+      auto text = std::make_shared<text::TextFile>(file);
+      return std::make_unique<markdown::MarkdownFile>(std::move(text));
+    } catch (...) {
+      ODR_VERBOSE(logger, "failed to open as markdown");
+    }
+    throw NoMarkdownFile();
   }
 
   if (as == FileType::xml) {

--- a/src/odr/internal/text/text_file.cpp
+++ b/src/odr/internal/text/text_file.cpp
@@ -7,6 +7,7 @@
 #include <odr/internal/encoding/transcode.hpp>
 #include <odr/internal/util/stream_util.hpp>
 
+#include <string>
 #include <utility>
 
 namespace odr::internal::text {
@@ -14,10 +15,13 @@ namespace odr::internal::text {
 TextFile::TextFile(std::shared_ptr<abstract::File> file)
     : m_file{std::move(file)} {
   const std::unique_ptr<std::istream> in = m_file->stream();
-  // nothing here rejects: text is the fallback for bytes nothing else claims,
-  // so a viewer handed a random binary shows junk rather than an error, and
-  // bytes we cannot name are `TextEncoding::unknown`
-  m_encoding = encoding::detect(encoding::read_probe(*in));
+  const std::string probe = encoding::read_probe(*in);
+  m_encoding = encoding::detect(probe);
+  // text is the fallback, so it is the only place that can call a file
+  // unreadable
+  if (!encoding::is_text(probe, m_encoding)) {
+    throw NoTextFile();
+  }
 }
 
 TextFile::TextFile(std::shared_ptr<abstract::File> file,

--- a/src/odr/internal/text/text_file.hpp
+++ b/src/odr/internal/text/text_file.hpp
@@ -10,7 +10,9 @@ namespace odr::internal::text {
 
 class TextFile final : public abstract::TextFile {
 public:
+  /// @throws NoTextFile if the bytes do not read as text.
   explicit TextFile(std::shared_ptr<abstract::File> file);
+  /// Reads @p file in @p encoding as given, rejecting nothing.
   TextFile(std::shared_ptr<abstract::File> file, TextEncoding encoding);
 
   [[nodiscard]] std::shared_ptr<abstract::File> file() const noexcept override;

--- a/test/src/internal/text/text_file_test.cpp
+++ b/test/src/internal/text/text_file_test.cpp
@@ -8,8 +8,10 @@
 
 #include <gtest/gtest.h>
 
+#include <cstdint>
 #include <memory>
 #include <string>
+#include <tuple>
 
 using namespace odr;
 using namespace odr::test;
@@ -26,23 +28,44 @@ TEST(TextFile, txt) {
   File(TestData::test_file_path("odr-public/txt/lorem ipsum.txt"));
 }
 
-/// Text is the fallback for bytes nothing else claims, so nothing is rejected
-/// — a viewer handed a random binary shows junk rather than an error.
-TEST(TextFile, anything_reads_as_text) {
-  EXPECT_NO_THROW(text_file(std::string("\0\1\2\3", 4)));
-  EXPECT_NO_THROW(text_file("plain ascii"));
+/// Text is the fallback, so it is the one place that can call a file
+/// unreadable — otherwise every caller re-derives that from the encoding.
+TEST(TextFile, binary_is_not_text) {
+  // every byte value twice; a short random run is named or not by luck
+  std::string all_bytes;
+  for (std::uint32_t i = 0; i < 512; ++i) {
+    all_bytes.push_back(static_cast<char>(i % 256));
+  }
+  EXPECT_THROW(text_file(all_bytes), NoTextFile);
+
+  // uchardet names nul padding utf-8, so the encoding alone does not decide
+  EXPECT_THROW(
+      text_file(std::string("SQLite format 3\0", 16) + std::string(496, '\0')),
+      NoTextFile);
+  EXPECT_THROW(text_file(std::string(512, '\0')), NoTextFile);
 
   const File odt(TestData::test_file_path("odr-public/odt/about.odt"));
-  EXPECT_NO_THROW(internal::text::TextFile(odt.impl()));
+  EXPECT_THROW(internal::text::TextFile(odt.impl()), NoTextFile);
+}
+
+TEST(TextFile, text_is_text) {
+  EXPECT_NO_THROW(text_file("plain ascii"));
+  // an empty file is an empty text file
+  EXPECT_NO_THROW(text_file(""));
+  // utf-16 and utf-32 spell ascii with nul bytes
+  EXPECT_NO_THROW(text_file(std::string("\xff\xfeh\0e\0l\0l\0o\0", 12)));
+  EXPECT_NO_THROW(text_file(std::string("\xff\xfe\0\0h\0\0\0i\0\0\0", 12)));
 }
 
 /// The same contract seen from outside, which `wasm/tests/smoke.test.mjs`
-/// pins downstream: bytes nothing recognises still open, as text.
-TEST(TextFile, unrecognised_bytes_open_as_text) {
-  const File junk = File::from_memory(std::string("\0\1\2\3\4\5\6\7", 8));
+/// pins downstream: bytes nothing recognises do not open at all.
+TEST(TextFile, unrecognised_bytes_do_not_open) {
+  const File junk = File::from_memory(std::string(512, '\0'));
 
-  EXPECT_EQ(mimetype(junk), "text/plain");
-  EXPECT_EQ(DecodedFile(junk).file_type(), FileType::text_file);
+  EXPECT_THROW(std::ignore = mimetype(junk), UnknownFileType);
+  EXPECT_THROW(DecodedFile{junk}, UnknownFileType);
+  // asking for text by name is no way around it
+  EXPECT_THROW(DecodedFile(junk, FileType::text_file), UnknownFileType);
 }
 
 TEST(TextFile, encoding_comes_from_the_byte_order_mark) {

--- a/wasm/tests/smoke.test.mjs
+++ b/wasm/tests/smoke.test.mjs
@@ -26,13 +26,16 @@ describe('smoke', () => {
     assert.equal(mimeType, 'application/vnd.oasis.opendocument.text');
   });
 
-  // Pinned because "unrecognised input throws" is the natural assumption: text
-  // is the fallback, so a viewer handed a random binary shows junk not an error.
-  it('falls back to text for bytes nothing recognises', () => {
-    const junk = new Uint8Array([0, 1, 2, 3, 4, 5, 6, 7]);
-    assert.equal(odr.detect(junk).mimeType, 'text/plain');
+  // Text is the fallback, but only for bytes that read as text.
+  it('opens bytes that read as text and refuses the rest', () => {
+    const junk = new Uint8Array(512);
+    assert.throws(() => odr.detect(junk), OdrError);
+    assert.throws(() => odr.open(junk), OdrError);
 
-    const doc = odr.open(junk);
+    const text = new TextEncoder().encode('lorem ipsum dolor sit amet');
+    assert.equal(odr.detect(text).mimeType, 'text/plain');
+
+    const doc = odr.open(text);
     try {
       assert.equal(doc.fileType, odr.enums.FileType.txt);
     } finally {


### PR DESCRIPTION
🤖 Generated with [Claude Code](https://claude.com/claude-code)

Closes #728.

`DecodedFile::decode` fell back to `FileType::text_file` for anything it did not
recognise, so a caller that trusted the answer rendered a page of nonsense
instead of saying the file cannot be opened. Both readers worked around it by
asking for the charset themselves and treating a null as unsupported — and, as
the issue's follow-up measured, that workaround does not catch a NUL padded
binary, because uchardet names one `UTF-8`.

## The rule

`encoding::is_text(probe, encoding)`, applied by `text::TextFile`'s detecting
constructor. A file is text when

- it is empty — an empty text file is worth keeping as text, and
- its encoding can be named, and
- it carries no NUL byte, unless the encoding spells ordinary characters with
  one (utf-16, utf-32).

Two rules rather than one because neither covers the issue's table alone: the
charset rule misses NUL padding, and the NUL rule misses a short random run.
The NUL test is what `file(1)` and git use.

The rest falls out of the open strategy: `list_file_types` leaves `text_file`
out, `open_file` throws `UnknownFileType`, `mimetype` throws rather than
answering `text/plain`, and `open(file, FileType::text_file)` is no way around
it. `TextFile(file, encoding)` — the caller saying what the bytes are, used by
`CsvOptions::encoding` — still rejects nothing.

## Measured

Every row of the issue and its follow-up, run through the new constructor:

| content | verdict | encoding |
| --- | --- | --- |
| empty | text | unknown |
| a real text file | text | UTF-8 |
| 512 × `0x00` | not text | — |
| `"SQLite format 3\0"` + NUL padding | not text | — |
| `"SQLite format 3\0"` + random padding | not text | — |
| 512 × `0xFF` | **text** | windows-1252 |
| every byte value, twice | not text | — |
| 64 random bytes | not text | — |
| utf-16le with a mark | text | UTF-16LE |

The one row left as it was is 512 × `0xFF`: no NUL, and windows-1252 maps every
byte, so it is 512 × `ÿ`. `file(1)` calls it ISO-8859 text too.

## Also

- The markdown branch of `open_file_as` now catches and throws `NoMarkdownFile`
  like every other format — md4c is still total, but reading the bytes as text
  can now fail.
- `TextFile.anything_reads_as_text` and the wasm smoke test pinned the old
  behaviour deliberately; both are flipped, with the fixtures the issue found
  sturdy (a short random run makes no fixture).
- Downstream, `CoreLoader.kt` and its iOS copy can drop the charset check.

Full `odr_test` green (1191 passed, the 6 usual skips).