### PR TITLE
feat(html): let a host ask the view to measure the fit itself

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -57,6 +57,9 @@ The release run heads these entries with the version and opens a fresh
   `elementFromPoint` takes, for a host hit-testing while a zoom is applied.
 - A view whose zoom does not follow the viewport — `viewport_width`,
   `initial_zoom`, a sheet — keeps the reader's place across a width change.
+- New `HtmlViewportMode::fit_width_by_view`: the view measures the fit and keeps
+  it current, so a rotation refits instead of holding what it opened at. For a
+  host whose web view does not fit a top-level document itself.
 
 ## v6.10.1 - 2026-08-21
 

--- a/apple/include/OdrCoreObjC/ODRHtml.h
+++ b/apple/include/OdrCoreObjC/ODRHtml.h
@@ -37,8 +37,8 @@ typedef NS_ENUM(NSInteger, ODRHtmlColorScheme) {
   ODRHtmlColorSchemeSystem,
 } NS_SWIFT_NAME(HtmlColorScheme);
 
-/// Initial zoom of the emitted HTML on mobile (the viewport meta tag). Desktop
-/// browsers ignore it entirely.
+/// The zoom a view opens at, and who fits it: the browser through the viewport
+/// meta tag, which desktop browsers ignore, or the view itself.
 typedef NS_ENUM(NSInteger, ODRHtmlViewportMode) {
   /// Fixed-size paged content fits the width; reflowing content is actual size.
   ODRHtmlViewportModeAutomatic = 0,
@@ -46,6 +46,8 @@ typedef NS_ENUM(NSInteger, ODRHtmlViewportMode) {
   ODRHtmlViewportModeActualSize,
   /// No viewport meta tag at all.
   ODRHtmlViewportModeNone,
+  /// The view measures and applies the fit itself, and keeps it current.
+  ODRHtmlViewportModeFitWidthByView,
 } NS_SWIFT_NAME(HtmlViewportMode);
 
 /// How text is emitted in PDF→HTML output.

--- a/apple/src/ODRHtml.mm
+++ b/apple/src/ODRHtml.mm
@@ -36,6 +36,8 @@ ODR_SAME_ENUM(ODRHtmlViewportModeFitWidth, odr::HtmlViewportMode::fit_width);
 ODR_SAME_ENUM(ODRHtmlViewportModeActualSize,
               odr::HtmlViewportMode::actual_size);
 ODR_SAME_ENUM(ODRHtmlViewportModeNone, odr::HtmlViewportMode::none);
+ODR_SAME_ENUM(ODRHtmlViewportModeFitWidthByView,
+              odr::HtmlViewportMode::fit_width_by_view);
 
 ODR_SAME_ENUM(ODRPdfTextModeDualLayer, odr::PdfTextMode::dual_layer);
 ODR_SAME_ENUM(ODRPdfTextModeSingleLayer, odr::PdfTextMode::single_layer);

--- a/jni/java/app/opendocument/core/HtmlViewportMode.java
+++ b/jni/java/app/opendocument/core/HtmlViewportMode.java
@@ -2,7 +2,7 @@ package app.opendocument.core;
 
 /** Mirrors {@code odr::HtmlViewportMode}; constant order must match the C++ declaration. */
 public enum HtmlViewportMode {
-  AUTOMATIC, FIT_WIDTH, ACTUAL_SIZE, NONE;
+  AUTOMATIC, FIT_WIDTH, ACTUAL_SIZE, NONE, FIT_WIDTH_BY_VIEW;
 
   static HtmlViewportMode fromNative(int code) {
     return code < 0 ? null : values()[code];

--- a/jni/tests/app/opendocument/core/HtmlTest.java
+++ b/jni/tests/app/opendocument/core/HtmlTest.java
@@ -81,6 +81,12 @@ class HtmlTest {
             .contains(
                 "<meta name=\"viewport\" content=\"width=device-width,user-scalable=yes\"/>"));
 
+    // only paged content has a width to fit, hence the margins
+    HtmlConfig byView = new HtmlConfig();
+    byView.viewportMode = HtmlViewportMode.FIT_WIDTH_BY_VIEW;
+    byView.textDocumentMargin = true;
+    assertTrue(renderOdt(byView).contains("--odr-fit:view"));
+
     HtmlConfig raw = new HtmlConfig();
     raw.viewportContent = "width=420";
     assertTrue(renderOdt(raw).contains("<meta name=\"viewport\" content=\"width=420\"/>"));

--- a/python/src/bind_html.cpp
+++ b/python/src/bind_html.cpp
@@ -39,7 +39,8 @@ void odr_python::bind_html(py::module_ &m) {
       .value("automatic", odr::HtmlViewportMode::automatic)
       .value("fit_width", odr::HtmlViewportMode::fit_width)
       .value("actual_size", odr::HtmlViewportMode::actual_size)
-      .value("none", odr::HtmlViewportMode::none);
+      .value("none", odr::HtmlViewportMode::none)
+      .value("fit_width_by_view", odr::HtmlViewportMode::fit_width_by_view);
 
   py::enum_<odr::PdfTextMode>(m, "PdfTextMode")
       .value("dual_layer", odr::PdfTextMode::dual_layer)

--- a/python/tests/test_html.py
+++ b/python/tests/test_html.py
@@ -79,6 +79,12 @@ def test_viewport_mode_reaches_the_html(odt_path, tmp_path):
         in render("fit_width", fit_width)
     )
 
+    # only paged content has a width to fit, hence the margins
+    by_view = pyodr.HtmlConfig()
+    by_view.viewport_mode = pyodr.HtmlViewportMode.fit_width_by_view
+    by_view.text_document_margin = True
+    assert "--odr-fit:view" in render("by_view", by_view)
+
     raw = pyodr.HtmlConfig()
     raw.viewport_content = "width=420"
     assert '<meta name="viewport" content="width=420"/>' in render("raw", raw)

--- a/src/odr/html.hpp
+++ b/src/odr/html.hpp
@@ -81,8 +81,8 @@ enum class HtmlColorScheme {
   system, ///< `light` or `dark`, by the reader's `prefers-color-scheme`
 };
 
-/// @brief Initial zoom of the emitted HTML on mobile (viewport meta tag).
-/// Desktop browsers ignore the tag entirely.
+/// @brief The zoom a view opens at, and who fits it: the browser through the
+/// viewport meta tag, which desktop browsers ignore, or the view itself.
 enum class HtmlViewportMode {
   automatic,   ///< `fit_width` for fixed-size paged content (PDF pages, slides,
                ///< drawings, images, text documents with page margins),
@@ -90,6 +90,10 @@ enum class HtmlViewportMode {
   fit_width,   ///< initial zoom fits the content's full width on screen
   actual_size, ///< initial zoom locked to 100% (`initial-scale=1.0`)
   none,        ///< no viewport meta tag at all
+  /// Like @ref fit_width, but measured by the view and kept current, so a
+  /// rotation refits. Needs the script. Last because the bindings map this
+  /// enum by ordinal.
+  fit_width_by_view,
 };
 
 /// @brief How text is emitted in PDF→HTML output. Neither mode needs
@@ -141,7 +145,7 @@ struct HtmlConfig {
   /// Which gridlines a sheet paints.
   HtmlTableGridlines spreadsheet_gridlines{HtmlTableGridlines::soft};
 
-  /// Initial zoom on mobile; see @ref HtmlViewportMode.
+  /// The zoom the view opens at; see @ref HtmlViewportMode.
   HtmlViewportMode viewport_mode{HtmlViewportMode::automatic};
   /// Overrides @ref viewport_mode for spreadsheet content when set.
   std::optional<HtmlViewportMode> spreadsheet_viewport_mode;

--- a/src/odr/internal/html/common.cpp
+++ b/src/odr/internal/html/common.cpp
@@ -15,6 +15,7 @@
 #include <iomanip>
 #include <sstream>
 #include <string>
+#include <string_view>
 #include <unordered_map>
 
 namespace odr::internal {
@@ -39,6 +40,8 @@ void html::write_viewport_meta(
     out.write_header_viewport("width=device-width,user-scalable=yes");
     break;
   case HtmlViewportMode::actual_size:
+  // A stated scale is what turns the browser's own fitting off.
+  case HtmlViewportMode::fit_width_by_view:
     out.write_header_viewport(
         "width=device-width,initial-scale=1.0,user-scalable=yes");
     break;
@@ -48,18 +51,25 @@ void html::write_viewport_meta(
   }
 }
 
-bool html::fits_width(const HtmlConfig &config, const bool fit_width_by_default,
-                      const std::optional<HtmlViewportMode> mode_override) {
+html::WidthFit
+html::width_fit(const HtmlConfig &config, const bool fit_width_by_default,
+                const std::optional<HtmlViewportMode> mode_override) {
   // A raw `viewport_content` is the caller taking the question over.
   if (config.viewport_content.has_value()) {
-    return false;
+    return WidthFit::none;
   }
 
   const HtmlViewportMode mode = mode_override.value_or(config.viewport_mode);
-  if (mode == HtmlViewportMode::automatic) {
-    return fit_width_by_default;
+  switch (mode) {
+  case HtmlViewportMode::automatic:
+    return fit_width_by_default ? WidthFit::browser : WidthFit::none;
+  case HtmlViewportMode::fit_width:
+    return WidthFit::browser;
+  case HtmlViewportMode::fit_width_by_view:
+    return WidthFit::view;
+  default:
+    return WidthFit::none;
   }
-  return mode == HtmlViewportMode::fit_width;
 }
 
 std::optional<double> html::css_pixels(const std::optional<Measure> &measure) {
@@ -82,18 +92,28 @@ std::optional<double> html::css_pixels(const std::optional<Measure> &measure) {
 }
 
 void html::write_zoom_style(HtmlWriter &out, const HtmlConfig &config,
-                            const bool fits,
+                            const WidthFit fits,
                             const std::optional<double> content_pixels) {
+  // The factor, or who measures it where the css cannot state it.
   std::optional<double> fit = 1;
-  if (fits) {
+  std::string_view measures;
+  switch (fits) {
+  case WidthFit::none:
+    break;
+  case WidthFit::browser:
     if (config.viewport_width.has_value() && content_pixels.has_value()) {
       // only ever down: a page narrower than the viewport is shown at its size
       fit = std::min(1.0, static_cast<double>(config.viewport_width.value()) /
                               *content_pixels);
     } else {
-      // only the view can measure this one
       fit.reset();
+      measures = "auto";
     }
+    break;
+  case WidthFit::view:
+    fit.reset();
+    measures = "view";
+    break;
   }
 
   const std::optional<double> zoom =
@@ -118,7 +138,7 @@ void html::write_zoom_style(HtmlWriter &out, const HtmlConfig &config,
       if (fit.has_value()) {
         out.out() << number(*fit);
       } else {
-        out.out() << "auto";
+        out.out() << measures;
       }
       if (writes_pin) {
         out.out() << ";";

--- a/src/odr/internal/html/common.hpp
+++ b/src/odr/internal/html/common.hpp
@@ -46,10 +46,16 @@ void write_viewport_meta(HtmlWriter &out, const HtmlConfig &config,
                          bool fit_width_by_default,
                          std::optional<HtmlViewportMode> mode_override = {});
 
-/// Whether the output is meant to fit its width to the viewport.
-[[nodiscard]] bool
-fits_width(const HtmlConfig &config, bool fit_width_by_default,
-           std::optional<HtmlViewportMode> mode_override = {});
+/// Who fits the output's width to the viewport.
+enum class WidthFit {
+  none,    ///< nobody: it is shown at its size
+  browser, ///< the browser, steered by the viewport meta tag
+  view,    ///< the view itself, measured and kept current
+};
+
+[[nodiscard]] WidthFit
+width_fit(const HtmlConfig &config, bool fit_width_by_default,
+          std::optional<HtmlViewportMode> mode_override = {});
 
 /// @p measure in css pixels, or nothing without an absolute unit.
 [[nodiscard]] std::optional<double>
@@ -59,9 +65,9 @@ css_pixels(const std::optional<Measure> &measure);
 constexpr double page_column_gutter_pixels = 32;
 
 /// The zoom the view opens at: `--odr-fit` fits @p content_pixels into
-/// `config.viewport_width` (`auto` where only the view can measure it),
-/// `--odr-zoom` pins it, `body{zoom}` applies the winner.
-void write_zoom_style(HtmlWriter &out, const HtmlConfig &config, bool fits,
+/// `config.viewport_width`, or names who measures it instead, `--odr-zoom` pins
+/// it, `body{zoom}` applies the winner.
+void write_zoom_style(HtmlWriter &out, const HtmlConfig &config, WidthFit fits,
                       std::optional<double> content_pixels);
 
 std::string escape_text(std::string text);

--- a/src/odr/internal/html/document.cpp
+++ b/src/odr/internal/html/document.cpp
@@ -117,8 +117,9 @@ void front(const Document &document, const WritingState &state,
       viewport_mode_override(document, state.config());
   write_viewport_meta(out, state.config(), paged_content, mode_override);
   write_zoom_style(out, state.config(),
-                   paged_content &&
-                       fits_width(state.config(), paged_content, mode_override),
+                   paged_content
+                       ? width_fit(state.config(), paged_content, mode_override)
+                       : WidthFit::none,
                    content_pixels);
 
   write_document_style(state);

--- a/src/odr/internal/html/filesystem.cpp
+++ b/src/odr/internal/html/filesystem.cpp
@@ -188,7 +188,7 @@ public:
     out.write_header_target("_blank");
     out.write_header_title("odr");
     write_viewport_meta(out, config(), false);
-    write_zoom_style(out, config(), false, {});
+    write_zoom_style(out, config(), WidthFit::none, {});
     write_filesystem_style(state);
     write_filesystem_dark_style(state);
     write_search_style(state);

--- a/src/odr/internal/html/frontend.cpp
+++ b/src/odr/internal/html/frontend.cpp
@@ -337,17 +337,17 @@ constexpr std::string_view viewport_js = R"js(
   var minZoom = 0.1;
   var maxZoom = 10;
 
-  // Only a frame is fitted here: the viewport meta tag covers the top-level
-  // document but is inert in a frame.
   var framed = window.top !== window.self;
 
   function declared(name) {
     return getComputedStyle(root).getPropertyValue(name).trim();
   }
 
-  // `auto` where only we can measure the fit; a number where the css states it.
-  var measures = declared("--odr-fit") === "auto";
-  var fit = measures ? 1 : parseFloat(declared("--odr-fit")) || 1;
+  // A number is the css stating the fit; `view` and `auto` ask us to measure
+  // it. `auto` only in a frame, where the viewport meta tag is inert.
+  var stated = declared("--odr-fit");
+  var measures = stated === "view" || (stated === "auto" && framed);
+  var fit = measures ? 1 : parseFloat(stated) || 1;
 
   // `null` while the view follows the fit.
   var pinned = parseFloat(declared("--odr-zoom"));
@@ -382,9 +382,8 @@ constexpr std::string_view viewport_js = R"js(
 
   function measureFit() {
     var available = root.clientWidth;
-    if (!available || !framed) {
-      // Out of a frame the viewport meta tag has already fitted the document.
-      return available ? 1 : fit;
+    if (!available) {
+      return fit;
     }
     var content = contentWidth();
     if (!content) {

--- a/src/odr/internal/html/image_file.cpp
+++ b/src/odr/internal/html/image_file.cpp
@@ -120,10 +120,10 @@ public:
     write_viewport_meta(out, config(), true);
     // An image has no layout width to preserve, so css alone fits it, framed
     // or not - no measuring and no `viewport_width`.
-    write_zoom_style(out, config(), false, {});
+    write_zoom_style(out, config(), WidthFit::none, {});
     out.write_header_style_begin();
     out.out() << "body{margin:0;background:#fff}";
-    if (fits_width(config(), true)) {
+    if (width_fit(config(), true) != WidthFit::none) {
       // `100%` of a zoomed body is the viewport again, so the factor has to
       // be put back for the image to grow with it
       out.out() << "img{max-width:calc(100% * var(--odr-zoom, 1));"

--- a/src/odr/internal/html/pdf_file.cpp
+++ b/src/odr/internal/html/pdf_file.cpp
@@ -2586,7 +2586,7 @@ public:
     out.write_header_target("_blank");
     out.write_header_title("odr");
     write_viewport_meta(out, config(), true);
-    write_zoom_style(out, config(), fits_width(config(), true), content);
+    write_zoom_style(out, config(), width_fit(config(), true), content);
     out.write_header_style_begin();
     out.out() << "body{margin:0;background:#525659}";
     // `.d`: the page column, sized to the widest page so pages of differing

--- a/src/odr/internal/html/text_file.cpp
+++ b/src/odr/internal/html/text_file.cpp
@@ -99,7 +99,7 @@ public:
     out.write_header_target("_blank");
     out.write_header_title("odr");
     write_viewport_meta(out, config(), false);
-    write_zoom_style(out, config(), false, {});
+    write_zoom_style(out, config(), WidthFit::none, {});
 
     write_text_style(state);
     write_text_dark_style(state);

--- a/src/odr/internal/html/xml_file.cpp
+++ b/src/odr/internal/html/xml_file.cpp
@@ -259,7 +259,7 @@ public:
     out.write_header_target("_blank");
     out.write_header_title("odr");
     write_viewport_meta(out, config(), false);
-    write_zoom_style(out, config(), false, {});
+    write_zoom_style(out, config(), WidthFit::none, {});
 
     write_xml_style(state);
     write_xml_dark_style(state);

--- a/test/browser/viewport/README.md
+++ b/test/browser/viewport/README.md
@@ -29,5 +29,10 @@ Why the harness is shaped this way:
 - **Positions are read as `(scrollY + y) / zoom`**, never through the script's
   helpers, so a wrong answer cannot agree with itself.
 
-Keep the tab on screen: the browser throttles `resize` and
-`requestAnimationFrame` in a window that is not.
+Who fits the width is the one thing a frame cannot check: `--odr-fit` `auto` and
+`view` both measure in one. `tests.html` links the two top-level pages that can,
+each printing its own verdict.
+
+Keep the tab on screen: the browser throttles `requestAnimationFrame` in a
+window that is not. The harness dispatches the scroll and resize events itself,
+but not the settling frames that follow them.

--- a/test/browser/viewport/page.html
+++ b/test/browser/viewport/page.html
@@ -3,7 +3,8 @@
   <head>
     <meta charset="utf-8" />
     <script>
-      // Query: webkit=1, fit=<number>|auto, zoom=<number>, content=page|prose
+      // Query: webkit=1, fit=<number>|auto|view, zoom=<number>,
+      // content=page|prose, width=<page width in px>, expect=fit|nofit
       var q = new URLSearchParams(location.search);
       window.__q = q;
     </script>
@@ -77,6 +78,9 @@
         } else {
           var page = document.createElement("div");
           page.className = "odr-page";
+          if (q.get("width")) {
+            page.style.width = q.get("width") + "px";
+          }
           for (var j = 0; j < 400; ++j) {
             var line = document.createElement("div");
             line.className = "line";
@@ -114,7 +118,49 @@
         script.src = "viewport.js";
         script.onload = function () {
           window.__ready = true;
+          if (q.get("expect")) {
+            report(q.get("expect"));
+          }
         };
+
+        // For the checks that have to be run at the top level, where an iframe
+        // cannot stand in: `fit` expects the view to have fitted the page,
+        // `nofit` expects it to have left the width to the browser.
+        function report(expect) {
+          var root = document.documentElement;
+          var page = document.querySelector(".odr-page");
+          var pageWidth = page ? parseFloat(getComputedStyle(page).width) : 0;
+          var zoom = parseFloat(getComputedStyle(document.body).zoom) || 1;
+          var overflows = root.scrollWidth > root.clientWidth;
+          // A page no wider than the window says nothing either way, and a
+          // script that loaded but threw leaves the zoom at 1 like `nofit`.
+          var ok =
+            !!window.odr &&
+            pageWidth > root.clientWidth &&
+            (expect === "fit"
+              ? Math.abs(zoom - root.clientWidth / pageWidth) < 0.01
+              : zoom === 1 && overflows);
+          var banner = document.createElement("div");
+          banner.style.cssText =
+            "position:fixed;inset:0 0 auto 0;z-index:9;padding:8px 12px;" +
+            "font:14px/1.4 monospace;color:#fff;background:" +
+            (ok ? "#060" : "#b00");
+          banner.textContent =
+            (ok ? "PASS" : "FAIL") +
+            "  " +
+            (window.top === window.self ? "top level" : "framed") +
+            ", --odr-fit:" +
+            getComputedStyle(root).getPropertyValue("--odr-fit").trim() +
+            ", page " +
+            pageWidth +
+            " in " +
+            root.clientWidth +
+            ", zoom " +
+            zoom.toFixed(4) +
+            (overflows ? ", overflows" : ", no overflow") +
+            (window.odr ? "" : ", no odr");
+          document.body.appendChild(banner);
+        }
         document.head.appendChild(script);
       })();
     </script>

--- a/test/browser/viewport/tests.html
+++ b/test/browser/viewport/tests.html
@@ -184,6 +184,29 @@
         );
       }
 
+      // `auto` is measured in a frame only; `view` wherever the view is. A frame
+      // cannot tell the two apart, so the top-level half is linked below.
+      async function framedFitTest(label, fit) {
+        var page = 2400;
+        var win = await load("content=page&width=" + page + "&fit=" + fit, 600);
+        var doc = win.document;
+
+        async function fits(what) {
+          await wait(200);
+          var zoom = parseFloat(getComputedStyle(doc.body).zoom) || 1;
+          var want = doc.documentElement.clientWidth / page;
+          check(
+            label + ": " + what,
+            near(zoom, want, 0.01),
+            "zoom " + zoom.toFixed(4) + ", want " + want.toFixed(4),
+          );
+        }
+
+        await fits("a frame fits the page it holds");
+        resizeTo(win, frame, 300);
+        await fits("and refits it when the frame narrows");
+      }
+
       // A stated fit does not follow the viewport; the reader's place does.
       async function resizeHoldTest(label) {
         var win = await load("content=prose&fit=0.5", 900);
@@ -217,7 +240,25 @@
         await resizeHoldTest("resize");
 
         say("");
+        say("--- who measures the fit ---");
+        await framedFitTest("--odr-fit:auto", "auto");
+        await framedFitTest("--odr-fit:view", "view");
+
+        say("");
         say(failed ? "<b>" + failed + " failed</b>" : "all passed");
+        say("");
+        say("At the top level, where a frame cannot stand in - open each and");
+        say("read the banner:");
+        // Wider than the window it opens in, or neither banner says anything.
+        var wide = "content=page&width=" + Math.ceil(window.innerWidth * 2);
+        say(
+          '  <a href="page.html?' + wide + '&fit=view&expect=fit">' +
+            "--odr-fit:view fits itself</a>",
+        );
+        say(
+          '  <a href="page.html?' + wide + '&fit=auto&expect=nofit">' +
+            "--odr-fit:auto leaves it to the browser</a>",
+        );
       })();
     </script>
   </body>

--- a/test/src/html_test.cpp
+++ b/test/src/html_test.cpp
@@ -362,6 +362,18 @@ TEST(html, paged_output_fits_the_viewport) {
   }
 
   {
+    // The meta tag pins the scale so the browser does not fit it as well.
+    HtmlConfig config;
+    config.viewport_mode = HtmlViewportMode::fit_width_by_view;
+    config.viewport_width = 400;
+    const std::string html = render(config);
+    EXPECT_NE(html.find("--odr-fit:view"), std::string::npos);
+    EXPECT_NE(html.find("initial-scale=1.0"), std::string::npos);
+    // nothing to open at: the view measures and applies it
+    EXPECT_EQ(html.find("body{zoom:0."), std::string::npos);
+  }
+
+  {
     // A pinned zoom is what the view opens at, fit or no fit.
     HtmlConfig config;
     config.initial_zoom = 2;

--- a/test/src/internal/html/common_test.cpp
+++ b/test/src/internal/html/common_test.cpp
@@ -44,6 +44,14 @@ TEST(html_common, viewport_mode_beats_automatic_default) {
   EXPECT_EQ(emit_viewport(config, false), fit_width);
 }
 
+TEST(html_common, fit_width_by_view_pins_the_scale_the_browser_would_fit) {
+  HtmlConfig config;
+  config.viewport_mode = HtmlViewportMode::fit_width_by_view;
+  // the view fits it, so the browser is told not to
+  EXPECT_EQ(emit_viewport(config, true), actual_size);
+  EXPECT_EQ(emit_viewport(config, false), actual_size);
+}
+
 TEST(html_common, viewport_mode_none_writes_nothing) {
   HtmlConfig config;
   config.viewport_mode = HtmlViewportMode::none;
@@ -71,7 +79,7 @@ TEST(html_common, viewport_content_beats_modes_and_is_escaped) {
 
 namespace {
 
-std::string emit_zoom(const HtmlConfig &config, const bool fits,
+std::string emit_zoom(const HtmlConfig &config, const ihtml::WidthFit fits,
                       const std::optional<double> content_pixels) {
   std::ostringstream out;
   ihtml::HtmlWriter writer(out, false, "");
@@ -89,25 +97,34 @@ std::string styled(const std::string &css) {
 
 } // namespace
 
-TEST(html_common, fits_width_follows_the_resolved_mode) {
+TEST(html_common, width_fit_follows_the_resolved_mode) {
+  using ihtml::WidthFit;
   HtmlConfig config;
 
-  EXPECT_TRUE(ihtml::fits_width(config, true));
-  EXPECT_FALSE(ihtml::fits_width(config, false));
+  EXPECT_EQ(ihtml::width_fit(config, true), WidthFit::browser);
+  EXPECT_EQ(ihtml::width_fit(config, false), WidthFit::none);
 
   config.viewport_mode = HtmlViewportMode::fit_width;
-  EXPECT_TRUE(ihtml::fits_width(config, false));
+  EXPECT_EQ(ihtml::width_fit(config, false), WidthFit::browser);
 
   config.viewport_mode = HtmlViewportMode::actual_size;
-  EXPECT_FALSE(ihtml::fits_width(config, true));
+  EXPECT_EQ(ihtml::width_fit(config, true), WidthFit::none);
+
+  config.viewport_mode = HtmlViewportMode::fit_width_by_view;
+  EXPECT_EQ(ihtml::width_fit(config, false), WidthFit::view);
 
   config.viewport_mode = HtmlViewportMode::automatic;
-  EXPECT_TRUE(ihtml::fits_width(config, true, HtmlViewportMode::fit_width));
-  EXPECT_FALSE(ihtml::fits_width(config, true, HtmlViewportMode::none));
+  EXPECT_EQ(ihtml::width_fit(config, true, HtmlViewportMode::fit_width),
+            WidthFit::browser);
+  EXPECT_EQ(ihtml::width_fit(config, true, HtmlViewportMode::none),
+            WidthFit::none);
+  EXPECT_EQ(
+      ihtml::width_fit(config, false, HtmlViewportMode::fit_width_by_view),
+      WidthFit::view);
 
   // the caller took the question over
   config.viewport_content = "width=420";
-  EXPECT_FALSE(ihtml::fits_width(config, true));
+  EXPECT_EQ(ihtml::width_fit(config, true), WidthFit::none);
 }
 
 TEST(html_common, css_pixels_converts_the_absolute_units) {
@@ -127,7 +144,7 @@ TEST(html_common, the_fit_scales_the_body_to_the_configured_viewport) {
   config.viewport_width = 400;
 
   // `--odr-zoom` states a pin, and nothing pinned this one
-  EXPECT_EQ(emit_zoom(config, true, 800),
+  EXPECT_EQ(emit_zoom(config, ihtml::WidthFit::browser, 800),
             styled(":root{--odr-fit:0.5}body{zoom:0.5}"));
 }
 
@@ -135,21 +152,34 @@ TEST(html_common, the_fit_never_scales_up) {
   HtmlConfig config;
   config.viewport_width = 1200;
 
-  EXPECT_EQ(emit_zoom(config, true, 800), styled(""));
+  EXPECT_EQ(emit_zoom(config, ihtml::WidthFit::browser, 800), styled(""));
 }
 
 TEST(html_common, the_fit_is_left_to_the_view_where_a_width_is_missing) {
   HtmlConfig config;
 
   // no viewport width configured — the view measures itself instead
-  EXPECT_EQ(emit_zoom(config, true, 800), styled(":root{--odr-fit:auto}"));
+  EXPECT_EQ(emit_zoom(config, ihtml::WidthFit::browser, 800),
+            styled(":root{--odr-fit:auto}"));
 
   config.viewport_width = 400;
-  EXPECT_EQ(emit_zoom(config, true, std::nullopt),
+  EXPECT_EQ(emit_zoom(config, ihtml::WidthFit::browser, std::nullopt),
             styled(":root{--odr-fit:auto}"));
 
   // nothing to fit: the view opens at actual size
-  EXPECT_EQ(emit_zoom(config, false, 800), styled(""));
+  EXPECT_EQ(emit_zoom(config, ihtml::WidthFit::none, 800), styled(""));
+}
+
+TEST(html_common, the_view_measures_the_fit_where_it_was_asked_to) {
+  HtmlConfig config;
+
+  EXPECT_EQ(emit_zoom(config, ihtml::WidthFit::view, 800),
+            styled(":root{--odr-fit:view}"));
+
+  // a stated width does not turn it back into a factor the css writes
+  config.viewport_width = 400;
+  EXPECT_EQ(emit_zoom(config, ihtml::WidthFit::view, 800),
+            styled(":root{--odr-fit:view}"));
 }
 
 TEST(html_common, a_pinned_zoom_replaces_the_fit_it_opens_at) {
@@ -157,14 +187,14 @@ TEST(html_common, a_pinned_zoom_replaces_the_fit_it_opens_at) {
   config.initial_zoom = 2;
 
   // nothing is fitted, so the pinned zoom stands alone
-  EXPECT_EQ(emit_zoom(config, false, 800),
+  EXPECT_EQ(emit_zoom(config, ihtml::WidthFit::none, 800),
             styled(":root{--odr-zoom:2}body{zoom:2}"));
 
   // the fit is still stated, so `resetZoom()` has one to go back to
   config.viewport_width = 400;
-  EXPECT_EQ(emit_zoom(config, true, 800),
+  EXPECT_EQ(emit_zoom(config, ihtml::WidthFit::browser, 800),
             styled(":root{--odr-fit:0.5;--odr-zoom:2}body{zoom:2}"));
-  EXPECT_EQ(emit_zoom(config, true, std::nullopt),
+  EXPECT_EQ(emit_zoom(config, ihtml::WidthFit::browser, std::nullopt),
             styled(":root{--odr-fit:auto;--odr-zoom:2}body{zoom:2}"));
 }
 
@@ -173,15 +203,15 @@ TEST(html_common, a_zoom_pinned_to_actual_size_is_still_a_pin) {
   config.initial_zoom = 1;
 
   // nothing to apply, but the view has to know the fit was turned down
-  EXPECT_EQ(emit_zoom(config, true, std::nullopt),
+  EXPECT_EQ(emit_zoom(config, ihtml::WidthFit::browser, std::nullopt),
             styled(":root{--odr-fit:auto;--odr-zoom:1}"));
 
   config.viewport_width = 400;
-  EXPECT_EQ(emit_zoom(config, true, 800),
+  EXPECT_EQ(emit_zoom(config, ihtml::WidthFit::browser, 800),
             styled(":root{--odr-fit:0.5;--odr-zoom:1}"));
 
   // and a pin that lands on the fit is a pin too: a resize leaves it alone
   config.initial_zoom = 0.5;
-  EXPECT_EQ(emit_zoom(config, true, 800),
+  EXPECT_EQ(emit_zoom(config, ihtml::WidthFit::browser, 800),
             styled(":root{--odr-fit:0.5;--odr-zoom:0.5}body{zoom:0.5}"));
 }

--- a/wasm/src/wasm_core.cpp
+++ b/wasm/src/wasm_core.cpp
@@ -107,11 +107,13 @@ emscripten::val enum_tables() {
              table(entry("light", HtmlColorScheme::light),
                    entry("dark", HtmlColorScheme::dark),
                    entry("system", HtmlColorScheme::system)));
-  result.set("HtmlViewportMode",
-             table(entry("automatic", HtmlViewportMode::automatic),
-                   entry("fit_width", HtmlViewportMode::fit_width),
-                   entry("actual_size", HtmlViewportMode::actual_size),
-                   entry("none", HtmlViewportMode::none)));
+  result.set(
+      "HtmlViewportMode",
+      table(entry("automatic", HtmlViewportMode::automatic),
+            entry("fit_width", HtmlViewportMode::fit_width),
+            entry("actual_size", HtmlViewportMode::actual_size),
+            entry("none", HtmlViewportMode::none),
+            entry("fit_width_by_view", HtmlViewportMode::fit_width_by_view)));
   result.set("PdfTextMode",
              table(entry("dual_layer", PdfTextMode::dual_layer),
                    entry("single_layer", PdfTextMode::single_layer)));

--- a/wasm/tests/enums.test.mjs
+++ b/wasm/tests/enums.test.mjs
@@ -25,6 +25,7 @@ const pinned = {
     fit_width: 1,
     actual_size: 2,
     none: 3,
+    fit_width_by_view: 4,
   },
   PdfTextMode: { dual_layer: 0, single_layer: 1 },
   EncryptionState: {


### PR DESCRIPTION
🤖 Generated with [Claude Code](https://claude.com/claude-code)

Stacked on #744 — review that first; base moves to `main` once it lands.

Mode (4) from #726: the view measures the fit and keeps it current, at the top level, opt-in.

## What it does

`HtmlViewportMode::fit_width_by_view` writes `--odr-fit:view`, which drops the `framed` condition in the script, **and** pins `initial-scale=1.0`.

The meta tag is the part #726 does not mention, and it is what makes this one switch rather than a negotiation: `loadWithOverviewMode` only fires where the page has not stated a scale. So droid does not have to turn it off, ios has nothing left for its user script to correct, and no host can end up fitting the document twice.

The three existing modes are untouched — `automatic` and `fit_width` still leave a top-level document to the meta tag, so nothing in the 377 public reference renders moves (full suite run below).

`viewport_width` set alongside it loses: `view` means the view keeps the fit current, which is the opposite of freezing a factor into the css. A host under a CSP that cannot run the script wants `viewport_width` and not this mode.

## The internal shape

`fits_width` → `width_fit`, returning `WidthFit::{none, host, view}`. The question stopped being yes/no — `#726` puts it as three modes where four are wanted — and a tri-state makes the contradictory combinations unrepresentable rather than something callers have to not write.

The enumerator is appended after `none`: apple casts the enum to `NSInteger` and jni maps it by ordinal, so the existing values stay put.

## Verification

- `odr_test` in full: 1199 tests, 1193 passed, 6 pre-existing skips — including the 280 reference-output comparisons, so no existing render moved.
- New: `html_common.fit_width_by_view_pins_the_scale_the_browser_would_fit`, `html_common.the_view_measures_the_fit_where_it_was_asked_to`, `width_fit_follows_the_resolved_mode` extended, and a case in `html.paged_output_fits_the_viewport`.
- jni: `viewportModeReachesTheHtml` extended and run green.
- Browser, `test/browser/viewport/`, a 2400px page: **top level** `--odr-fit:view` opens at 0.63 with no overflow in a 1512px window and refits to 0.3333 when the window goes to 800 — and `--odr-fit:auto` at the top level still opens at 1 and overflows, which is the behaviour this must not change. Framed, both fit. `tests.html` links the two top-level pages since a frame cannot tell the modes apart.

## Not run here

- **No device.** Neither an ios simulator nor an android emulator. What #726 says this mode buys the apps — the ios user script deleted, `loadWithOverviewMode` turned off — is unmeasured from this side.
- **python and wasm bindings compile-checked only by inspection**: the build dir's venv is gone and wasm needs emscripten. Both are a one-line enum registration beside three identical siblings. The apple binding does compile here, so its `ODR_SAME_ENUM` ordinal asserts hold.
- The python test added alongside them has not been run.
