### PR TITLE
fix(test): bind a pdf test's loop variable to the literal it iterates

### DIFF
--- a/test/src/internal/pdf/pdf_file.cpp
+++ b/test/src/internal/pdf/pdf_file.cpp
@@ -445,8 +445,7 @@ TEST(PdfFile, views_agree_on_an_image_name) {
 
   // path -> the bytes served under it, across every view
   std::map<std::string, std::string> bytes_by_path;
-  for (const std::string &view :
-       {"document.html", "page0.html", "page1.html"}) {
+  for (const auto *const view : {"document.html", "page0.html", "page1.html"}) {
     std::ostringstream out;
     for (const auto &[resource, location] : service.write_html(view, out)) {
       if (resource.type() != HtmlResourceType::image) {


### PR DESCRIPTION
`main` is red on gcc-14 since #751:

```
test/src/internal/pdf/pdf_file.cpp:448:27: error: loop variable 'view' of type
'const std::string&' binds to a temporary constructed from type 'const char* const'
[-Werror=range-loop-construct]
```

The loop iterates a braced list of `const char *`, so binding each element to a
`const std::string &` materialises a temporary per iteration. Clang does not
diagnose this, which is how it got through review and the mac/clang builds.

Iterating as `const auto *const` binds the pointer itself; the conversion to
`std::string` still happens at the `write_html` call, where it is intended.

🤖 Generated with [Claude Code](https://claude.com/claude-code)