### PR TITLE
feat(html): report the sheet a view cut, and budget its cells

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,12 @@ The release run heads these entries with the version and opens a fresh
   `https`, `mailto`, `ftp`, `ftps`, `tel` or a relative reference — the
   allowlist a PDF `/URI` action already went through. `Link::href()` is
   unchanged.
+- `HtmlView::sheet_cut` reports the extent a sheet's cells span against the
+  extent the rendered markup carries, or nothing where the limits cut nothing.
+  Bound in python, jni, wasm and apple as `sheet_cut` / `sheetCut`.
+- New `HtmlConfig::spreadsheet_cell_limit`, 500000 cells for one sheet, bounds
+  the rows a sheet keeps by its width; `spreadsheet_limit` rises from 10000 to
+  100000 rows. wasm gains both.
 - A saved document opens in LibreOffice again: every zip entry's size goes into
   its local header instead of a trailing data descriptor, which LibreOffice
   rejects on a stored entry — an odf package always stores `mimetype`.

--- a/apple/include/OdrCoreObjC/ODRHtml.h
+++ b/apple/include/OdrCoreObjC/ODRHtml.h
@@ -89,6 +89,9 @@ NS_SWIFT_NAME(HtmlConfig)
 
 /// `nil` for no limit.
 @property(nonatomic, strong, nullable) NSValue *spreadsheetLimit;
+/// Most cells written for one sheet; bounds the rows by the sheet's width.
+/// `nil` for no budget.
+@property(nonatomic, strong, nullable) NSNumber *spreadsheetCellLimit;
 @property(nonatomic) BOOL spreadsheetLimitByContent;
 @property(nonatomic) ODRHtmlTableGridlines spreadsheetGridlines;
 
@@ -175,6 +178,18 @@ NS_SWIFT_NAME(Html)
 + (instancetype)new NS_UNAVAILABLE;
 @end
 
+/// What a view leaves out of the sheet it renders. `odr::HtmlSheetCut`.
+NS_SWIFT_NAME(HtmlSheetCut)
+@interface ODRHtmlSheetCut : NSObject
+/// The extent the sheet's cells span.
+@property(nonatomic, readonly) ODRTableDimensions content;
+/// The extent the markup carries.
+@property(nonatomic, readonly) ODRTableDimensions rendered;
+
+- (instancetype)init NS_UNAVAILABLE;
++ (instancetype)new NS_UNAVAILABLE;
+@end
+
 /// One renderable view of a document — a slide, a sheet, a page, or the whole
 /// thing. `odr::HtmlView`.
 NS_SWIFT_NAME(HtmlView)
@@ -183,6 +198,10 @@ NS_SWIFT_NAME(HtmlView)
 @property(nonatomic, readonly) NSUInteger index;
 /// The path this view is served at.
 @property(nonatomic, readonly, copy) NSString *path;
+
+/// The sheet this view cuts down to `spreadsheetLimit` and
+/// `spreadsheetCellLimit`, or `nil` where it writes every cell.
+@property(nonatomic, readonly, nullable) ODRHtmlSheetCut *sheetCut;
 
 /// Renders the view. The resources it refers to come back alongside it.
 - (nullable NSString *)writeHtmlWithResources:

--- a/apple/src/ODRHtml.mm
+++ b/apple/src/ODRHtml.mm
@@ -97,6 +97,10 @@ std::vector<std::string> to_strings(NSArray<NSString *> *strings) {
     _spreadsheetLimit = [NSValue valueWithBytes:&limit
                                        objCType:@encode(ODRTableDimensions)];
   }
+  _spreadsheetCellLimit =
+      config.spreadsheet_cell_limit.has_value()
+          ? @(static_cast<unsigned long long>(*config.spreadsheet_cell_limit))
+          : nil;
   _spreadsheetLimitByContent = config.spreadsheet_limit_by_content ? YES : NO;
   _spreadsheetGridlines =
       static_cast<ODRHtmlTableGridlines>(config.spreadsheet_gridlines);
@@ -162,6 +166,12 @@ std::vector<std::string> to_strings(NSArray<NSString *> *strings) {
     config.spreadsheet_limit = odr::TableDimensions(limit.rows, limit.columns);
   } else {
     config.spreadsheet_limit.reset();
+  }
+  if (_spreadsheetCellLimit != nil) {
+    config.spreadsheet_cell_limit =
+        static_cast<std::uint64_t>(_spreadsheetCellLimit.unsignedLongLongValue);
+  } else {
+    config.spreadsheet_cell_limit.reset();
   }
   config.spreadsheet_limit_by_content = _spreadsheetLimitByContent == YES;
   config.spreadsheet_gridlines =
@@ -336,6 +346,19 @@ NSArray<ODRHtmlResource *> *to_nsarray(const odr::HtmlResources &resources) {
 
 } // namespace
 
