### PR TITLE
fix(pdf): read a simple font's codes one byte at a time

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -77,6 +77,9 @@ The release run heads these entries with the version and opens a fresh
   missing.
 - An odf shape or frame that is not filled no longer paints the colour of one
   that was.
+- Text in a pdf can be selected, searched and copied where it came out as CJK
+  before. A simple font's codes are one byte each, whatever codespace its
+  `ToUnicode` map declares, and producers routinely declare two.
 
 ## v6.10.1 - 2026-08-21
 

--- a/src/odr/internal/pdf/AGENTS.md
+++ b/src/odr/internal/pdf/AGENTS.md
@@ -53,7 +53,13 @@ directly; legacy CJK CMaps via `pdf_cid`/`pdf_cid_data`: code → CID → Unicod
 `/CIDSystemInfo` collection for `Identity-H`/embedded-CMap → embedded-font reverse
 map (code → glyph → `code_point_for_glyph`). Only a genuinely unmapped code yields
 "no Unicode" — never byte-garbage. The point of the chain is that each link
-recovers a class of real-world PDF the previous one misses.
+recovers a class of real-world PDF the previous one misses. A **simple font's
+codes are one byte** (9.10.3), so `to_unicode` imposes that width rather than
+read it off the `/ToUnicode` codespace — producers write the two-byte
+`<0000> <FFFF>` boilerplate there regardless, and splitting by it pairs the
+bytes into CJK. The entries themselves are keyed either way, so an imposed
+one-byte code is also looked up zero-padded. Composite codes keep splitting by
+the codespace, as `Font::codes` splits them.
 
 **`std::any`-based object model.** `Object` holds its value in `std::any` with
 typed `is_*`/`as_*` accessors (mirrors `oldms/`'s `Entry`). Pro: one value type

--- a/src/odr/internal/pdf/pdf_cmap.cpp
+++ b/src/odr/internal/pdf/pdf_cmap.cpp
@@ -4,6 +4,7 @@
 
 #include <algorithm>
 #include <cstdint>
+#include <optional>
 
 namespace odr::internal::pdf {
 
@@ -62,19 +63,31 @@ std::size_t CMap::code_length(const std::string &codes,
   return code_width(static_cast<std::uint8_t>(codes[pos]));
 }
 
-std::string CMap::translate_string(const std::string &codes) const {
+std::string
+CMap::translate_string(const std::string &codes,
+                       const std::optional<std::size_t> code_width) const {
   std::u16string result;
 
   std::size_t pos = 0;
   while (pos < codes.size()) {
-    const std::size_t width =
-        std::min(code_length(codes, pos), codes.size() - pos);
+    const std::size_t width = std::min(
+        code_width.value_or(code_length(codes, pos)), codes.size() - pos);
     const std::string code = codes.substr(pos, width);
     pos += width;
 
     if (const auto it = m_map.find(code); it != m_map.end()) {
       result += it->second;
       continue;
+    }
+
+    // Only for an imposed width — a declared mixed codespace keeps `<20>` and
+    // `<0020>` distinct.
+    if (code_width.has_value() && code.size() == 1) {
+      if (const auto it = m_map.find(std::string(1, '\0') + code);
+          it != m_map.end()) {
+        result += it->second;
+        continue;
+      }
     }
 
     // Unknown code: fall back to its numeric value as a single UTF-16 unit

--- a/src/odr/internal/pdf/pdf_cmap.cpp
+++ b/src/odr/internal/pdf/pdf_cmap.cpp
@@ -63,15 +63,16 @@ std::size_t CMap::code_length(const std::string &codes,
   return code_width(static_cast<std::uint8_t>(codes[pos]));
 }
 
-std::string
-CMap::translate_string(const std::string &codes,
-                       const std::optional<std::size_t> code_width) const {
+std::string CMap::translate_string(const std::string &codes,
+                                   const bool single_byte_codes) const {
   std::u16string result;
 
   std::size_t pos = 0;
   while (pos < codes.size()) {
-    const std::size_t width = std::min(
-        code_width.value_or(code_length(codes, pos)), codes.size() - pos);
+    const std::size_t width =
+        single_byte_codes
+            ? 1
+            : std::min(code_length(codes, pos), codes.size() - pos);
     const std::string code = codes.substr(pos, width);
     pos += width;
 
@@ -82,7 +83,7 @@ CMap::translate_string(const std::string &codes,
 
     // Only for an imposed width — a declared mixed codespace keeps `<20>` and
     // `<0020>` distinct.
-    if (code_width.has_value() && code.size() == 1) {
+    if (single_byte_codes) {
       if (const auto it = m_map.find(std::string(1, '\0') + code);
           it != m_map.end()) {
         result += it->second;

--- a/src/odr/internal/pdf/pdf_cmap.hpp
+++ b/src/odr/internal/pdf/pdf_cmap.hpp
@@ -56,8 +56,7 @@ public:
   /// does, keeping a mixed 1-/2-byte codespace aligned across both.
   [[nodiscard]] std::size_t code_width(std::uint8_t first) const;
 
-  /// `single_byte_codes` overrides the codespace ranges and splits the codes
-  /// one byte each (a simple font's width, ISO 32000-1 9.10.3). An imposed
+  /// `single_byte_codes` overrides the codespace ranges. An imposed
   /// single-byte code is also looked up zero-padded to two bytes, producers
   /// keying the entries either way.
   [[nodiscard]] std::string

--- a/src/odr/internal/pdf/pdf_cmap.hpp
+++ b/src/odr/internal/pdf/pdf_cmap.hpp
@@ -56,12 +56,13 @@ public:
   /// does, keeping a mixed 1-/2-byte codespace aligned across both.
   [[nodiscard]] std::size_t code_width(std::uint8_t first) const;
 
-  /// `code_width` overrides the codespace ranges. An imposed single-byte code
-  /// is also looked up zero-padded to two bytes, producers keying the entries
-  /// either way.
+  /// `single_byte_codes` overrides the codespace ranges and splits the codes
+  /// one byte each (a simple font's width, ISO 32000-1 9.10.3). An imposed
+  /// single-byte code is also looked up zero-padded to two bytes, producers
+  /// keying the entries either way.
   [[nodiscard]] std::string
   translate_string(const std::string &codes,
-                   std::optional<std::size_t> code_width = {}) const;
+                   bool single_byte_codes = false) const;
 
   /// True when at least one `cidchar`/`cidrange` mapping was parsed (an
   /// embedded CID `/Encoding` CMap). When false the composite code -> CID is

--- a/src/odr/internal/pdf/pdf_cmap.hpp
+++ b/src/odr/internal/pdf/pdf_cmap.hpp
@@ -56,7 +56,12 @@ public:
   /// does, keeping a mixed 1-/2-byte codespace aligned across both.
   [[nodiscard]] std::size_t code_width(std::uint8_t first) const;
 
-  [[nodiscard]] std::string translate_string(const std::string &codes) const;
+  /// `code_width` overrides the codespace ranges. An imposed single-byte code
+  /// is also looked up zero-padded to two bytes, producers keying the entries
+  /// either way.
+  [[nodiscard]] std::string
+  translate_string(const std::string &codes,
+                   std::optional<std::size_t> code_width = {}) const;
 
   /// True when at least one `cidchar`/`cidrange` mapping was parsed (an
   /// embedded CID `/Encoding` CMap). When false the composite code -> CID is

--- a/src/odr/internal/pdf/pdf_document.cpp
+++ b/src/odr/internal/pdf/pdf_document.cpp
@@ -161,8 +161,12 @@ std::uint16_t Font::glyph_for_code(const std::uint32_t code) const {
 }
 
 std::string Font::to_unicode(const std::string &codes) const {
+  // A simple font's codes are one byte each (ISO 32000-1 9.10.3); its
+  // `ToUnicode` codespace is not to be trusted, producers writing the
+  // two-byte `<0000> <FFFF>` boilerplate there regardless.
   if (!cmap.empty()) {
-    return cmap.translate_string(codes);
+    return composite ? cmap.translate_string(codes)
+                     : cmap.translate_string(codes, 1);
   }
   if (composite) {
     // A composite (Type0) font with no `ToUnicode` CMap. A predefined
@@ -210,7 +214,7 @@ std::string Font::to_unicode(const std::string &codes) const {
       !unicode.empty()) {
     return unicode;
   }
-  return cmap.translate_string(codes);
+  return cmap.translate_string(codes, 1);
 }
 
 } // namespace odr::internal::pdf

--- a/src/odr/internal/pdf/pdf_document.cpp
+++ b/src/odr/internal/pdf/pdf_document.cpp
@@ -165,8 +165,7 @@ std::string Font::to_unicode(const std::string &codes) const {
   // `ToUnicode` codespace is not to be trusted, producers writing the
   // two-byte `<0000> <FFFF>` boilerplate there regardless.
   if (!cmap.empty()) {
-    return composite ? cmap.translate_string(codes)
-                     : cmap.translate_string(codes, 1);
+    return cmap.translate_string(codes, /*single_byte_codes=*/!composite);
   }
   if (composite) {
     // A composite (Type0) font with no `ToUnicode` CMap. A predefined
@@ -214,7 +213,7 @@ std::string Font::to_unicode(const std::string &codes) const {
       !unicode.empty()) {
     return unicode;
   }
-  return cmap.translate_string(codes, 1);
+  return cmap.translate_string(codes, /*single_byte_codes=*/true);
 }
 
 } // namespace odr::internal::pdf

--- a/src/odr/internal/pdf/pdf_document.cpp
+++ b/src/odr/internal/pdf/pdf_document.cpp
@@ -165,7 +165,7 @@ std::string Font::to_unicode(const std::string &codes) const {
   // `ToUnicode` codespace is not to be trusted, producers writing the
   // two-byte `<0000> <FFFF>` boilerplate there regardless.
   if (!cmap.empty()) {
-    return cmap.translate_string(codes, /*single_byte_codes=*/!composite);
+    return cmap.translate_string(codes, !composite);
   }
   if (composite) {
     // A composite (Type0) font with no `ToUnicode` CMap. A predefined
@@ -213,7 +213,7 @@ std::string Font::to_unicode(const std::string &codes) const {
       !unicode.empty()) {
     return unicode;
   }
-  return cmap.translate_string(codes, /*single_byte_codes=*/true);
+  return cmap.translate_string(codes, true);
 }
 
 } // namespace odr::internal::pdf

--- a/test/src/internal/pdf/pdf_cmap.cpp
+++ b/test/src/internal/pdf/pdf_cmap.cpp
@@ -212,8 +212,7 @@ TEST(PdfCMap, imposed_code_width_overrides_codespace) {
                     "endbfchar\n");
 
   EXPECT_EQ(cmap.translate_string("\x41\x42"), "\xe4\x85\x82"); // U+4142
-  EXPECT_EQ(cmap.translate_string("\x41\x42", /*single_byte_codes=*/true),
-            "AB");
+  EXPECT_EQ(cmap.translate_string("\x41\x42", true), "AB");
 }
 
 TEST(PdfCMap, imposed_code_width_falls_back_to_a_padded_entry) {
@@ -225,8 +224,7 @@ TEST(PdfCMap, imposed_code_width_falls_back_to_a_padded_entry) {
                     "<0042> <0042>\n"
                     "endbfchar\n");
 
-  EXPECT_EQ(cmap.translate_string("\x41\x42", /*single_byte_codes=*/true),
-            "AB");
+  EXPECT_EQ(cmap.translate_string("\x41\x42", true), "AB");
 }
 
 TEST(PdfCMap, imposed_code_width_keeps_a_mixed_codespace_distinct) {

--- a/test/src/internal/pdf/pdf_cmap.cpp
+++ b/test/src/internal/pdf/pdf_cmap.cpp
@@ -212,7 +212,8 @@ TEST(PdfCMap, imposed_code_width_overrides_codespace) {
                     "endbfchar\n");
 
   EXPECT_EQ(cmap.translate_string("\x41\x42"), "\xe4\x85\x82"); // U+4142
-  EXPECT_EQ(cmap.translate_string("\x41\x42", 1), "AB");
+  EXPECT_EQ(cmap.translate_string("\x41\x42", /*single_byte_codes=*/true),
+            "AB");
 }
 
 TEST(PdfCMap, imposed_code_width_falls_back_to_a_padded_entry) {
@@ -224,7 +225,8 @@ TEST(PdfCMap, imposed_code_width_falls_back_to_a_padded_entry) {
                     "<0042> <0042>\n"
                     "endbfchar\n");
 
-  EXPECT_EQ(cmap.translate_string("\x41\x42", 1), "AB");
+  EXPECT_EQ(cmap.translate_string("\x41\x42", /*single_byte_codes=*/true),
+            "AB");
 }
 
 TEST(PdfCMap, imposed_code_width_keeps_a_mixed_codespace_distinct) {

--- a/test/src/internal/pdf/pdf_cmap.cpp
+++ b/test/src/internal/pdf/pdf_cmap.cpp
@@ -199,3 +199,46 @@ TEST(PdfCMap, usecmap_disables_local_codespace_authority) {
   EXPECT_TRUE(cmap.has_cid_map());
   EXPECT_EQ(cmap.cid_for_code(std::string_view("\x20", 1)), 1u);
 }
+
+TEST(PdfCMap, imposed_code_width_overrides_codespace) {
+  // A simple font's `ToUnicode` CMap carrying the two-byte `<0000> <FFFF>`
+  // boilerplate over one-byte entries; splitting by it pairs the codes up.
+  CMap cmap = parse("1 begincodespacerange\n"
+                    "<0000> <FFFF>\n"
+                    "endcodespacerange\n"
+                    "2 beginbfchar\n"
+                    "<41> <0041>\n"
+                    "<42> <0042>\n"
+                    "endbfchar\n");
+
+  EXPECT_EQ(cmap.translate_string("\x41\x42"), "\xe4\x85\x82"); // U+4142
+  EXPECT_EQ(cmap.translate_string("\x41\x42", 1), "AB");
+}
+
+TEST(PdfCMap, imposed_code_width_falls_back_to_a_padded_entry) {
+  CMap cmap = parse("1 begincodespacerange\n"
+                    "<0000> <FFFF>\n"
+                    "endcodespacerange\n"
+                    "2 beginbfchar\n"
+                    "<0041> <0041>\n"
+                    "<0042> <0042>\n"
+                    "endbfchar\n");
+
+  EXPECT_EQ(cmap.translate_string("\x41\x42", 1), "AB");
+}
+
+TEST(PdfCMap, imposed_code_width_keeps_a_mixed_codespace_distinct) {
+  // Padding is only for an imposed width; a declared mixed codespace keeps
+  // `<20>` and `<2120>` apart.
+  CMap cmap = parse("2 begincodespacerange\n"
+                    "<00> <20>\n"
+                    "<2100> <FFFF>\n"
+                    "endcodespacerange\n"
+                    "2 beginbfchar\n"
+                    "<20> <0041>\n"
+                    "<2120> <0042>\n"
+                    "endbfchar\n");
+
+  EXPECT_EQ(cmap.translate_string("\x20"), "A");
+  EXPECT_EQ(cmap.translate_string("\x21\x20"), "B");
+}

--- a/test/src/internal/pdf/pdf_font.cpp
+++ b/test/src/internal/pdf/pdf_font.cpp
@@ -185,9 +185,6 @@ TEST(PdfFont, to_unicode_prefers_cmap_over_reverse_map) {
 }
 
 TEST(PdfFont, simple_font_to_unicode_ignores_cmap_codespace) {
-  // A simple font whose `ToUnicode` CMap declares the two-byte
-  // `<0000> <FFFF>` boilerplate: the codes still split one byte each
-  // (splitting by the codespace would pair them into U+4142).
   Font font;
   font.cmap.add_codespace_range(codes2({0}), codes2({0xffff}));
   font.cmap.map_single("\x41", u"A");
@@ -197,8 +194,6 @@ TEST(PdfFont, simple_font_to_unicode_ignores_cmap_codespace) {
 }
 
 TEST(PdfFont, composite_to_unicode_splits_by_cmap_codespace) {
-  // The same codespace on a composite font stays authoritative: the two
-  // bytes form one code.
   Font font;
   font.composite = true;
   font.cmap.add_codespace_range(codes2({0}), codes2({0xffff}));

--- a/test/src/internal/pdf/pdf_font.cpp
+++ b/test/src/internal/pdf/pdf_font.cpp
@@ -184,6 +184,29 @@ TEST(PdfFont, to_unicode_prefers_cmap_over_reverse_map) {
   EXPECT_EQ(font.to_unicode(codes2({1})), "Z");
 }
 
+TEST(PdfFont, simple_font_to_unicode_ignores_cmap_codespace) {
+  // A simple font whose `ToUnicode` CMap declares the two-byte
+  // `<0000> <FFFF>` boilerplate: the codes still split one byte each
+  // (splitting by the codespace would pair them into U+4142).
+  Font font;
+  font.cmap.add_codespace_range(codes2({0}), codes2({0xffff}));
+  font.cmap.map_single("\x41", u"A");
+  font.cmap.map_single("\x42", u"B");
+
+  EXPECT_EQ(font.to_unicode("\x41\x42"), "AB");
+}
+
+TEST(PdfFont, composite_to_unicode_splits_by_cmap_codespace) {
+  // The same codespace on a composite font stays authoritative: the two
+  // bytes form one code.
+  Font font;
+  font.composite = true;
+  font.cmap.add_codespace_range(codes2({0}), codes2({0xffff}));
+  font.cmap.map_single(codes2({0x4142}), u"Z");
+
+  EXPECT_EQ(font.to_unicode("\x41\x42"), "Z");
+}
+
 TEST(PdfFont, simple_font_glyph_for_code_via_cmap) {
   // A simple (1-byte) TrueType font: the code's Unicode reaches the glyph
   // through the embedded (3,1) cmap.


### PR DESCRIPTION
🤖 Generated with [Claude Code](https://claude.com/claude-code)

A simple font's character codes are one byte each (ISO 32000-1 9.10.3), but `Font::to_unicode` split them by whatever codespace the `/ToUnicode` CMap declared. Producers write the two-byte `<0000> <FFFF>` boilerplate there regardless, so the bytes got paired up and the extracted text came out as CJK — `IAN 479084_2410` as `䥁丠㐷㤰㠴弲㐱0`.

Display was never affected: the glyph path goes through `Font::codes`, which already imposes the width. Only selection, search and copy were broken.

`CMap::translate_string` now takes the width to split by, and `to_unicode` imposes one byte for a simple font. An imposed one-byte code is also looked up zero-padded, since producers key the entries either way; a declared mixed codespace still keeps `<20>` and `<0020>` distinct.

## Verification

Rendered the 11 pdfs a user reported (all already in the test corpus), and compared against ghostscript page by page — rasters for display, `txtwrite` for text.

Word-level extraction recall vs ghostscript:

| file | before | after |
|---|---|---|
| `Rockrider_e-Actv500_Gebrauchsinformationen` | 30% | 100% |
| `Laserentfernungsmesser_PLEM50_D5` | 41% | 99% |
| `Thule_E-Flexi_G2_959` | 48% | 97% |
| `HUK_Fahrrad-Schutzbrief` | 57% | 100% |
| `Rockrider_e-Actv500_Allgemein_und_Garantie` | 92% | 100% |

The remaining misses are ghostscript's own — it drops Greek case and accents (`ΜΠΟΡΕΊ` → `μπορει`) and mis-decodes `ffi` ligatures, where odr is right.

Pixel-comparing all 255 rendered pages against their ghostscript rasters gives byte-identical scores before and after, as expected for a change confined to the invisible selection layer.

Full suite: 1226 passed, 0 failed, 6 pre-existing skips. Three new `PdfCMap` cases cover the imposed width, the zero-padded fallback and the mixed-codespace guard.