### PR TITLE
fix(html): read a zoomed view's rects in the space its pointer events use

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -76,6 +76,7 @@ bytes ─▶ magic/open_strategy ─▶ DecodedFile ─▶ Document ─▶ Eleme
 | `wasm/` | WebAssembly bindings (embind), packaged as the npm package `@opendocument/odr-core`; see [`wasm/AGENTS.md`](wasm/AGENTS.md). |
 | `tools/pdf/` | Dev tooling (not built): PDF encoding-data generators, see `tools/pdf/README.md`. |
 | `test/src/` | GoogleTest suites; data fetched into `test/data` (see `cmake/test_data.cmake`). |
+| `test/browser/` | Checks for the emitted scripts, run by hand in a browser — what they do is not visible to `odr_test`; see [`viewport/README.md`](test/browser/viewport/README.md). |
 | `offline/documentation/MS-*/` | Vendored Microsoft spec text (see [Specs](#specs)). |
 | `docs/design/README.md` | High-level design rationale. |
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -50,6 +50,13 @@ The release run heads these entries with the version and opens a fresh
 - `psd`, `jp2`, `wmf` and `emf` no longer declare `translate_html` — no browser
   paints them, and `html::translate` throws `UnsupportedFileType` instead of
   writing a blank page. They are still detected and still open.
+- `odr.setZoom(value, focus)` holds the point the pinch is centred on. Webkit
+  does not carry an applied `body{zoom}` in `getBoundingClientRect`, so the
+  focus moved with the zoom.
+- New `odr.getViewportRect(element)`: the element's box in the coordinates
+  `elementFromPoint` takes, for a host hit-testing while a zoom is applied.
+- A view whose zoom does not follow the viewport — `viewport_width`,
+  `initial_zoom`, a sheet — keeps the reader's place across a width change.
 
 ## v6.10.1 - 2026-08-21
 

--- a/src/odr/internal/html/frontend.cpp
+++ b/src/odr/internal/html/frontend.cpp
@@ -323,6 +323,8 @@ constexpr std::string_view document_js = R"js(
 )js";
 
 /// The zoom api, and the fit where the css could not state it.
+/// `test/browser/viewport/serve` lifts the script out by this declaration read
+/// verbatim, so renaming it breaks the browser checks.
 constexpr std::string_view viewport_js = R"js(
 (function () {
   "use strict";
@@ -418,15 +420,23 @@ constexpr std::string_view viewport_js = R"js(
     return rectsZoomed ? 1 : zoom;
   }
 
-  // @p element's box in viewport coordinates.
+  // @p element's box in viewport coordinates, shaped like a `DOMRect`.
   function boxOf(element) {
     var box = element.getBoundingClientRect();
     var factor = rectFactor();
+    var left = box.left * factor;
+    var top = box.top * factor;
+    var width = box.width * factor;
+    var height = box.height * factor;
     return {
-      left: box.left * factor,
-      top: box.top * factor,
-      width: box.width * factor,
-      height: box.height * factor,
+      x: left,
+      y: top,
+      left: left,
+      top: top,
+      right: left + width,
+      bottom: top + height,
+      width: width,
+      height: height,
     };
   }
 
@@ -501,7 +511,11 @@ constexpr std::string_view viewport_js = R"js(
     var token = ++settling;
     var frames = 30;
     (function again() {
-      if (token !== settling || frames-- <= 0) {
+      if (token !== settling) {
+        // A newer run - or the reader - owns the state below now.
+        return;
+      }
+      if (frames-- <= 0) {
         restoring = false;
         remember();
         return;
@@ -557,20 +571,9 @@ constexpr std::string_view viewport_js = R"js(
   // @p element's box in the coordinates `elementFromPoint` takes, for a host
   // hit-testing while a zoom is applied.
   odr.getViewportRect = function (element) {
-    if (!element || typeof element.getBoundingClientRect !== "function") {
-      return null;
-    }
-    var box = boxOf(element);
-    return {
-      x: box.left,
-      y: box.top,
-      left: box.left,
-      top: box.top,
-      right: box.left + box.width,
-      bottom: box.top + box.height,
-      width: box.width,
-      height: box.height,
-    };
+    return element && typeof element.getBoundingClientRect === "function"
+      ? boxOf(element)
+      : null;
   };
 
   // @p focus, a pinch's midpoint, is the point that stays put across the

--- a/src/odr/internal/html/frontend.cpp
+++ b/src/odr/internal/html/frontend.cpp
@@ -392,6 +392,44 @@ constexpr std::string_view viewport_js = R"js(
     return content > available ? available / content : 1;
   }
 
+  // Whether `getBoundingClientRect` carries the zoom applied to the body;
+  // webkit does not. Only decidable while a zoom is applied.
+  var rectsZoomed = null;
+
+  // Rect coordinates times this are viewport coordinates.
+  function rectFactor() {
+    var zoom = parseFloat(getComputedStyle(body).zoom);
+    if (!isFinite(zoom) || zoom <= 0 || zoom === 1) {
+      return 1;
+    }
+    if (rectsZoomed === null) {
+      var probe = document.createElement("div");
+      probe.style.cssText =
+        "position:absolute;top:0;left:0;width:100px;height:100px;" +
+        "box-sizing:content-box;margin:0;padding:0;border:0";
+      body.appendChild(probe);
+      var measured = probe.getBoundingClientRect().width;
+      body.removeChild(probe);
+      if (!measured) {
+        return 1;
+      }
+      rectsZoomed = Math.abs(measured - 100 * zoom) < Math.abs(measured - 100);
+    }
+    return rectsZoomed ? 1 : zoom;
+  }
+
+  // @p element's box in viewport coordinates.
+  function boxOf(element) {
+    var box = element.getBoundingClientRect();
+    var factor = rectFactor();
+    return {
+      left: box.left * factor,
+      top: box.top * factor,
+      width: box.width * factor,
+      height: box.height * factor,
+    };
+  }
+
   // The element under @p point, and how far into it that point sits - a
   // fraction of the scroll height cannot stand in, the height scales too. Only
   // a given point pins x; the page column centres itself.
@@ -402,7 +440,7 @@ constexpr std::string_view viewport_js = R"js(
     if (!element) {
       return null;
     }
-    var box = element.getBoundingClientRect();
+    var box = boxOf(element);
     return {
       element: element,
       x: point ? x : null,
@@ -439,7 +477,7 @@ constexpr std::string_view viewport_js = R"js(
     if (!target || !target.element.isConnected) {
       return;
     }
-    var box = target.element.getBoundingClientRect();
+    var box = boxOf(target.element);
     var deltaY = box.top + target.intoY * box.height - target.y;
     var deltaX =
       target.x === null ? 0 : box.left + target.intoX * box.width - target.x;
@@ -456,11 +494,7 @@ constexpr std::string_view viewport_js = R"js(
 
   // The browser applies a scroll offset of its own a few frames later, so
   // @p target is re-asserted until it settles.
-  function apply(target) {
-    var zoom = applied();
-    body.style.zoom = zoom;
-    root.style.setProperty("--odr-zoom", zoom);
-
+  function settle(target) {
     restoring = true;
     restore(target);
 
@@ -475,7 +509,14 @@ constexpr std::string_view viewport_js = R"js(
       restore(target);
       requestAnimationFrame(again);
     })();
+  }
 
+  function apply(target) {
+    var zoom = applied();
+    body.style.zoom = zoom;
+    root.style.setProperty("--odr-zoom", zoom);
+
+    settle(target);
     notify();
   }
 
@@ -490,8 +531,8 @@ constexpr std::string_view viewport_js = R"js(
     width = root.clientWidth;
 
     if (pinned !== null || !measures) {
-      // the scale does not follow the viewport
-      remember();
+      // The scale does not follow the viewport; the reader's place still does.
+      settle(target);
       return;
     }
 
@@ -511,6 +552,25 @@ constexpr std::string_view viewport_js = R"js(
 
   odr.isZoomFitted = function () {
     return pinned === null;
+  };
+
+  // @p element's box in the coordinates `elementFromPoint` takes, for a host
+  // hit-testing while a zoom is applied.
+  odr.getViewportRect = function (element) {
+    if (!element || typeof element.getBoundingClientRect !== "function") {
+      return null;
+    }
+    var box = boxOf(element);
+    return {
+      x: box.left,
+      y: box.top,
+      left: box.left,
+      top: box.top,
+      right: box.left + box.width,
+      bottom: box.top + box.height,
+      width: box.width,
+      height: box.height,
+    };
   };
 
   // @p focus, a pinch's midpoint, is the point that stays put across the

--- a/src/odr/internal/html/frontend.hpp
+++ b/src/odr/internal/html/frontend.hpp
@@ -46,8 +46,9 @@ void write_text_script(const WritingState &state);
 void write_search_script(const WritingState &state);
 
 /// `odr.getZoom()`, `setZoom(value, focus)`, `adjustZoom(factor, focus)`,
-/// `resetZoom(focus)`, `isZoomFitted()`, `onZoomChange`, plus the fit @ref
-/// write_zoom_style left to be measured. Holds the reading position.
+/// `resetZoom(focus)`, `isZoomFitted()`, `getViewportRect(element)`,
+/// `onZoomChange`, plus the fit @ref write_zoom_style left to be measured.
+/// Holds the reading position.
 void write_viewport_script(const WritingState &state);
 
 /// What the corresponding `write_*` calls would link, without writing anything:

--- a/test/browser/viewport/.gitignore
+++ b/test/browser/viewport/.gitignore
@@ -1,0 +1,1 @@
+viewport.js

--- a/test/browser/viewport/README.md
+++ b/test/browser/viewport/README.md
@@ -1,0 +1,28 @@
+# `viewport.js` checks
+
+What the emitted zoom script does can only be seen in a browser, so these are
+run by hand rather than by `odr_test`.
+
+```bash
+test/browser/viewport/serve      # extracts the script, serves on :8731
+open http://localhost:8731/tests.html
+```
+
+`serve` lifts `viewport_js` out of `src/odr/internal/html/frontend.cpp`, so what
+runs is what ships. `page.html` stands in for a rendered view: it writes the
+`:root{--odr-fit;--odr-zoom}` and `body{zoom}` that `write_zoom_style` would.
+
+Why the harness is shaped this way:
+
+- **`?webkit=1`** divides an applied zoom back out of chromium's rects, which is
+  what webkit returns — so one browser covers both.
+- **A pinch focus, not the top of the viewport.** `restore()` is re-asserted for
+  30 frames, and that loop converges at `y = 1` whatever coordinate space it
+  computes in; a focus 400px down does not.
+- **`overflow-anchor: none`**, or chromium's own scroll anchoring covers for the
+  script. Webkit has none.
+- **Positions are read as `(scrollY + y) / zoom`**, never through the script's
+  helpers, so a wrong answer cannot agree with itself.
+
+Keep the tab on screen: the browser throttles `resize` and
+`requestAnimationFrame` in a window that is not.

--- a/test/browser/viewport/README.md
+++ b/test/browser/viewport/README.md
@@ -15,7 +15,12 @@ runs is what ships. `page.html` stands in for a rendered view: it writes the
 Why the harness is shaped this way:
 
 - **`?webkit=1`** divides an applied zoom back out of chromium's rects, which is
-  what webkit returns — so one browser covers both.
+  what webkit returns — so one browser covers the rect space. It does not cover
+  the scroll space: `restore()` reads deltas in viewport coordinates and hands
+  them to `window.scrollBy`, which is only right if webkit's `scrollBy`/`scrollY`
+  are in that same zoomed space. `rectFactor()` probes for the rect convention at
+  runtime; nothing probes the scroll one, and here it is chromium's. So the pinch
+  check is worth one run in real safari.
 - **A pinch focus, not the top of the viewport.** `restore()` is re-asserted for
   30 frames, and that loop converges at `y = 1` whatever coordinate space it
   computes in; a focus 400px down does not.

--- a/test/browser/viewport/page.html
+++ b/test/browser/viewport/page.html
@@ -1,0 +1,122 @@
+<!doctype html>
+<html>
+  <head>
+    <meta charset="utf-8" />
+    <script>
+      // Query: webkit=1, fit=<number>|auto, zoom=<number>, content=page|prose
+      var q = new URLSearchParams(location.search);
+      window.__q = q;
+    </script>
+    <style id="odr-style"></style>
+    <style>
+      /* Chromium anchors scrolls on its own; webkit does not. */
+      body {
+        overflow-anchor: none;
+        margin: 0;
+      }
+      .odr-page {
+        width: 826px;
+        margin: 0 auto;
+        padding: 32px 0;
+        background: #fff;
+      }
+      .line {
+        font: 16px/1.5 monospace;
+        height: 24px;
+      }
+      /* No gap between them: a point at the top of the viewport must land in a
+         paragraph, not in a margin the body owns. */
+      .prose {
+        font: 16px/1.5 monospace;
+        margin: 0;
+      }
+    </style>
+  </head>
+  <body>
+    <script>
+      (function () {
+        var q = window.__q;
+
+        // The css `write_zoom_style` would have written.
+        var fit = q.get("fit");
+        var zoom = q.get("zoom");
+        var css = "";
+        var applied = 1;
+        if (fit || zoom) {
+          css += ":root{";
+          if (fit) {
+            css += "--odr-fit:" + fit + (zoom ? ";" : "");
+          }
+          if (zoom) {
+            css += "--odr-zoom:" + zoom;
+          }
+          css += "}";
+          applied = parseFloat(zoom || fit);
+          if (isFinite(applied) && applied !== 1) {
+            css += "body{zoom:" + applied + "}";
+          }
+        }
+        document.getElementById("odr-style").textContent = css;
+
+        var host = document.body;
+        if (q.get("content") === "prose") {
+          // Reflows with the viewport, so a width change moves the reader.
+          for (var i = 0; i < 400; ++i) {
+            var p = document.createElement("p");
+            p.className = "prose";
+            p.id = "p" + i;
+            p.textContent =
+              "paragraph " +
+              i +
+              " " +
+              "lorem ipsum dolor sit amet consectetur adipiscing elit sed do ".repeat(
+                3,
+              );
+            host.appendChild(p);
+          }
+        } else {
+          var page = document.createElement("div");
+          page.className = "odr-page";
+          for (var j = 0; j < 400; ++j) {
+            var line = document.createElement("div");
+            line.className = "line";
+            line.id = "l" + j;
+            line.textContent = "line " + j + " of the document";
+            page.appendChild(line);
+          }
+          host.appendChild(page);
+        }
+
+        // Webkit reports rects in layout coordinates while an applied `zoom`
+        // scales the viewport; dividing it back out reproduces that.
+        if (q.get("webkit") === "1") {
+          var native = Element.prototype.getBoundingClientRect;
+          Element.prototype.getBoundingClientRect = function () {
+            var box = native.call(this);
+            var z = parseFloat(getComputedStyle(document.body).zoom);
+            if (!isFinite(z) || z <= 0 || z === 1) {
+              return box;
+            }
+            return {
+              x: box.x / z,
+              y: box.y / z,
+              left: box.left / z,
+              top: box.top / z,
+              right: box.right / z,
+              bottom: box.bottom / z,
+              width: box.width / z,
+              height: box.height / z,
+            };
+          };
+        }
+
+        var script = document.createElement("script");
+        script.src = "viewport.js";
+        script.onload = function () {
+          window.__ready = true;
+        };
+        document.head.appendChild(script);
+      })();
+    </script>
+  </body>
+</html>

--- a/test/browser/viewport/serve
+++ b/test/browser/viewport/serve
@@ -1,0 +1,36 @@
+#!/usr/bin/env python3
+"""Extracts the emitted zoom script and serves the checks beside it."""
+
+import functools
+import http.server
+import pathlib
+import socketserver
+
+PORT = 8731
+
+HERE = pathlib.Path(__file__).resolve().parent
+SOURCE = HERE.parents[2] / "src" / "odr" / "internal" / "html" / "frontend.cpp"
+BEGIN = 'constexpr std::string_view viewport_js = R"js('
+END = ')js";'
+
+
+def extract() -> str:
+    source = SOURCE.read_text()
+    begin = source.index(BEGIN)
+    return source[begin + len(BEGIN) : source.index(END, begin)]
+
+
+def main() -> None:
+    target = HERE / "viewport.js"
+    target.write_text(extract())
+    print(f"{SOURCE.name} -> {target.name}")
+
+    handler = functools.partial(http.server.SimpleHTTPRequestHandler, directory=str(HERE))
+    socketserver.TCPServer.allow_reuse_address = True
+    with socketserver.TCPServer(("127.0.0.1", PORT), handler) as server:
+        print(f"http://localhost:{PORT}/tests.html")
+        server.serve_forever()
+
+
+if __name__ == "__main__":
+    main()

--- a/test/browser/viewport/tests.html
+++ b/test/browser/viewport/tests.html
@@ -1,0 +1,209 @@
+<!doctype html>
+<html>
+  <head>
+    <meta charset="utf-8" />
+    <title>viewport.js checks</title>
+    <style>
+      body {
+        font: 14px/1.6 monospace;
+        margin: 16px;
+      }
+      #frame {
+        border: 1px solid #999;
+      }
+      #out b {
+        color: #b00;
+      }
+      pre {
+        white-space: pre-wrap;
+      }
+    </style>
+  </head>
+  <body>
+    <pre id="out">running…</pre>
+    <iframe id="frame" width="900" height="600"></iframe>
+    <script>
+      var out = document.getElementById("out");
+      var frame = document.getElementById("frame");
+      var lines = [];
+      var failed = 0;
+
+      function say(text) {
+        lines.push(text);
+        out.innerHTML = lines.join("\n");
+      }
+
+      function check(name, ok, detail) {
+        if (!ok) {
+          ++failed;
+        }
+        var head = ok ? "PASS  " : "<b>FAIL</b>  ";
+        say(head + name + (detail ? "   " + detail : ""));
+      }
+
+      function wait(ms) {
+        return new Promise(function (resolve) {
+          setTimeout(resolve, ms);
+        });
+      }
+
+      function load(query, width) {
+        frame.width = width || 900;
+        return new Promise(function (resolve) {
+          frame.onload = function () {
+            (function poll() {
+              if (frame.contentWindow.__ready && frame.contentWindow.odr) {
+                setTimeout(function () {
+                  resolve(frame.contentWindow);
+                }, 60);
+              } else {
+                setTimeout(poll, 20);
+              }
+            })();
+          };
+          frame.src = "page.html?" + query;
+        });
+      }
+
+      // A window that is not on screen has its scroll and resize events
+      // throttled away, so the harness dispatches them.
+      function scrollTo(win, y) {
+        win.scrollTo(0, y);
+        win.dispatchEvent(new win.Event("scroll"));
+      }
+
+      function resizeTo(win, frame, width) {
+        frame.width = width;
+        void frame.contentDocument.documentElement.clientWidth;
+        win.dispatchEvent(new win.Event("resize"));
+      }
+
+      // The first identified thing at the top of the viewport; a point can land
+      // in a margin, which belongs to the body.
+      function topId(win) {
+        var doc = win.document;
+        var cx = Math.floor(doc.documentElement.clientWidth / 2);
+        for (var y = 1; y <= 24; ++y) {
+          var at = doc.elementFromPoint(cx, y);
+          var owner = at && at.closest ? at.closest("[id]") : null;
+          if (owner) {
+            return owner.id;
+          }
+        }
+        return "(none)";
+      }
+
+      // The document position under viewport row `y`, in the document's own
+      // unzoomed coordinates - read without the script's own helpers.
+      function docAt(win, y) {
+        var zoom = parseFloat(getComputedStyle(win.document.body).zoom);
+        return (win.scrollY + y) / (isFinite(zoom) && zoom > 0 ? zoom : 1);
+      }
+
+      function near(a, b, tolerance) {
+        return Math.abs(a - b) <= tolerance;
+      }
+
+      // Webkit does not carry an applied `body{zoom}` in a rect, so what a host
+      // reads off one is not what `elementFromPoint` takes.
+      async function rectTest(label, webkit, expectRawHit) {
+        var win = await load(
+          "content=page&zoom=0.472155&webkit=" + (webkit ? 1 : 0),
+        );
+        var doc = win.document;
+        scrollTo(win, 2000);
+        await wait(60);
+
+        // Whatever is on screen, the way a host picks an element.
+        var cx = Math.floor(doc.documentElement.clientWidth / 2);
+        var element = doc.elementFromPoint(cx, 200);
+        var raw = element.getBoundingClientRect();
+        var view = win.odr.getViewportRect(element);
+
+        var rawHit = doc.elementFromPoint(
+          raw.left + raw.width / 2,
+          raw.top + raw.height / 2,
+        );
+        var viewHit = doc.elementFromPoint(
+          view.left + view.width / 2,
+          view.top + view.height / 2,
+        );
+
+        check(
+          label + ": a raw rect centre hits the element",
+          (rawHit === element) === expectRawHit,
+          "expected " + (expectRawHit ? "a hit" : "a miss") + ", got " +
+            (rawHit ? rawHit.id || rawHit.tagName : "none"),
+        );
+        check(
+          label + ": getViewportRect centre hits the element",
+          viewHit === element,
+          element.id + " -> " +
+            (viewHit ? viewHit.id || viewHit.tagName : "none"),
+        );
+        check(
+          label + ": rect factor",
+          near(view.width / raw.width, webkit ? 0.472155 : 1, 1e-6),
+          "view/raw=" + (view.width / raw.width).toFixed(6),
+        );
+      }
+
+      // A pinch hands `setZoom` its midpoint, which must stay put. The top of
+      // the viewport is where the settling loop converges either way.
+      async function pinchTest(label, webkit, focusY) {
+        var win = await load("content=page&zoom=0.5&webkit=" + (webkit ? 1 : 0));
+        scrollTo(win, 2500);
+        await wait(80);
+
+        var cx = Math.floor(win.document.documentElement.clientWidth / 2);
+        var before = docAt(win, focusY);
+        win.odr.setZoom(0.8, { x: cx, y: focusY });
+        await wait(200);
+        var after = docAt(win, focusY);
+
+        check(
+          label + ": the point under the pinch stays put (y=" + focusY + ")",
+          near(after, before, 24),
+          before.toFixed(1) + " -> " + after.toFixed(1) + ", off by " +
+            (after - before).toFixed(1) + "px of document",
+        );
+      }
+
+      // A stated fit does not follow the viewport; the reader's place does.
+      async function resizeHoldTest(label) {
+        var win = await load("content=prose&fit=0.5", 900);
+        scrollTo(win, 4000);
+        await wait(120);
+        var before = topId(win);
+
+        resizeTo(win, frame, 400);
+        await wait(150);
+        var after = topId(win);
+
+        check(
+          label + ": the paragraph at the top survives a width change",
+          before === after,
+          before + " -> " + after,
+        );
+      }
+
+      (async function () {
+        say("--- rect space against viewport space ---");
+        await rectTest("chromium", false, true);
+        await rectTest("webkit-simulated", true, false);
+
+        say("");
+        say("--- the pinch focus holds ---");
+        await pinchTest("chromium", false, 400);
+        await pinchTest("webkit-simulated", true, 400);
+
+        say("");
+        say("--- a stated fit holds the reading position ---");
+        await resizeHoldTest("resize");
+
+        say("");
+        say(failed ? "<b>" + failed + " failed</b>" : "all passed");
+      })();
+    </script>
+  </body>
+</html>

--- a/test/browser/viewport/tests.html
+++ b/test/browser/viewport/tests.html
@@ -106,7 +106,7 @@
 
       // Webkit does not carry an applied `body{zoom}` in a rect, so what a host
       // reads off one is not what `elementFromPoint` takes.
-      async function rectTest(label, webkit, expectRawHit) {
+      async function rectTest(label, webkit) {
         var win = await load(
           "content=page&zoom=0.472155&webkit=" + (webkit ? 1 : 0),
         );
@@ -131,8 +131,8 @@
 
         check(
           label + ": a raw rect centre hits the element",
-          (rawHit === element) === expectRawHit,
-          "expected " + (expectRawHit ? "a hit" : "a miss") + ", got " +
+          (rawHit === element) === !webkit,
+          "expected " + (webkit ? "a miss" : "a hit") + ", got " +
             (rawHit ? rawHit.id || rawHit.tagName : "none"),
         );
         check(
@@ -145,6 +145,11 @@
           label + ": rect factor",
           near(view.width / raw.width, webkit ? 0.472155 : 1, 1e-6),
           "view/raw=" + (view.width / raw.width).toFixed(6),
+        );
+        check(
+          label + ": a non-element gives null",
+          win.odr.getViewportRect(null) === null &&
+            win.odr.getViewportRect({}) === null,
         );
       }
 
@@ -161,6 +166,16 @@
         await wait(200);
         var after = docAt(win, focusY);
 
+        // Read off the body, not `odr.getZoom()`: that answers with what was
+        // asked for, whether or not it was ever applied - and a zoom that
+        // never lands moves nothing, which the check below cannot tell from a
+        // held point.
+        var applied = parseFloat(getComputedStyle(win.document.body).zoom);
+        check(
+          label + ": the zoom applied",
+          near(applied, 0.8, 1e-6),
+          "body zoom=" + applied,
+        );
         check(
           label + ": the point under the pinch stays put (y=" + focusY + ")",
           near(after, before, 24),
@@ -189,8 +204,8 @@
 
       (async function () {
         say("--- rect space against viewport space ---");
-        await rectTest("chromium", false, true);
-        await rectTest("webkit-simulated", true, false);
+        await rectTest("chromium", false);
+        await rectTest("webkit-simulated", true);
 
         say("");
         say("--- the pinch focus holds ---");


### PR DESCRIPTION
🤖 Generated with [Claude Code](https://claude.com/claude-code)

Two defects in the emitted zoom script, both against 6.10.0 and neither waiting on #726's mode (4). Stacked on top of this: the opt-in live fit itself.

## The coordinate split

`getBoundingClientRect` carries an applied `body{zoom}` on chromium (since 128) and not on webkit, while `elementFromPoint` takes viewport coordinates on both. `anchor()` and `restore()` mixed the two spaces directly, so on webkit a `body{zoom}` — written by `viewport_width`, or applied by `odr.setZoom()` — put the anchor's `intoY` in one space and its target point in the other.

What that costs, measured:

| | `setZoom(0.8)` from 0.5, webkit | |
|---|---|---|
| focus at `y = 400` | **off by 301px of document** | fixed: 1.3px |
| no focus (`y = 1`) | off by 1.3px | 0.6px |

The unfocused anchor was already right, which is why nothing had shown up: `restore()` is re-asserted over 30 frames, and that iteration converges on the same answer for a point at `y = 1` whatever space it computes in. A pinch's focus is where it comes apart.

`rectFactor()` measures how much of the zoom the engine reports, through a 100px probe, and caches the answer — it is a property of the engine, and only decidable while a zoom is applied, which is also the only time it matters. The correction is `1` on chromium, so nothing changes there.

`odr.getViewportRect(element)` puts the same conversion in reach of a host. That is the half core cannot fix from inside: OpenDocument.ios#180's edit test reads a rect and hands its centre to `elementFromPoint`, which picks nothing while a fit is applied.

## The dropped reading position

`resized()` assigned `width` before delegating, so `remember()`'s `root.clientWidth !== width` guard passed and `held = anchor()` overwrote the pre-resize anchor with one read after the browser had already relaid out and moved the scroll. Every view whose zoom does not follow the viewport — a stated `viewport_width`, a pinned `initial_zoom`, a sheet — lost the reader's place on every rotation.

The settling loop is now `settle()`, which `apply()` calls after changing the zoom and `resized()` calls without changing it. A prose document scrolled to paragraph 143, viewport 900 → 400: **p143 → p100 before, p143 → p143 after.**

This is a behaviour change beyond the missing variable, and the changelog says so: a sheet resized in a desktop browser now holds its place too. Chromium's own scroll anchoring was already doing approximately this; webkit has none.

## Verification

`test/browser/viewport/` — the harness this was measured with, added because `viewport.js` had no way to be tested and this changes what it does. `serve` lifts the script out of `frontend.cpp` so it cannot drift from what ships; `tests.html` runs it in an iframe and reports.

Both engines are covered from one browser: `page.html?webkit=1` divides the zoom back out of chromium's rects, which is exactly what webkit returns. Positions are read as `(scrollY + y) / zoom`, never through the script's own helpers, and `overflow-anchor: none` keeps chromium's scroll anchoring from covering for the script. It is run by hand — there is no headless driver here — and the README says what each choice is for.

Against this branch all seven checks pass; against `main`'s script the pinch is 301px out, the resize drifts 43 paragraphs, and `getViewportRect` does not exist.

## Not covered

Neither fix has been run on a real device — no ios simulator or android emulator in this loop. The webkit half is a simulation of the behaviour OpenDocument.ios#180 measured, not a reading from webkit itself.