+@implementation ODRHtmlSheetCut
+
++ (instancetype)cutWithHandle:(const odr::HtmlSheetCut &)handle {
+  ODRHtmlSheetCut *const result = [[ODRHtmlSheetCut alloc] init];
+  result->_content =
+      ODRTableDimensionsMake(handle.content.rows, handle.content.columns);
+  result->_rendered =
+      ODRTableDimensionsMake(handle.rendered.rows, handle.rendered.columns);
+  return result;
+}
+
+@end
+
 @implementation ODRHtmlView {
   std::optional<odr::HtmlView> _handle;
   // The view's impl holds a bare pointer to its service, so the view has to
@@ -365,6 +388,15 @@ NSArray<ODRHtmlResource *> *to_nsarray(const odr::HtmlResources &resources) {
 
 - (NSString *)path {
   return guarded_value([&] { return to_nsstring(_handle->path()); }, @"");
+}
+
+- (ODRHtmlSheetCut *)sheetCut {
+  return guarded_value(
+      [&]() -> ODRHtmlSheetCut * {
+        const std::optional<odr::HtmlSheetCut> &cut = _handle->sheet_cut();
+        return cut.has_value() ? [ODRHtmlSheetCut cutWithHandle:*cut] : nil;
+      },
+      static_cast<ODRHtmlSheetCut *>(nil));
 }
 
 - (nullable NSString *)writeHtmlWithResources:

--- a/apple/src/ODRPrivate.h
+++ b/apple/src/ODRPrivate.h
@@ -157,6 +157,10 @@ ODRMeasure *_Nullable box(const std::optional<odr::Measure> &measure);
 + (instancetype)htmlWithHandle:(const odr::Html &)handle;
 @end
 
+@interface ODRHtmlSheetCut (Private)
++ (instancetype)cutWithHandle:(const odr::HtmlSheetCut &)handle;
+@end
+
 @interface ODRHtmlView (Private)
 + (instancetype)viewWithHandle:(odr::HtmlView)handle owner:(id)owner;
 - (const odr::HtmlView &)handle;

--- a/jni/CMakeLists.txt
+++ b/jni/CMakeLists.txt
@@ -111,6 +111,7 @@ add_jar(odr_java
         "java/app/opendocument/core/HtmlResource.java"
         "java/app/opendocument/core/HtmlResourceType.java"
         "java/app/opendocument/core/HtmlService.java"
+        "java/app/opendocument/core/HtmlSheetCut.java"
         "java/app/opendocument/core/HtmlTableGridlines.java"
         "java/app/opendocument/core/HtmlView.java"
         "java/app/opendocument/core/HtmlViewportMode.java"

--- a/jni/java/app/opendocument/core/HtmlConfig.java
+++ b/jni/java/app/opendocument/core/HtmlConfig.java
@@ -27,7 +27,14 @@ public final class HtmlConfig {
   public HtmlColorScheme colorScheme = HtmlColorScheme.LIGHT;
 
   /** {@code null} disables the spreadsheet limit. */
-  public TableDimensions spreadsheetLimit = new TableDimensions(10000, 500);
+  public TableDimensions spreadsheetLimit = new TableDimensions(100000, 500);
+
+  /**
+   * Most cells written for one sheet; bounds the rows by the sheet's width. {@code null} disables
+   * the budget.
+   */
+  public Long spreadsheetCellLimit = 500000L;
+
   public boolean spreadsheetLimitByContent = true;
   public HtmlTableGridlines spreadsheetGridlines = HtmlTableGridlines.SOFT;
 

--- a/jni/java/app/opendocument/core/HtmlSheetCut.java
+++ b/jni/java/app/opendocument/core/HtmlSheetCut.java
@@ -1,0 +1,26 @@
+package app.opendocument.core;
+
+/**
+ * What a view leaves out of the sheet it renders. Mirrors {@code odr::HtmlSheetCut}.
+ *
+ * @see HtmlView#sheetCut()
+ */
+public final class HtmlSheetCut {
+  /** The extent the sheet's cells span. */
+  public TableDimensions content;
+
+  /** The extent the markup carries. */
+  public TableDimensions rendered;
+
+  public HtmlSheetCut() {}
+
+  public HtmlSheetCut(TableDimensions content, TableDimensions rendered) {
+    this.content = content;
+    this.rendered = rendered;
+  }
+
+  @Override
+  public String toString() {
+    return "HtmlSheetCut(content=" + content + ", rendered=" + rendered + ")";
+  }
+}

--- a/jni/java/app/opendocument/core/HtmlView.java
+++ b/jni/java/app/opendocument/core/HtmlView.java
@@ -22,6 +22,14 @@ public final class HtmlView extends NativeResource {
     return configNative(handle());
   }
 
+  /**
+   * The sheet this view cuts down to {@link HtmlConfig#spreadsheetLimit} and {@link
+   * HtmlConfig#spreadsheetCellLimit}, or {@code null} where it writes every cell.
+   */
+  public HtmlSheetCut sheetCut() {
+    return sheetCutNative(handle());
+  }
+
   /** Renders this view; returns the HTML and its resources. */
   public Html.Content writeHtml() {
     return writeHtmlNative(handle());
@@ -41,6 +49,8 @@ public final class HtmlView extends NativeResource {
   private native String pathNative(long handle);
 
   private native HtmlConfig configNative(long handle);
+
+  private native HtmlSheetCut sheetCutNative(long handle);
 
   private native Html.Content writeHtmlNative(long handle);
 

--- a/jni/src/jni_convert.hpp
+++ b/jni/src/jni_convert.hpp
@@ -38,6 +38,9 @@ jobject make_page_layout(JNIEnv *env, const odr::PageLayout &layout);
 jobject make_table_dimensions(JNIEnv *env,
                               const odr::TableDimensions &dimensions);
 jobject make_table_position(JNIEnv *env, const odr::TablePosition &position);
+/// `nullptr` where nothing was cut.
+jobject make_html_sheet_cut(JNIEnv *env,
+                            const std::optional<odr::HtmlSheetCut> &cut);
 jobject make_file_meta(JNIEnv *env, const odr::FileMeta &meta);
 jobject make_file_type_capabilities(JNIEnv *env,
                                     const odr::FileTypeCapabilities &);

--- a/jni/src/jni_html.cpp
+++ b/jni/src/jni_html.cpp
@@ -342,6 +342,14 @@ Java_app_opendocument_core_HtmlView_configNative(JNIEnv *env, jobject,
 }
 
 extern "C" JNIEXPORT jobject JNICALL
+Java_app_opendocument_core_HtmlView_sheetCutNative(JNIEnv *env, jobject,
+                                                   jlong handle) {
+  return guarded(env, [&] {
+    return odr_jni::make_html_sheet_cut(env, view(handle).sheet_cut());
+  });
+}
+
+extern "C" JNIEXPORT jobject JNICALL
 Java_app_opendocument_core_HtmlView_writeHtmlNative(JNIEnv *env, jobject,
                                                     jlong handle) {
   return guarded(env, [&] {

--- a/jni/src/jni_style.cpp
+++ b/jni/src/jni_style.cpp
@@ -80,6 +80,14 @@ jobject box_integer(JNIEnv *env, const std::optional<std::uint32_t> &value) {
                             static_cast<jint>(*value));
 }
 
+jobject box_long(JNIEnv *env, const std::optional<std::uint64_t> &value) {
+  if (!value.has_value()) {
+    return nullptr;
+  }
+  return call_static_object(env, "java/lang/Long", "valueOf",
+                            "(J)Ljava/lang/Long;", static_cast<jlong>(*value));
+}
+
 /// Looks up an enum constant by its C++ code (= Java ordinal).
 jobject enum_from_code(JNIEnv *env, const char *class_name, const jint code) {
   if (code < 0) {
@@ -309,6 +317,18 @@ jobject make_table_dimensions(JNIEnv *env,
                     static_cast<jint>(dimensions.columns));
 }
 
+jobject make_html_sheet_cut(JNIEnv *env,
+                            const std::optional<odr::HtmlSheetCut> &cut) {
+  if (!cut.has_value()) {
+    return nullptr;
+  }
+  return new_object(env, "app/opendocument/core/HtmlSheetCut",
+                    "(Lapp/opendocument/core/TableDimensions;Lapp/opendocument/"
+                    "core/TableDimensions;)V",
+                    make_table_dimensions(env, cut->content),
+                    make_table_dimensions(env, cut->rendered));
+}
+
 jobject make_table_position(JNIEnv *env, const odr::TablePosition &position) {
   return new_object(env, "app/opendocument/core/TablePosition", "(II)V",
                     static_cast<jint>(position.column),
@@ -392,6 +412,8 @@ jobject html_config_to_java(JNIEnv *env, const odr::HtmlConfig &config) {
              config.spreadsheet_limit.has_value()
                  ? make_table_dimensions(env, *config.spreadsheet_limit)
                  : nullptr);
+  set_object("spreadsheetCellLimit", "Ljava/lang/Long;",
+             box_long(env, config.spreadsheet_cell_limit));
   set_boolean("spreadsheetLimitByContent", config.spreadsheet_limit_by_content);
   set_object("spreadsheetGridlines",
              "Lapp/opendocument/core/HtmlTableGridlines;",
@@ -525,6 +547,18 @@ odr::HtmlConfig html_config_from_java(JNIEnv *env, jobject config) {
           odr::TableDimensions(static_cast<std::uint32_t>(rows),
                                static_cast<std::uint32_t>(columns));
       env->DeleteLocalRef(dimensions_cls);
+    }
+  }
+  {
+    jobject cell_limit = get_object("spreadsheetCellLimit", "Ljava/lang/Long;");
+    if (cell_limit == nullptr) {
+      result.spreadsheet_cell_limit = std::nullopt;
+    } else {
+      jclass long_cls = env->GetObjectClass(cell_limit);
+      jmethodID long_value = env->GetMethodID(long_cls, "longValue", "()J");
+      result.spreadsheet_cell_limit = static_cast<std::uint64_t>(
+          env->CallLongMethod(cell_limit, long_value));
+      env->DeleteLocalRef(long_cls);
     }
   }
   result.spreadsheet_limit_by_content =

--- a/jni/tests/app/opendocument/core/HtmlTest.java
+++ b/jni/tests/app/opendocument/core/HtmlTest.java
@@ -1,6 +1,7 @@
 package app.opendocument.core;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertNull;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
@@ -158,6 +159,33 @@ class HtmlTest {
     assertEquals(1, html.pages().size());
     String content = Files.readString(Path.of(html.pages().get(0).path));
     assertTrue(content.contains(TestFiles.ODT_WORD));
+  }
+
+  /** The C++ suite covers where the limits land; this proves the pair crosses JNI. */
+  @Test
+  void spreadsheetCutReachesTheView() throws IOException {
+    assertEquals(Long.valueOf(500000L), new HtmlConfig().spreadsheetCellLimit);
+
+    Path cache = Files.createDirectories(tempDir.resolve("cache"));
+    DecodedFile file = Odr.open(TestFiles.csvFile(tempDir).toString());
+
+    HtmlConfig full = new HtmlConfig();
+    for (HtmlView view : Html.translate(file, cache.toString(), full).listViews()) {
+      assertNull(view.sheetCut());
+    }
+
+    HtmlConfig cut = new HtmlConfig();
+    cut.spreadsheetLimit = new TableDimensions(2, 1);
+    cut.spreadsheetCellLimit = null;
+    HtmlService service = Html.translate(file, cache.toString(), cut);
+
+    assertNull(service.config().spreadsheetCellLimit);
+    HtmlSheetCut sheetCut = service.listViews().get(1).sheetCut();
+    assertNotNull(sheetCut);
+    assertEquals(3, sheetCut.content.rows);
+    assertEquals(2, sheetCut.content.columns);
+    assertEquals(2, sheetCut.rendered.rows);
+    assertEquals(1, sheetCut.rendered.columns);
   }
 
   @Test

--- a/python/src/bind_html.cpp
+++ b/python/src/bind_html.cpp
@@ -83,6 +83,8 @@ void odr_python::bind_html(py::module_ &m) {
                      &odr::HtmlConfig::text_document_margin)
       .def_readwrite("color_scheme", &odr::HtmlConfig::color_scheme)
       .def_readwrite("spreadsheet_limit", &odr::HtmlConfig::spreadsheet_limit)
+      .def_readwrite("spreadsheet_cell_limit",
+                     &odr::HtmlConfig::spreadsheet_cell_limit)
       .def_readwrite("spreadsheet_limit_by_content",
                      &odr::HtmlConfig::spreadsheet_limit_by_content)
       .def_readwrite("spreadsheet_gridlines",
@@ -117,6 +119,10 @@ void odr_python::bind_html(py::module_ &m) {
       .def_readwrite("output_path", &odr::HtmlConfig::output_path)
       .def_readwrite("resource_locator", &odr::HtmlConfig::resource_locator);
 
+  py::class_<odr::HtmlSheetCut>(m, "HtmlSheetCut")
+      .def_readonly("content", &odr::HtmlSheetCut::content)
+      .def_readonly("rendered", &odr::HtmlSheetCut::rendered);
+
   py::class_<odr::HtmlPage>(m, "HtmlPage")
       .def_readonly("name", &odr::HtmlPage::name)
       .def_readonly("path", &odr::HtmlPage::path)
@@ -135,6 +141,10 @@ void odr_python::bind_html(py::module_ &m) {
       .def("index", &odr::HtmlView::index)
       .def("path", &odr::HtmlView::path)
       .def("config", &odr::HtmlView::config)
+      .def(
+          "sheet_cut",
+          [](const odr::HtmlView &view) { return view.sheet_cut(); },
+          "The sheet this view cut down to the spreadsheet limits, or None.")
       .def(
           "write_html",
           [](const odr::HtmlView &view) {

--- a/python/tests/test_html.py
+++ b/python/tests/test_html.py
@@ -25,6 +25,28 @@ def test_html_config_defaults():
     assert config.editable
     assert config.spreadsheet_limit.rows == 100
 
+    assert config.spreadsheet_cell_limit == 500000
+    config.spreadsheet_cell_limit = None
+    assert config.spreadsheet_cell_limit is None
+
+
+def test_html_view_sheet_cut(csv_path, tmp_path):
+    cache = tmp_path / "cache"
+    file = pyodr.open(str(csv_path))
+
+    config = pyodr.HtmlConfig()
+    service = pyodr.html.translate(file, str(cache), config)
+    assert all(view.sheet_cut() is None for view in service.list_views())
+
+    config.spreadsheet_limit = pyodr.TableDimensions(2, 1)
+    config.spreadsheet_cell_limit = None
+    service = pyodr.html.translate(file, str(cache), config)
+
+    cut = service.list_views()[1].sheet_cut()
+    assert cut is not None
+    assert (cut.content.rows, cut.content.columns) == (3, 2)
+    assert (cut.rendered.rows, cut.rendered.columns) == (2, 1)
+
 
 def test_html_config_color_scheme_defaults():
     config = pyodr.HtmlConfig()

--- a/src/odr/html.cpp
+++ b/src/odr/html.cpp
@@ -158,6 +158,10 @@ const std::string &HtmlView::path() const { return m_impl->path(); }
 
 const HtmlConfig &HtmlView::config() const { return m_impl->config(); }
 
+const std::optional<HtmlSheetCut> &HtmlView::sheet_cut() const {
+  return m_impl->sheet_cut();
+}
+
 HtmlResources HtmlView::write_html(std::ostream &out) const {
   internal::html::HtmlWriter writer(out, config());
   return m_impl->write_html(writer);

--- a/src/odr/html.hpp
+++ b/src/odr/html.hpp
@@ -139,9 +139,12 @@ struct HtmlConfig {
   /// The colors the output renders against.
   HtmlColorScheme color_scheme{HtmlColorScheme::light};
 
-  /// Largest sheet region written; cells past it are dropped.
-  std::optional<TableDimensions> spreadsheet_limit{TableDimensions(10000, 500)};
-  /// Trim a sheet to the cells it uses before @ref spreadsheet_limit applies.
+  /// Largest sheet region written, per axis; cells past it are dropped.
+  std::optional<TableDimensions> spreadsheet_limit{
+      TableDimensions(100000, 500)};
+  /// Most cells written for one sheet; bounds the rows by the sheet's width.
+  std::optional<std::uint64_t> spreadsheet_cell_limit{500000};
+  /// Trim a sheet to the cells it uses before the limits above apply.
   bool spreadsheet_limit_by_content{true};
   /// Which gridlines a sheet paints.
   HtmlTableGridlines spreadsheet_gridlines{HtmlTableGridlines::soft};
@@ -230,6 +233,15 @@ struct HtmlPage final {
   HtmlPage(std::string name, std::string path);
 };
 
+/// What a view leaves out of the sheet it renders. See @ref
+/// HtmlView::sheet_cut.
+struct HtmlSheetCut final {
+  /// The extent the sheet's cells span.
+  TableDimensions content;
+  /// The extent the markup carries.
+  TableDimensions rendered;
+};
+
 class HtmlView final {
 public:
   HtmlView();
@@ -239,6 +251,10 @@ public:
   [[nodiscard]] std::size_t index() const;
   [[nodiscard]] const std::string &path() const;
   [[nodiscard]] const HtmlConfig &config() const;
+
+  /// What the spreadsheet limits cut from this view's sheet, or nothing where
+  /// they cut nothing. A view of several sheets answers for the first it cut.
+  [[nodiscard]] const std::optional<HtmlSheetCut> &sheet_cut() const;
 
   HtmlResources write_html(std::ostream &out) const;
 

--- a/src/odr/internal/abstract/html_service.hpp
+++ b/src/odr/internal/abstract/html_service.hpp
@@ -40,6 +40,8 @@ public:
   [[nodiscard]] virtual std::size_t index() const = 0;
   [[nodiscard]] virtual const std::string &path() const = 0;
   [[nodiscard]] virtual const HtmlConfig &config() const = 0;
+  [[nodiscard]] virtual const std::optional<HtmlSheetCut> &
+  sheet_cut() const = 0;
 
   virtual HtmlResources write_html(html::HtmlWriter &out) const = 0;
 };

--- a/src/odr/internal/html/document.cpp
+++ b/src/odr/internal/html/document.cpp
@@ -61,6 +61,20 @@ std::optional<double> fragment_content_pixels(const Sheet &,
   return {};
 }
 
+/// Only a sheet has cells a limit can cut.
+std::optional<HtmlSheetCut> fragment_sheet_cut(const Sheet &sheet,
+                                               const HtmlConfig &config) {
+  return sheet_cut(sheet, config);
+}
+std::optional<HtmlSheetCut> fragment_sheet_cut(const Slide &,
+                                               const HtmlConfig &) {
+  return {};
+}
+std::optional<HtmlSheetCut> fragment_sheet_cut(const Page &,
+                                               const HtmlConfig &) {
+  return {};
+}
+
 /// The widest of them, for the view that writes every page into one file.
 std::optional<double> document_content_pixels(const Document &document,
                                               const HtmlConfig &config) {
@@ -206,6 +220,17 @@ public:
   [[nodiscard]] virtual std::optional<double>
   content_pixels(const HtmlConfig &config) const = 0;
 
+  /// Measured on demand: a walk over the cells, and most hosts never ask.
+  [[nodiscard]] const std::optional<HtmlSheetCut> &
+  sheet_cut(const HtmlConfig &config) const {
+    std::lock_guard lock(m_cut_mutex);
+    if (!m_cut_measured) {
+      m_cut = measure_sheet_cut(config);
+      m_cut_measured = true;
+    }
+    return m_cut;
+  }
+
   void write_document(HtmlWriter &out, WritingState &state) const {
     const std::optional<double> content = content_pixels(state.config());
     front(m_document, state, m_name, content);
@@ -214,10 +239,18 @@ public:
   }
 
 protected:
+  [[nodiscard]] virtual std::optional<HtmlSheetCut>
+  measure_sheet_cut(const HtmlConfig &config) const = 0;
+
   std::string m_name;
   std::size_t m_index = 0;
   std::string m_path;
   Document m_document;
+
+private:
+  mutable std::mutex m_cut_mutex;
+  mutable std::optional<HtmlSheetCut> m_cut;
+  mutable bool m_cut_measured = false;
 };
 
 class HtmlFragmentView final : public abstract::HtmlView {
@@ -238,6 +271,9 @@ public:
   [[nodiscard]] const HtmlConfig &config() const override {
     return m_service->config();
   }
+  [[nodiscard]] const std::optional<HtmlSheetCut> &sheet_cut() const override {
+    return m_fragment->sheet_cut(config());
+  }
   [[nodiscard]] const abstract::HtmlService &service() const {
     return *m_service;
   }
@@ -254,6 +290,32 @@ private:
   std::shared_ptr<HtmlFragmentBase> m_fragment;
 };
 
+/// The view that writes every fragment into one file; for a workbook that is
+/// every sheet, so it answers for the first one it cut.
+class HtmlDocumentView final : public HtmlView {
+public:
+  HtmlDocumentView(
+      const abstract::HtmlService &service, std::string name,
+      const std::size_t index, std::string path,
+      const std::vector<std::shared_ptr<HtmlFragmentBase>> &fragments)
+      : HtmlView(service, std::move(name), index, std::move(path)),
+        m_fragments{&fragments} {}
+
+  [[nodiscard]] const std::optional<HtmlSheetCut> &sheet_cut() const override {
+    for (const auto &fragment : *m_fragments) {
+      if (const std::optional<HtmlSheetCut> &cut =
+              fragment->sheet_cut(config());
+          cut.has_value()) {
+        return cut;
+      }
+    }
+    return HtmlView::sheet_cut();
+  }
+
+private:
+  const std::vector<std::shared_ptr<HtmlFragmentBase>> *m_fragments{nullptr};
+};
+
 class HtmlServiceImpl final : public HtmlService {
 public:
   HtmlServiceImpl(Document document,
@@ -261,8 +323,8 @@ public:
                   HtmlConfig config, const Logger &logger)
       : HtmlService(std::move(config), logger), m_document{std::move(document)},
         m_fragments{std::move(fragments)} {
-    m_views.emplace_back(
-        std::make_shared<HtmlView>(*this, "document", 0, "document.html"));
+    m_views.emplace_back(std::make_shared<HtmlDocumentView>(
+        *this, "document", 0, "document.html", m_fragments));
     for (const auto &fragment : m_fragments) {
       if (fragment->name() == "document") {
         continue;
@@ -421,6 +483,13 @@ public:
       out.write_element_end("div");
     }
   }
+
+protected:
+  /// A text document has no sheet to cut.
+  [[nodiscard]] std::optional<HtmlSheetCut>
+  measure_sheet_cut(const HtmlConfig &) const override {
+    return {};
+  }
 };
 
 /// A fragment rendering one top-level element handle (slide, sheet, page)
@@ -443,6 +512,12 @@ public:
 
   void write_fragment(HtmlWriter &, WritingState &state) const override {
     Translate(m_element, state);
+  }
+
+protected:
+  [[nodiscard]] std::optional<HtmlSheetCut>
+  measure_sheet_cut(const HtmlConfig &config) const override {
+    return fragment_sheet_cut(m_element, config);
   }
 
 private:

--- a/src/odr/internal/html/document_element.cpp
+++ b/src/odr/internal/html/document_element.cpp
@@ -79,26 +79,56 @@ void html::translate_element(const Element &element,
   }
 }
 
+TableDimensions html::sheet_rendered_extent(const Sheet &sheet,
+                                            const HtmlConfig &config) {
+  const TableDimensions dimensions = sheet.dimensions();
+
+  std::uint32_t end_column = dimensions.columns;
+  std::uint32_t end_row = dimensions.rows;
+  if (config.spreadsheet_limit_by_content) {
+    // Not the sheet's own extent clamped: a cell past the window does not
+    // stretch what precedes it.
+    const TableDimensions content = sheet.content(config.spreadsheet_limit);
+    end_column = content.columns;
+    end_row = content.rows;
+  }
+  if (config.spreadsheet_limit) {
+    end_column = std::min(end_column, config.spreadsheet_limit->columns);
+    end_row = std::min(end_row, config.spreadsheet_limit->rows);
+  }
+  end_column = std::max(1u, end_column);
+  if (config.spreadsheet_cell_limit) {
+    const std::uint64_t rows = *config.spreadsheet_cell_limit / end_column;
+    end_row = static_cast<std::uint32_t>(
+        std::min<std::uint64_t>(end_row, std::max<std::uint64_t>(1, rows)));
+  }
+  end_row = std::max(1u, end_row);
+
+  return {end_row, end_column};
+}
+
+std::optional<HtmlSheetCut> html::sheet_cut(const Sheet &sheet,
+                                            const HtmlConfig &config) {
+  const TableDimensions rendered = sheet_rendered_extent(sheet, config);
+  // Against the whole sheet, not the window: what dropping the limits would
+  // render.
+  const TableDimensions content = config.spreadsheet_limit_by_content
+                                      ? sheet.content(std::nullopt)
+                                      : sheet.dimensions();
+
+  if (rendered.rows >= content.rows && rendered.columns >= content.columns) {
+    return {};
+  }
+  return HtmlSheetCut{content, rendered};
+}
+
 void html::translate_sheet(const Sheet &sheet, const WritingState &state) {
   state.out().write_element_begin("table",
                                   HtmlElementOptions().set_class("odr-sheet"));
 
-  const TableDimensions dimensions = sheet.dimensions();
-  std::uint32_t end_column = dimensions.columns;
-  std::uint32_t end_row = dimensions.rows;
-  if (state.config().spreadsheet_limit_by_content) {
-    const TableDimensions content =
-        sheet.content(state.config().spreadsheet_limit);
-    end_column = content.columns;
-    end_row = content.rows;
-  }
-  if (state.config().spreadsheet_limit) {
-    end_column =
-        std::min(end_column, state.config().spreadsheet_limit->columns);
-    end_row = std::min(end_row, state.config().spreadsheet_limit->rows);
-  }
-  end_column = std::max(1u, end_column);
-  end_row = std::max(1u, end_row);
+  const TableDimensions rendered = sheet_rendered_extent(sheet, state.config());
+  const std::uint32_t end_column = rendered.columns;
+  const std::uint32_t end_row = rendered.rows;
 
   state.out().write_element_begin("col",
                                   HtmlElementOptions()

--- a/src/odr/internal/html/document_element.hpp
+++ b/src/odr/internal/html/document_element.hpp
@@ -1,5 +1,7 @@
 #pragma once
 
+#include <odr/html.hpp>
+
 #include <string>
 
 namespace odr {
@@ -20,6 +22,15 @@ void translate_element(const Element &element, const WritingState &state);
 
 void translate_slide(const Slide &slide, const WritingState &state);
 void translate_sheet(const Sheet &sheet, const WritingState &state);
+
+/// The extent `translate_sheet` writes @p sheet at, once the limits in
+/// @p config have applied.
+[[nodiscard]] TableDimensions sheet_rendered_extent(const Sheet &sheet,
+                                                    const HtmlConfig &config);
+
+/// Costs a pass over the cells, so measure it once.
+[[nodiscard]] std::optional<HtmlSheetCut> sheet_cut(const Sheet &sheet,
+                                                    const HtmlConfig &config);
 void translate_page(const Page &page, const WritingState &state);
 
 void translate_master_page(const MasterPage &masterPage,

--- a/src/odr/internal/html/html_service.cpp
+++ b/src/odr/internal/html/html_service.cpp
@@ -24,6 +24,12 @@ const std::string &HtmlView::path() const { return m_path; }
 
 const HtmlConfig &HtmlView::config() const { return m_service->config(); }
 
+/// Only a sheet cuts anything, and only `html/document.cpp` renders one.
+const std::optional<HtmlSheetCut> &HtmlView::sheet_cut() const {
+  static const std::optional<HtmlSheetCut> none;
+  return none;
+}
+
 const abstract::HtmlService &HtmlView::service() const { return *m_service; }
 
 HtmlResources HtmlView::write_html(HtmlWriter &out) const {

--- a/src/odr/internal/html/html_service.hpp
+++ b/src/odr/internal/html/html_service.hpp
@@ -29,6 +29,7 @@ public:
   [[nodiscard]] std::size_t index() const override;
   [[nodiscard]] const std::string &path() const override;
   [[nodiscard]] const HtmlConfig &config() const override;
+  [[nodiscard]] const std::optional<HtmlSheetCut> &sheet_cut() const override;
   [[nodiscard]] const abstract::HtmlService &service() const;
 
   HtmlResources write_html(HtmlWriter &out) const override;

--- a/test/src/html_test.cpp
+++ b/test/src/html_test.cpp
@@ -585,6 +585,28 @@ std::string render_markdown(const std::string &markdown) {
   return std::move(out).str();
 }
 
+/// A sheet of exactly @p rows by @p columns, with no trailing empty cells.
+DecodedFile csv_file(const std::uint32_t rows, const std::uint32_t columns) {
+  std::string csv;
+  for (std::uint32_t row = 0; row < rows; ++row) {
+    for (std::uint32_t column = 0; column < columns; ++column) {
+      csv += (column == 0 ? "" : ",") + std::to_string(row * columns + column);
+    }
+    csv += "\n";
+  }
+  return DecodedFile(File::from_memory(csv), FileType::comma_separated_values);
+}
+
+const HtmlView &view_at(const HtmlService &service,
+                        const std::string_view path) {
+  const auto it =
+      std::ranges::find_if(service.list_views(), [path](const HtmlView &view) {
+        return view.path() == path;
+      });
+  EXPECT_NE(it, service.list_views().end()) << path;
+  return *it;
+}
+
 } // namespace
 
 // #737. The entity forms are resolved before the href is stored, so the filter
@@ -617,4 +639,64 @@ TEST(html, a_link_that_is_navigable_keeps_its_href) {
   EXPECT_NE(render_markdown("[a](#bookmark)\n")
                 .find(R"(<a href="#bookmark"><x-s>a</x-s></a>)"),
             std::string::npos);
+}
+
+// #740: a sheet that ran into a limit used to end without saying so.
+TEST(html, a_sheet_written_in_full_reports_no_cut) {
+  HtmlConfig config;
+  config.spreadsheet_limit = TableDimensions(100, 100);
+  config.spreadsheet_cell_limit = 10000;
+
+  const HtmlService service = html::translate(csv_file(4, 5), config);
+
+  EXPECT_FALSE(view_at(service, "sheet0.html").sheet_cut().has_value());
+  EXPECT_FALSE(view_at(service, "document.html").sheet_cut().has_value());
+}
+
+TEST(html, a_sheet_cut_by_the_rectangle_reports_what_it_left_out) {
+  HtmlConfig config;
+  config.spreadsheet_limit = TableDimensions(3, 4);
+  config.spreadsheet_cell_limit = std::nullopt;
+
+  const HtmlService service = html::translate(csv_file(10, 6), config);
+
+  const std::optional<HtmlSheetCut> &cut =
+      view_at(service, "sheet0.html").sheet_cut();
+  ASSERT_TRUE(cut.has_value());
+  EXPECT_EQ(cut->content.rows, 10);
+  EXPECT_EQ(cut->content.columns, 6);
+  EXPECT_EQ(cut->rendered.rows, 3);
+  EXPECT_EQ(cut->rendered.columns, 4);
+}
+
+// The rows a sheet keeps follow how wide it turns out to be.
+TEST(html, the_cell_budget_bounds_the_rows_by_the_width) {
+  HtmlConfig config;
+  config.spreadsheet_limit = TableDimensions(1000, 1000);
+  config.spreadsheet_cell_limit = 60;
+
+  const auto rendered = [&config](const std::uint32_t rows,
+                                  const std::uint32_t columns) {
+    const HtmlService service =
+        html::translate(csv_file(rows, columns), config);
+    const std::optional<HtmlSheetCut> &cut =
+        view_at(service, "sheet0.html").sheet_cut();
+    return cut.has_value() ? cut->rendered : TableDimensions(rows, columns);
+  };
+
+  // 3 wide: 20 rows fit the budget, and 30 do not
+  EXPECT_EQ(rendered(20, 3).rows, 20);
+  EXPECT_EQ(rendered(30, 3).rows, 20);
+  // 6 wide: the same budget is half the rows
+  EXPECT_EQ(rendered(30, 6).rows, 10);
+  // the rectangle still caps a sheet the budget would let through
+  config.spreadsheet_limit = TableDimensions(5, 1000);
+  EXPECT_EQ(rendered(30, 3).rows, 5);
+}
+
+TEST(html, a_view_that_renders_no_sheet_has_no_cut) {
+  const DecodedFile file(File::from_memory("<a><b>c</b></a>"), FileType::xml);
+  const HtmlService service = html::translate(file, HtmlConfig());
+
+  EXPECT_FALSE(service.list_views().at(0).sheet_cut().has_value());
 }

--- a/wasm/js/index.d.ts
+++ b/wasm/js/index.d.ts
@@ -43,10 +43,22 @@ export interface Detection {
   mimeType: string;
 }
 
+/** What a view leaves out of the sheet it renders. */
+export interface SheetCut {
+  /** The extent the sheet's cells span. */
+  contentRows: number;
+  contentColumns: number;
+  /** The extent the markup carries. */
+  renderedRows: number;
+  renderedColumns: number;
+}
+
 export interface View {
   name: string;
   index: number;
   path: string;
+  /** Set where `spreadsheetLimit` or `spreadsheetCellLimit` cut this view's sheet. */
+  sheetCut?: SheetCut;
 }
 
 /** A resource the markup links to rather than inlining. Fetch with
@@ -85,6 +97,10 @@ export interface HtmlConfig {
   pageRangeBegin?: number;
   pageRangeEnd?: number;
   colorScheme?: number;
+  /** Largest sheet region written, per axis; `null` drops the cap. */
+  spreadsheetLimit?: { rows: number; columns: number } | null;
+  /** Most cells written for one sheet; `null` drops the budget. */
+  spreadsheetCellLimit?: number | null;
   spreadsheetGridlines?: number;
   viewportMode?: number;
   /** The width the output is shown at, in css pixels; fits paged content to it. */

--- a/wasm/src/wasm_html.cpp
+++ b/wasm/src/wasm_html.cpp
@@ -6,6 +6,7 @@
 
 #include <emscripten/bind.h>
 
+#include <cstdint>
 #include <optional>
 #include <sstream>
 #include <string>
@@ -66,6 +67,15 @@ emscripten::val list_views(const Handle handle) {
       entry.set("name", view.name());
       entry.set("index", static_cast<double>(view.index()));
       entry.set("path", view.path());
+      if (const std::optional<HtmlSheetCut> &cut = view.sheet_cut();
+          cut.has_value()) {
+        emscripten::val sheet_cut = emscripten::val::object();
+        sheet_cut.set("contentRows", cut->content.rows);
+        sheet_cut.set("contentColumns", cut->content.columns);
+        sheet_cut.set("renderedRows", cut->rendered.rows);
+        sheet_cut.set("renderedColumns", cut->rendered.columns);
+        entry.set("sheetCut", sheet_cut);
+      }
       result.call<void>("push", entry);
     }
     return ok(result);
@@ -151,6 +161,24 @@ HtmlConfig to_html_config(const emscripten::val &value) {
 
   read_enum(value, "colorScheme", config.color_scheme);
   read_enum(value, "spreadsheetGridlines", config.spreadsheet_gridlines);
+  // `null` drops a limit, which is how a host renders a cut sheet in full;
+  // absent leaves the default in place.
+  if (const emscripten::val limit = value["spreadsheetLimit"];
+      !limit.isUndefined()) {
+    config.spreadsheet_limit = limit.isNull()
+                                   ? std::optional<TableDimensions>()
+                                   : std::optional(TableDimensions(
+                                         limit["rows"].as<std::uint32_t>(),
+                                         limit["columns"].as<std::uint32_t>()));
+  }
+  if (const emscripten::val limit = value["spreadsheetCellLimit"];
+      !limit.isUndefined()) {
+    // as a `number`, not a BigInt - a cell budget is nowhere near 2^53
+    config.spreadsheet_cell_limit =
+        limit.isNull()
+            ? std::optional<std::uint64_t>()
+            : std::optional(static_cast<std::uint64_t>(limit.as<double>()));
+  }
   read_enum(value, "viewportMode", config.viewport_mode);
   if (const emscripten::val width = value["viewportWidth"];
       !width.isUndefined() && !width.isNull()) {


### PR DESCRIPTION
🤖 Generated with [Claude Code](https://claude.com/claude-code)

Fixes #740.

`spreadsheet_limit` dropped every cell past it and wrote nothing in its place: the `<table>` simply ended, and nothing came back to say so. A reader saw a document that looked complete and was not, and an embedder could only find out by opening the document a second time to measure it — a second parse, for a read-only format, to re-derive what translation had just computed and thrown away.

## The view property

```cpp
struct HtmlSheetCut final {
  TableDimensions content;   // the extent the sheet's cells span
  TableDimensions rendered;  // the extent the markup carries
};

[[nodiscard]] const std::optional<HtmlSheetCut> &HtmlView::sheet_cut() const;
```

Nothing where the view writes every cell, and for a view that renders no sheet. **Measured without rendering, and cached** — so a host can decide *before* it renders, which is the point. A view writing several sheets into one file (`document.html` for a workbook) answers for the first it cut; the remedy — re-render with the limits dropped — is global anyway.

No sheet name in the struct: a sheet view's `name()` already is one.

## The cell budget

`HtmlConfig::spreadsheet_cell_limit`, 500000 cells for one sheet, bounding the rows by how wide the sheet turns out to be:

```
columns = min(content.columns, limit.columns)
rows    = min(content.rows, limit.rows, cell_limit / columns)
```

As a rectangle alone the limit punished a tall-narrow sheet — 5 columns by 100000 rows is half a million cells and an ordinary export — to guard against a wide one, where 10000×500 is five million and no WebView survives it. With the budget doing the protecting, `spreadsheet_limit` rises from 10000 to **100000** rows. The trade is the other way at the wide end: a sheet 500 columns across keeps 1000 rows where it kept 10000 — which is the protection the rectangle was buying badly, and it is no longer silent.

Both halves need the same measurement, so they share one.

## What is *not* changed

The renderer still measures its content extent **within the window** (`Sheet::content(spreadsheet_limit)`). Passing `nullopt` there instead looks like a simplification and is not: for a `.ods` whose cells stop at row 3 but which carries one cell far down, it turned a 3-row render into thousands of empty ones. The cut is measured separately, against the whole sheet — which is exactly what makes it able to say "you are seeing 3 rows of 65364".

## Bindings

python, jni, wasm and apple. wasm gains `spreadsheetLimit` too — it was never exposed there, and without it a host cannot act on the report.

## Test

- Four C++ tests: no cut when the sheet fits, what a rectangle cut reports, the budget following the width (3 wide → 20 rows, 6 wide → 10, with the rectangle still capping), and a view that renders no sheet.
- One JNI test and one python test, proving the pair crosses each boundary.
- Full suite green. **No reference output moves**: the corpus's largest sheet is 427k cells, under the budget, and the output test keeps its own 4000×500 rectangle.
