### PR TITLE
feat(pdf): skip laying out and painting an off-screen page

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -84,6 +84,9 @@ The release run heads these entries with the version and opens a fresh
 - Text in a pdf can be selected, searched and copied where it came out as CJK
   before. A simple font's codes are one byte each, whatever codespace its
   `ToUnicode` map declares, and producers routinely declare two.
+- A pdf page that is off screen is no longer laid out or painted. On a drawing-
+  heavy file this halves the time to open and takes a zoom step from ~340ms to
+  ~50ms.
 
 ## v6.10.1 - 2026-08-21
 

--- a/src/odr/internal/html/pdf_file.cpp
+++ b/src/odr/internal/html/pdf_file.cpp
@@ -2599,7 +2599,9 @@ public:
                  "width:max-content;min-width:100%}";
     // `overflow:hidden` clips to the crop box, as a viewer does: content may
     // sit outside it (a bleed, or an InDesign spread's other page).
-    out.out() << ".p{position:relative;"
+    // `content-visibility` skips an off-screen page; the box states its own
+    // size, so no `contain-intrinsic-size` and no scroll geometry change.
+    out.out() << ".p{content-visibility:auto;position:relative;"
                  "margin:0 max(16px,var(--odr-min-margin-right,0px)) 0 "
                  "max(16px,var(--odr-min-margin-left,0px));background:#fff;"
                  "overflow:hidden;box-shadow:0 1px 4px rgba(0,0,0,.5)}";


### PR DESCRIPTION
🤖 Generated with [Claude Code](https://claude.com/claude-code)

Stacked on #749.

A body zoom relays out every element on every page at every step. On a drawing-heavy pdf that is tens of thousands of SVG paths per page. `content-visibility:auto` on the page box lets the browser skip an off-screen page entirely.

One declaration. The box already states its own width and height, so it needs no `contain-intrinsic-size` and the scroll geometry does not move.

## Measured

`Sunfun_Melina_BBQ_Pavillion` (11 pages, 181k DOM nodes, 172k `<path>`), Chrome over loopback, rule in the stylesheet as shipped:

| | before | after |
|---|---|---|
| domComplete | 4316 ms | **2256 ms** |
| load event | 6018 ms | **2329 ms** |
| zoom frame, median | 340 ms | **48 ms** |
| zoom frame, max | 656 ms | **54 ms** |
| `scrollHeight` | 12540 | 12540 |

## Render-neutral

- All 255 rendered pages of the 11-file pdf corpus rasterised and scored against ghostscript: identical to the digit, before and after.
- `getBoundingClientRect()` inside a skipped page still returns real geometry, so search highlight positioning is unaffected — checked on the last page of an 11-page document (794x1123 @ top 11401).
- Print still emits all 9 pages with full content. The residual pixel delta is text antialiasing; a control printing the *same* file twice is already nondeterministic.

## Not in this PR

Swapping `body{zoom}` for `transform:scale()` removes the remaining layout cost entirely (~48ms -> ~12ms per frame), but it touches the `rectsZoomed` webkit probe in `viewport.js` and the browser checks, so it belongs on its own.

`content-visibility` needs Safari 18+ in WKWebView; older webviews ignore it and get today's behaviour.