### PR TITLE
feat(document): save to a stream or into memory, and bind edit/save in wasm

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -36,6 +36,7 @@
 
 ## OpenDocument.core
 build/
+build-wasm/
 cmake-build-*/
 jni/target/
 jni/.flattened-pom.xml

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,17 @@ The release run heads these entries with the version and opens a fresh
 
 ## Unreleased
 
+- New `Document::save(std::ostream &)` and `Document::save_to_memory()`, which
+  returns the saved document as an in-memory `File`. The path overloads are
+  unchanged.
+
+- The wasm binding gained `edit(diff)`, `save()`, `isEditable()` and
+  `isSavable()`, so a browser can save an edit back.
+
+- Memory saves in the other bindings: `save_to_memory()` returns `bytes` in
+  python, `saveToMemory()` `byte[]` in java, `-saveToMemoryWithError:` `NSData`
+  in Objective-C.
+
 - Two entries of the same zip document can be read at once; nothing serialises
   on a single lock any more.
 

--- a/apple/include/OdrCoreObjC/ODRDocument.h
+++ b/apple/include/OdrCoreObjC/ODRDocument.h
@@ -28,6 +28,13 @@ NS_SWIFT_NAME(Document)
       password:(NSString *)password
          error:(NSError **)error;
 
+/// The saved document as bytes.
+- (nullable NSData *)saveToMemoryWithError:(NSError **)error
+    NS_SWIFT_NAME(saveToMemory());
+- (nullable NSData *)saveToMemoryWithPassword:(NSString *)password
+                                        error:(NSError **)error
+    NS_SWIFT_NAME(saveToMemory(password:));
+
 /// The document's parts as a filesystem.
 - (nullable ODRFilesystem *)filesystemWithError:(NSError **)error
     NS_SWIFT_NAME(filesystem());

--- a/apple/src/ODRDocument.mm
+++ b/apple/src/ODRDocument.mm
@@ -6,6 +6,8 @@
 #include <odr/document.hpp>
 
 #include <optional>
+#include <sstream>
+#include <string>
 
 using odr::apple::guarded;
 using odr::apple::guarded_value;
@@ -60,6 +62,25 @@ using odr::apple::to_string;
   return guarded(error, [&] {
     _handle->save(to_string(path), to_string(password));
     return YES;
+  });
+}
+
+- (nullable NSData *)saveToMemoryWithError:(NSError **)error {
+  return guarded(error, [&]() -> NSData * {
+    std::ostringstream out;
+    _handle->save(out);
+    const std::string bytes = out.str();
+    return [NSData dataWithBytes:bytes.data() length:bytes.size()];
+  });
+}
+
+- (nullable NSData *)saveToMemoryWithPassword:(NSString *)password
+                                        error:(NSError **)error {
+  return guarded(error, [&]() -> NSData * {
+    std::ostringstream out;
+    _handle->save(out, to_string(password));
+    const std::string bytes = out.str();
+    return [NSData dataWithBytes:bytes.data() length:bytes.size()];
   });
 }
 

--- a/apple/tests/OdrCoreTests.swift
+++ b/apple/tests/OdrCoreTests.swift
@@ -247,6 +247,35 @@ final class ElementTreeTests: XCTestCase {
   }
 }
 
+final class DocumentSaveTests: XCTestCase {
+  private func document() throws -> Document {
+    try DecodedFile.decode(path: try Fixture.odt())
+      .asDocumentFile().document()
+  }
+
+  func testSaveToMemoryCarriesAnEdit() throws {
+    let document = try self.document()
+    XCTAssertTrue(document.isSavable)
+
+    let root = try XCTUnwrap(try document.rootElement())
+    let text = try XCTUnwrap(root.firstDescendant(ofType: Text.self))
+    try text.setContent("saved to memory")
+
+    let saved = try XCTUnwrap(try document.saveToMemory())
+    XCTAssertFalse(saved.isEmpty)
+
+    let path = URL(fileURLWithPath: try temporaryDirectory())
+      .appendingPathComponent("from-memory.odt")
+    try saved.write(to: path)
+
+    let reloaded = try DecodedFile.decode(path: path.path)
+      .asDocumentFile().document()
+    let reloadedRoot = try XCTUnwrap(try reloaded.rootElement())
+    XCTAssertTrue(
+      reloadedRoot.descendants(ofType: Text.self).contains { $0.content == "saved to memory" })
+  }
+}
+
 final class TableAddressTests: XCTestCase {
   func testRoundTrips() throws {
     XCTAssertEqual(TableAddress.columnNumber(from: "C"), 2)

--- a/jni/java/app/opendocument/core/Document.java
+++ b/jni/java/app/opendocument/core/Document.java
@@ -26,6 +26,15 @@ public final class Document extends NativeResource {
     saveEncryptedNative(handle(), path, password);
   }
 
+  /** The saved document as bytes. */
+  public byte[] saveToMemory() {
+    return saveToMemoryNative(handle());
+  }
+
+  public byte[] saveToMemory(String password) {
+    return saveToMemoryEncryptedNative(handle(), password);
+  }
+
   public FileType fileType() {
     return FileType.fromNative(fileTypeNative(handle()));
   }
@@ -59,6 +68,10 @@ public final class Document extends NativeResource {
   private native void saveNative(long handle, String path);
 
   private native void saveEncryptedNative(long handle, String path, String password);
+
+  private native byte[] saveToMemoryNative(long handle);
+
+  private native byte[] saveToMemoryEncryptedNative(long handle, String password);
 
   private native int fileTypeNative(long handle);
 

--- a/jni/src/jni_document.cpp
+++ b/jni/src/jni_document.cpp
@@ -7,6 +7,7 @@
 #include <odr/filesystem.hpp>
 #include <odr/html.hpp>
 
+#include <sstream>
 #include <vector>
 
 namespace {
@@ -16,6 +17,7 @@ using odr_jni::from_handle;
 using odr_jni::guarded;
 using odr_jni::HandleGuard;
 using odr_jni::make_handle;
+using odr_jni::to_jbytes;
 using odr_jni::to_jstring;
 using odr_jni::to_string;
 
@@ -102,6 +104,26 @@ Java_app_opendocument_core_Document_saveEncryptedNative(JNIEnv *env, jobject,
   guarded(env, [&] {
     from_handle<odr::Document>(handle)->save(to_string(env, path),
                                              to_string(env, password));
+  });
+}
+
+extern "C" JNIEXPORT jbyteArray JNICALL
+Java_app_opendocument_core_Document_saveToMemoryNative(JNIEnv *env, jobject,
+                                                       jlong handle) {
+  return guarded(env, [&] {
+    std::ostringstream out;
+    from_handle<odr::Document>(handle)->save(out);
+    return to_jbytes(env, out.str());
+  });
+}
+
+extern "C" JNIEXPORT jbyteArray JNICALL
+Java_app_opendocument_core_Document_saveToMemoryEncryptedNative(
+    JNIEnv *env, jobject, jlong handle, jstring password) {
+  return guarded(env, [&] {
+    std::ostringstream out;
+    from_handle<odr::Document>(handle)->save(out, to_string(env, password));
+    return to_jbytes(env, out.str());
   });
 }
 

--- a/jni/tests/app/opendocument/core/DocumentTest.java
+++ b/jni/tests/app/opendocument/core/DocumentTest.java
@@ -5,6 +5,7 @@ import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import java.io.IOException;
+import java.nio.file.Files;
 import java.nio.file.Path;
 import java.util.ArrayList;
 import java.util.List;
@@ -102,5 +103,23 @@ class DocumentTest {
     Html.edit(document, "{\"modifiedText\":{\"" + text + "\":\"edited by the diff\"}}");
 
     assertTrue(walkText(document.rootElement()).contains("edited by the diff"));
+  }
+
+  @Test
+  void saveToMemoryRoundTripsAnEdit() throws IOException {
+    Document document = openDocument();
+
+    Element paragraph = document.rootElement().firstChild();
+    DocumentPath text = paragraph.firstChild().documentPath();
+    Html.edit(document, "{\"modifiedText\":{\"" + text + "\":\"saved to memory\"}}");
+
+    byte[] saved = document.saveToMemory();
+    assertTrue(saved.length > 0);
+
+    Path reloadedPath = tempDir.resolve("from-memory.odt");
+    Files.write(reloadedPath, saved);
+    Document reloaded = Odr.open(reloadedPath.toString()).asDocumentFile().document();
+
+    assertTrue(walkText(reloaded.rootElement()).contains("saved to memory"));
   }
 }

--- a/python/src/bind_document.cpp
+++ b/python/src/bind_document.cpp
@@ -11,6 +11,7 @@
 
 #include <pybind11/stl.h>
 
+#include <sstream>
 #include <string>
 
 namespace py = pybind11;
@@ -333,6 +334,29 @@ void odr_python::bind_document(py::module_ &m) {
                &odr::Document::save, py::const_),
            py::arg("path"), py::arg("password"),
            py::call_guard<py::gil_scoped_release>())
+      .def(
+          "save_to_memory",
+          [](const odr::Document &document) {
+            std::ostringstream out;
+            {
+              py::gil_scoped_release release;
+              document.save(out);
+            }
+            return py::bytes(out.str());
+          },
+          "Save the document and return its bytes.")
+      .def(
+          "save_to_memory",
+          [](const odr::Document &document, const std::string &password) {
+            std::ostringstream out;
+            {
+              py::gil_scoped_release release;
+              document.save(out, password);
+            }
+            return py::bytes(out.str());
+          },
+          py::arg("password"),
+          "Save the document encrypted and return its bytes.")
       .def("file_type", &odr::Document::file_type)
       .def("document_type", &odr::Document::document_type)
       .def("root_element", &odr::Document::root_element, keep_self_alive)

--- a/python/tests/test_document.py
+++ b/python/tests/test_document.py
@@ -117,3 +117,30 @@ def test_list_markers(odt_path):
 
     assert [item.marker() for item in items(lists[1])] == ["1.", "2."]
     assert [item.number() for item in items(lists[1])] == [1, 2]
+
+
+def test_save_to_memory_round_trips(odt_path, tmp_path):
+    document = pyodr.open(str(odt_path)).as_document_file().document()
+    assert document.is_savable()
+
+    saved = document.save_to_memory()
+    assert isinstance(saved, bytes)
+    assert saved[:2] == b"PK"
+
+    path = tmp_path / "from_memory.odt"
+    path.write_bytes(saved)
+    reloaded = pyodr.open(str(path)).as_document_file().document()
+    assert walk_text(reloaded.root_element()) == walk_text(document.root_element())
+
+
+def test_save_to_memory_carries_an_edit(odt_path, tmp_path):
+    document = pyodr.open(str(odt_path)).as_document_file().document()
+
+    diff = '{"modifiedText":{"/child:0/child:0":"edited in python"}}'
+    pyodr.html.edit(document, diff)
+
+    path = tmp_path / "edited.odt"
+    path.write_bytes(document.save_to_memory())
+    reloaded = pyodr.open(str(path)).as_document_file().document()
+
+    assert "edited in python" in walk_text(reloaded.root_element())

--- a/src/odr/document.cpp
+++ b/src/odr/document.cpp
@@ -7,9 +7,12 @@
 
 #include <odr/internal/abstract/document.hpp>
 #include <odr/internal/common/filesystem.hpp>
-#include <odr/internal/common/path.hpp>
+#include <odr/internal/util/file_util.hpp>
 
+#include <fstream>
 #include <memory>
+#include <sstream>
+#include <utility>
 
 namespace odr {
 
@@ -26,13 +29,40 @@ bool Document::is_savable(const bool encrypted) const noexcept {
   return m_impl->is_savable(encrypted);
 }
 
+// Checked here so an unsavable format leaves no empty file behind.
 void Document::save(const std::string &path) const {
-  m_impl->save(internal::Path(path));
+  if (!m_impl->is_savable(false)) {
+    throw UnsupportedOperation();
+  }
+  std::ofstream out = internal::util::file::create(path);
+  m_impl->save(out);
 }
 
 void Document::save(const std::string &path,
                     const std::string &password) const {
-  m_impl->save(internal::Path(path), password.c_str());
+  if (!m_impl->is_savable(true)) {
+    throw UnsupportedOperation();
+  }
+  std::ofstream out = internal::util::file::create(path);
+  m_impl->save(out, password.c_str());
+}
+
+void Document::save(std::ostream &out) const { m_impl->save(out); }
+
+void Document::save(std::ostream &out, const std::string &password) const {
+  m_impl->save(out, password.c_str());
+}
+
+File Document::save_to_memory() const {
+  std::ostringstream out;
+  m_impl->save(out);
+  return File::from_memory(std::move(out).str());
+}
+
+File Document::save_to_memory(const std::string &password) const {
+  std::ostringstream out;
+  m_impl->save(out, password.c_str());
+  return File::from_memory(std::move(out).str());
 }
 
 FileType Document::file_type() const noexcept { return m_impl->file_type(); }

--- a/src/odr/document.hpp
+++ b/src/odr/document.hpp
@@ -1,5 +1,6 @@
 #pragma once
 
+#include <iosfwd>
 #include <memory>
 #include <string>
 
@@ -12,6 +13,7 @@ enum class FileType;
 enum class DocumentType;
 class DocumentFile;
 class Element;
+class File;
 class Filesystem;
 
 /// @brief Represents a document.
@@ -24,6 +26,13 @@ public:
 
   void save(const std::string &path) const;
   void save(const std::string &path, const std::string &password) const;
+
+  void save(std::ostream &out) const;
+  void save(std::ostream &out, const std::string &password) const;
+
+  /// @brief The saved document as a file in memory.
+  [[nodiscard]] File save_to_memory() const;
+  [[nodiscard]] File save_to_memory(const std::string &password) const;
 
   [[nodiscard]] FileType file_type() const noexcept;
   [[nodiscard]] DocumentType document_type() const noexcept;

--- a/src/odr/internal/abstract/document.hpp
+++ b/src/odr/internal/abstract/document.hpp
@@ -4,6 +4,7 @@
 #include <odr/quantity.hpp>
 
 #include <cstdint>
+#include <iosfwd>
 #include <memory>
 #include <optional>
 #include <string>
@@ -28,10 +29,6 @@ struct TextStyle;
 struct ParagraphStyle;
 struct GraphicStyle;
 } // namespace odr
-
-namespace odr::internal {
-class Path;
-} // namespace odr::internal
 
 namespace odr::internal::abstract {
 class ReadableFilesystem;
@@ -71,8 +68,8 @@ public:
   /// Savable, @p encrypted to ask for an encrypted save.
   [[nodiscard]] virtual bool is_savable(bool encrypted) const noexcept = 0;
 
-  virtual void save(const Path &path) const = 0;
-  virtual void save(const Path &path, const char *password) const = 0;
+  virtual void save(std::ostream &out) const = 0;
+  virtual void save(std::ostream &out, const char *password) const = 0;
 
   [[nodiscard]] virtual FileType file_type() const noexcept = 0;
   [[nodiscard]] virtual DocumentType document_type() const noexcept = 0;

--- a/src/odr/internal/csv/csv_document.cpp
+++ b/src/odr/internal/csv/csv_document.cpp
@@ -313,12 +313,12 @@ bool CsvDocument::is_savable(
   return false;
 }
 
-void CsvDocument::save([[maybe_unused]] const Path &path) const {
+void CsvDocument::save(std::ostream & /*out*/) const {
   throw UnsupportedOperation();
 }
 
-void CsvDocument::save([[maybe_unused]] const Path &path,
-                       [[maybe_unused]] const char *password) const {
+void CsvDocument::save(std::ostream & /*out*/,
+                       const char * /*password*/) const {
   throw UnsupportedOperation();
 }
 

--- a/src/odr/internal/csv/csv_document.hpp
+++ b/src/odr/internal/csv/csv_document.hpp
@@ -31,8 +31,8 @@ public:
   [[nodiscard]] bool is_editable() const noexcept override;
   [[nodiscard]] bool is_savable(bool encrypted) const noexcept override;
 
-  void save(const Path &path) const override;
-  void save(const Path &path, const char *password) const override;
+  void save(std::ostream &out) const override;
+  void save(std::ostream &out, const char *password) const override;
 
   /// The cell's text, empty where a row stops short.
   [[nodiscard]] std::string_view cell(std::uint32_t column,

--- a/src/odr/internal/iwork/iwork_document.cpp
+++ b/src/odr/internal/iwork/iwork_document.cpp
@@ -60,14 +60,11 @@ bool Document::is_savable(const bool encrypted) const noexcept {
   return false;
 }
 
-void Document::save(const Path &path) const {
-  (void)path;
+void Document::save(std::ostream & /*out*/) const {
   throw UnsupportedOperation();
 }
 
-void Document::save(const Path &path, const char *password) const {
-  (void)path;
-  (void)password;
+void Document::save(std::ostream & /*out*/, const char * /*password*/) const {
   throw UnsupportedOperation();
 }
 

--- a/src/odr/internal/iwork/iwork_document.hpp
+++ b/src/odr/internal/iwork/iwork_document.hpp
@@ -22,8 +22,8 @@ public:
   [[nodiscard]] bool is_editable() const noexcept override;
   [[nodiscard]] bool is_savable(bool encrypted) const noexcept override;
 
-  void save(const Path &path) const override;
-  void save(const Path &path, const char *password) const override;
+  void save(std::ostream &out) const override;
+  void save(std::ostream &out, const char *password) const override;
 
 private:
   ElementRegistry m_element_registry;

--- a/src/odr/internal/markdown/markdown_document.cpp
+++ b/src/odr/internal/markdown/markdown_document.cpp
@@ -41,14 +41,11 @@ bool Document::is_savable(const bool encrypted) const noexcept {
   return false;
 }
 
-void Document::save(const Path &path) const {
-  (void)path;
+void Document::save(std::ostream & /*out*/) const {
   throw UnsupportedOperation();
 }
 
-void Document::save(const Path &path, const char *password) const {
-  (void)path;
-  (void)password;
+void Document::save(std::ostream & /*out*/, const char * /*password*/) const {
   throw UnsupportedOperation();
 }
 

--- a/src/odr/internal/markdown/markdown_document.hpp
+++ b/src/odr/internal/markdown/markdown_document.hpp
@@ -21,8 +21,8 @@ public:
   [[nodiscard]] bool is_editable() const noexcept override;
   [[nodiscard]] bool is_savable(bool encrypted) const noexcept override;
 
-  void save(const Path &path) const override;
-  void save(const Path &path, const char *password) const override;
+  void save(std::ostream &out) const override;
+  void save(std::ostream &out, const char *password) const override;
 
 private:
   ElementRegistry m_element_registry;

--- a/src/odr/internal/odf/odf_document.cpp
+++ b/src/odr/internal/odf/odf_document.cpp
@@ -13,13 +13,12 @@
 #include <odr/internal/odf/odf_parser.hpp>
 #include <odr/internal/odf/odf_table.hpp>
 #include <odr/internal/util/document_util.hpp>
-#include <odr/internal/util/file_util.hpp>
 #include <odr/internal/util/string_util.hpp>
 #include <odr/internal/util/xml_util.hpp>
 #include <odr/internal/zip/zip_archive.hpp>
 
 #include <cstring>
-#include <fstream>
+#include <ostream>
 #include <sstream>
 
 namespace odr::internal::odf {
@@ -84,11 +83,10 @@ bool Document::is_savable(const bool encrypted) const noexcept {
   return !encrypted;
 }
 
-void Document::save(const Path &path) const {
+void Document::save(std::ostream &out) const {
   // no package to rebuild: a flat document is the one tree, and `save` puts
   // back the declaration the parse dropped
   if (m_files == nullptr) {
-    std::ofstream out = util::file::create(path.string());
     m_content_xml.save(out, "", pugi::format_raw);
     return;
   }
@@ -115,9 +113,9 @@ void Document::save(const Path &path) const {
     }
     if (abs_path == Path("/content.xml")) {
       // TODO stream
-      std::stringstream out;
-      m_content_xml.print(out, "", pugi::format_raw);
-      auto tmp = std::make_shared<MemoryFile>(out.str());
+      std::stringstream content;
+      m_content_xml.print(content, "", pugi::format_raw);
+      auto tmp = std::make_shared<MemoryFile>(content.str());
       archive.insert_file(std::end(archive), rel_path, tmp);
       continue;
     }
@@ -130,9 +128,9 @@ void Document::save(const Path &path) const {
         node.node().parent().remove_child(node.node());
       }
 
-      std::stringstream out;
-      manifest.print(out, "", pugi::format_raw);
-      auto tmp = std::make_shared<MemoryFile>(out.str());
+      std::stringstream content;
+      manifest.print(content, "", pugi::format_raw);
+      auto tmp = std::make_shared<MemoryFile>(content.str());
       archive.insert_file(std::end(archive), rel_path, tmp);
 
       continue;
@@ -140,11 +138,10 @@ void Document::save(const Path &path) const {
     archive.insert_file(std::end(archive), rel_path, m_files->open(abs_path));
   }
 
-  std::ofstream ostream = util::file::create(path.string());
-  archive.save(ostream);
+  archive.save(out);
 }
 
-void Document::save(const Path & /*path*/, const char * /*password*/) const {
+void Document::save(std::ostream & /*out*/, const char * /*password*/) const {
   // TODO throw if not savable
   throw UnsupportedOperation();
 }

--- a/src/odr/internal/odf/odf_document.hpp
+++ b/src/odr/internal/odf/odf_document.hpp
@@ -27,8 +27,8 @@ public:
   [[nodiscard]] bool is_editable() const noexcept override;
   [[nodiscard]] bool is_savable(bool encrypted) const noexcept override;
 
-  void save(const Path &path) const override;
-  void save(const Path &path, const char *password) const override;
+  void save(std::ostream &out) const override;
+  void save(std::ostream &out, const char *password) const override;
 
 private:
   void init_(pugi::xml_node content_root, pugi::xml_node styles_root);

--- a/src/odr/internal/oldms/presentation/ppt_document.cpp
+++ b/src/odr/internal/oldms/presentation/ppt_document.cpp
@@ -48,14 +48,11 @@ bool Document::is_savable(const bool encrypted) const noexcept {
   return false;
 }
 
-void Document::save(const Path &path) const {
-  (void)path;
+void Document::save(std::ostream & /*out*/) const {
   throw UnsupportedOperation();
 }
 
-void Document::save(const Path &path, const char *password) const {
-  (void)path;
-  (void)password;
+void Document::save(std::ostream & /*out*/, const char * /*password*/) const {
   throw UnsupportedOperation();
 }
 

--- a/src/odr/internal/oldms/presentation/ppt_document.hpp
+++ b/src/odr/internal/oldms/presentation/ppt_document.hpp
@@ -21,8 +21,8 @@ public:
   [[nodiscard]] bool is_editable() const noexcept override;
   [[nodiscard]] bool is_savable(bool encrypted) const noexcept override;
 
-  void save(const Path &path) const override;
-  void save(const Path &path, const char *password) const override;
+  void save(std::ostream &out) const override;
+  void save(std::ostream &out, const char *password) const override;
 
 private:
   ElementRegistry m_element_registry;

--- a/src/odr/internal/oldms/spreadsheet/xls_document.cpp
+++ b/src/odr/internal/oldms/spreadsheet/xls_document.cpp
@@ -44,14 +44,11 @@ bool Document::is_savable(const bool encrypted) const noexcept {
   return false;
 }
 
-void Document::save(const Path &path) const {
-  (void)path;
+void Document::save(std::ostream & /*out*/) const {
   throw UnsupportedOperation();
 }
 
-void Document::save(const Path &path, const char *password) const {
-  (void)path;
-  (void)password;
+void Document::save(std::ostream & /*out*/, const char * /*password*/) const {
   throw UnsupportedOperation();
 }
 

--- a/src/odr/internal/oldms/spreadsheet/xls_document.hpp
+++ b/src/odr/internal/oldms/spreadsheet/xls_document.hpp
@@ -21,8 +21,8 @@ public:
   [[nodiscard]] bool is_editable() const noexcept override;
   [[nodiscard]] bool is_savable(bool encrypted) const noexcept override;
 
-  void save(const Path &path) const override;
-  void save(const Path &path, const char *password) const override;
+  void save(std::ostream &out) const override;
+  void save(std::ostream &out, const char *password) const override;
 
 private:
   ElementRegistry m_element_registry;

--- a/src/odr/internal/oldms/text/doc_document.cpp
+++ b/src/odr/internal/oldms/text/doc_document.cpp
@@ -43,14 +43,11 @@ bool Document::is_savable(const bool encrypted) const noexcept {
   return false;
 }
 
-void Document::save(const Path &path) const {
-  (void)path;
+void Document::save(std::ostream & /*out*/) const {
   throw UnsupportedOperation();
 }
 
-void Document::save(const Path &path, const char *password) const {
-  (void)path;
-  (void)password;
+void Document::save(std::ostream & /*out*/, const char * /*password*/) const {
   throw UnsupportedOperation();
 }
 

--- a/src/odr/internal/oldms/text/doc_document.hpp
+++ b/src/odr/internal/oldms/text/doc_document.hpp
@@ -21,8 +21,8 @@ public:
   [[nodiscard]] bool is_editable() const noexcept override;
   [[nodiscard]] bool is_savable(bool encrypted) const noexcept override;
 
-  void save(const Path &path) const override;
-  void save(const Path &path, const char *password) const override;
+  void save(std::ostream &out) const override;
+  void save(std::ostream &out, const char *password) const override;
 
 private:
   ElementRegistry m_element_registry;

--- a/src/odr/internal/ooxml/presentation/ooxml_presentation_document.cpp
+++ b/src/odr/internal/ooxml/presentation/ooxml_presentation_document.cpp
@@ -144,11 +144,11 @@ bool Document::is_savable(const bool /*encrypted*/) const noexcept {
   return false;
 }
 
-void Document::save(const Path & /*path*/) const {
+void Document::save(std::ostream & /*out*/) const {
   throw UnsupportedOperation();
 }
 
-void Document::save(const Path & /*path*/, const char * /*password*/) const {
+void Document::save(std::ostream & /*out*/, const char * /*password*/) const {
   throw UnsupportedOperation();
 }
 

--- a/src/odr/internal/ooxml/presentation/ooxml_presentation_document.hpp
+++ b/src/odr/internal/ooxml/presentation/ooxml_presentation_document.hpp
@@ -31,8 +31,8 @@ public:
   [[nodiscard]] bool is_editable() const noexcept override;
   [[nodiscard]] bool is_savable(bool encrypted) const noexcept override;
 
-  void save(const Path &path) const override;
-  void save(const Path &path, const char *password) const override;
+  void save(std::ostream &out) const override;
+  void save(std::ostream &out, const char *password) const override;
 
 private:
   pugi::xml_document m_document_xml;

--- a/src/odr/internal/ooxml/spreadsheet/ooxml_spreadsheet_document.cpp
+++ b/src/odr/internal/ooxml/spreadsheet/ooxml_spreadsheet_document.cpp
@@ -75,11 +75,11 @@ bool Document::is_savable(const bool /*encrypted*/) const noexcept {
   return false;
 }
 
-void Document::save(const Path & /*path*/) const {
+void Document::save(std::ostream & /*out*/) const {
   throw UnsupportedOperation();
 }
 
-void Document::save(const Path & /*path*/, const char * /*password*/) const {
+void Document::save(std::ostream & /*out*/, const char * /*password*/) const {
   throw UnsupportedOperation();
 }
 

--- a/src/odr/internal/ooxml/spreadsheet/ooxml_spreadsheet_document.hpp
+++ b/src/odr/internal/ooxml/spreadsheet/ooxml_spreadsheet_document.hpp
@@ -24,8 +24,8 @@ public:
   [[nodiscard]] bool is_editable() const noexcept override;
   [[nodiscard]] bool is_savable(bool encrypted) const noexcept override;
 
-  void save(const Path &path) const override;
-  void save(const Path &path, const char *password) const override;
+  void save(std::ostream &out) const override;
+  void save(std::ostream &out, const char *password) const override;
 
 private:
   XmlDocumentsAndRelations m_xml_documents_and_relations;

--- a/src/odr/internal/ooxml/text/ooxml_text_document.cpp
+++ b/src/odr/internal/ooxml/text/ooxml_text_document.cpp
@@ -9,13 +9,12 @@
 #include <odr/internal/ooxml/ooxml_util.hpp>
 #include <odr/internal/ooxml/text/ooxml_text_parser.hpp>
 #include <odr/internal/util/document_util.hpp>
-#include <odr/internal/util/file_util.hpp>
 #include <odr/internal/util/xml_util.hpp>
 #include <odr/internal/zip/zip_archive.hpp>
 
 #include <cstring>
-#include <fstream>
 #include <iterator>
+#include <ostream>
 #include <sstream>
 
 namespace odr::internal::ooxml::text {
@@ -117,7 +116,7 @@ bool Document::is_savable(const bool encrypted) const noexcept {
   return !encrypted;
 }
 
-void Document::save(const Path &path) const {
+void Document::save(std::ostream &out) const {
   // TODO this would decrypt/inflate and encrypt/deflate again
   zip::ZipArchive archive;
 
@@ -131,20 +130,19 @@ void Document::save(const Path &path) const {
     }
     if (abs_path == AbsPath("/word/document.xml")) {
       // TODO stream
-      std::stringstream out;
-      m_document_xml.print(out, "", pugi::format_raw);
-      auto tmp = std::make_shared<MemoryFile>(out.str());
+      std::stringstream content;
+      m_document_xml.print(content, "", pugi::format_raw);
+      auto tmp = std::make_shared<MemoryFile>(content.str());
       archive.insert_file(std::end(archive), rel_path, tmp);
       continue;
     }
     archive.insert_file(std::end(archive), rel_path, m_files->open(abs_path));
   }
 
-  std::ofstream ostream = util::file::create(path.string());
-  archive.save(ostream);
+  archive.save(out);
 }
 
-void Document::save(const Path & /*path*/, const char * /*password*/) const {
+void Document::save(std::ostream & /*out*/, const char * /*password*/) const {
   throw UnsupportedOperation();
 }
 

--- a/src/odr/internal/ooxml/text/ooxml_text_document.hpp
+++ b/src/odr/internal/ooxml/text/ooxml_text_document.hpp
@@ -30,8 +30,8 @@ public:
   [[nodiscard]] bool is_editable() const noexcept override;
   [[nodiscard]] bool is_savable(bool encrypted) const noexcept override;
 
-  void save(const Path &path) const override;
-  void save(const Path &path, const char *password) const override;
+  void save(std::ostream &out) const override;
+  void save(std::ostream &out, const char *password) const override;
 
 private:
   pugi::xml_document m_document_xml;

--- a/src/odr/internal/rtf/rtf_document.cpp
+++ b/src/odr/internal/rtf/rtf_document.cpp
@@ -40,14 +40,11 @@ bool Document::is_savable(const bool encrypted) const noexcept {
   return false;
 }
 
-void Document::save(const Path &path) const {
-  (void)path;
+void Document::save(std::ostream & /*out*/) const {
   throw UnsupportedOperation();
 }
 
-void Document::save(const Path &path, const char *password) const {
-  (void)path;
-  (void)password;
+void Document::save(std::ostream & /*out*/, const char * /*password*/) const {
   throw UnsupportedOperation();
 }
 

--- a/src/odr/internal/rtf/rtf_document.hpp
+++ b/src/odr/internal/rtf/rtf_document.hpp
@@ -20,8 +20,8 @@ public:
   [[nodiscard]] bool is_editable() const noexcept override;
   [[nodiscard]] bool is_savable(bool encrypted) const noexcept override;
 
-  void save(const Path &path) const override;
-  void save(const Path &path, const char *password) const override;
+  void save(std::ostream &out) const override;
+  void save(std::ostream &out, const char *password) const override;
 
 private:
   ElementRegistry m_element_registry;

--- a/test/src/document_test.cpp
+++ b/test/src/document_test.cpp
@@ -1,6 +1,8 @@
 #include <odr/document.hpp>
 #include <odr/document_element.hpp>
 #include <odr/document_path.hpp>
+#include <odr/exceptions.hpp>
+#include <odr/file.hpp>
 #include <odr/html.hpp>
 #include <odr/style.hpp>
 
@@ -10,6 +12,7 @@
 
 #include <filesystem>
 #include <optional>
+#include <sstream>
 #include <string>
 
 using namespace odr;
@@ -326,4 +329,61 @@ TEST(Document, edit_docx_diff) {
   expect_text_at(document, "/child:24/child:0/child:0",
                  "Colorasdfasdfasdfed Line");
   expect_text_at(document, "/child:6/child:0/child:0", "Text hello world!");
+}
+
+namespace {
+
+/// The one document `save` writes as xml rather than as a zip.
+constexpr const char *flat_odt =
+    R"(<?xml version="1.0" encoding="UTF-8"?>)"
+    R"(<office:document office:mimetype=")"
+    R"(application/vnd.oasis.opendocument.text">)"
+    R"(<office:body><office:text><text:p>hello</text:p></office:text>)"
+    R"(</office:body></office:document>)";
+
+} // namespace
+
+TEST(Document, save_to_memory_round_trips_a_flat_document) {
+  const Document document = DocumentFile::from_memory(flat_odt).document();
+
+  set_every_text(document.root_element(), "hello world!");
+
+  const File saved = document.save_to_memory();
+  EXPECT_EQ(FileLocation::memory, saved.location());
+
+  const Document reloaded = DocumentFile(saved).document();
+  expect_every_text(reloaded.root_element(), "hello world!");
+}
+
+TEST(Document, save_to_a_stream_writes_what_save_to_memory_holds) {
+  const Document document = DocumentFile::from_memory(flat_odt).document();
+
+  std::ostringstream out;
+  document.save(out);
+
+  EXPECT_EQ(out.str(), document.save_to_memory().memory_data().value());
+}
+
+TEST(Document, save_to_memory_round_trips_a_package) {
+  const Document document =
+      DocumentFile(TestData::test_file_path("odr-public/odt/about.odt"))
+          .document();
+
+  set_every_text(document.root_element(), "hello world!");
+
+  const Document reloaded = DocumentFile(document.save_to_memory()).document();
+  expect_every_text(reloaded.root_element(), "hello world!");
+}
+
+TEST(Document, saving_an_unsavable_format_leaves_no_file) {
+  const Document document =
+      DocumentFile(
+          TestData::test_file_path("odr-public/pptx/style-various-1.pptx"))
+          .document();
+  ASSERT_FALSE(document.is_savable());
+
+  const std::string path =
+      (std::filesystem::current_path() / "unsavable_save.pptx").string();
+  EXPECT_THROW(document.save(path), UnsupportedOperation);
+  EXPECT_FALSE(std::filesystem::exists(path));
 }

--- a/wasm/AGENTS.md
+++ b/wasm/AGENTS.md
@@ -39,7 +39,10 @@ Worker**, where every value that crosses is structured-cloned.
   view an index within its session. This also dissolves the keep-alive problem
   the other bindings hand-built: `HtmlView` holds a bare pointer into its
   service and `Element` into the document adapter, and here neither is handed
-  out — `Session` owns file, service and views together. Handle `0` is never
+  out — `Session` owns file, document, service and views together. The
+  document is the *one* tree the render, the edit and the save all go through:
+  `DocumentFile::document()` decodes a fresh one per call, so a `save` that
+  opened its own would write the document nobody edited. Handle `0` is never
   issued, so a zeroed handle is always invalid.
 - **Config crosses as a plain object.** `to_html_config` reads known keys and
   leaves the rest defaulted. Never bind a mutable config: it could not cross

--- a/wasm/CMakeLists.txt
+++ b/wasm/CMakeLists.txt
@@ -32,6 +32,7 @@ endif ()
 add_executable(odr_wasm
         "src/odr_wasm.cpp"
         "src/wasm_core.cpp"
+        "src/wasm_document.cpp"
         "src/wasm_file.cpp"
         "src/wasm_html.cpp"
         "src/wasm_logger.cpp"

--- a/wasm/README.md
+++ b/wasm/README.md
@@ -59,6 +59,22 @@ for (const view of doc.listViews()) {
 }
 ```
 
+Editing is a round trip through the rendered page:
+
+```js
+const doc = odr.open(bytes, { editable: true });
+const { html } = doc.render(0);
+// ... the reader edits the page in the iframe ...
+doc.edit(JSON.stringify(iframe.contentWindow.odr.generateDiff()));
+
+const saved = doc.save();   // the document, not the html
+download(new Blob([saved]));
+```
+
+`isEditable()` and `isSavable()` answer for this document, where
+`capabilities()` answers for the format. Only ODF and docx can be saved so far;
+anything else throws `UnsupportedOperation`.
+
 Encrypted documents:
 
 ```js

--- a/wasm/js/index.d.ts
+++ b/wasm/js/index.d.ts
@@ -150,6 +150,16 @@ export declare class Document {
   render(index?: number): Rendered;
   read(path: string): Content;
 
+  /** `capabilities()` narrowed to this document. */
+  isEditable(): boolean;
+  isSavable(encrypted?: boolean): boolean;
+  /** Applies what the rendered page's `odr.generateDiff()` collected.
+   * @throws OdrError `NoDocumentFile` */
+  edit(diff: string): this;
+  /** The document's bytes, not the rendered html.
+   * @throws OdrError `UnsupportedOperation` where the format cannot be saved */
+  save(password?: string): Uint8Array;
+
   /** Idempotent; returns whether it released anything. */
   close(): boolean;
   [Symbol.dispose](): void;

--- a/wasm/js/index.js
+++ b/wasm/js/index.js
@@ -71,6 +71,28 @@ export class Document {
     return unwrap(this.#core.readPath(this.#handle, path));
   }
 
+  // `capabilities()` narrowed to this document.
+  isEditable() {
+    return unwrap(this.#core.isEditable(this.#handle));
+  }
+
+  isSavable(encrypted = false) {
+    return unwrap(this.#core.isSavable(this.#handle, encrypted));
+  }
+
+  // Applies what the rendered page's `odr.generateDiff()` collected.
+  edit(diff) {
+    unwrap(this.#core.edit(this.#handle, diff));
+    return this;
+  }
+
+  // The document's bytes, not the rendered html.
+  save(password) {
+    return password === undefined
+      ? unwrap(this.#core.save(this.#handle))
+      : unwrap(this.#core.saveEncrypted(this.#handle, password));
+  }
+
   close() {
     return unwrap(this.#core.close(this.#handle));
   }

--- a/wasm/src/odr_wasm.cpp
+++ b/wasm/src/odr_wasm.cpp
@@ -38,6 +38,13 @@ Session &session(const Handle handle) {
   return it->second;
 }
 
+Document &document_of(Session &session) {
+  if (!session.document.has_value()) {
+    session.document = session.file.as_document_file().document();
+  }
+  return *session.document;
+}
+
 Handle add_session(Session session) {
   const Handle handle = next_handle()++;
   sessions().emplace(handle, std::move(session));

--- a/wasm/src/odr_wasm.hpp
+++ b/wasm/src/odr_wasm.hpp
@@ -1,5 +1,6 @@
 #pragma once
 
+#include <odr/document.hpp>
 #include <odr/file.hpp>
 #include <odr/html.hpp>
 #include <odr/logger.hpp>
@@ -24,6 +25,9 @@ struct Session final {
   DecodedFile file;
   Logger logger;
   HtmlConfig config;
+  /// The one tree render, edit and save share; `DocumentFile::document()`
+  /// decodes a fresh one per call.
+  std::optional<Document> document;
   std::optional<HtmlService> service;
   HtmlViews views;
 };
@@ -32,6 +36,8 @@ Logger &default_logger();
 
 /// @throws std::out_of_range if @p handle is unknown.
 Session &session(Handle handle);
+/// @throws NoDocumentFile if the session's file is not a document.
+Document &document_of(Session &session);
 Handle add_session(Session session);
 bool remove_session(Handle handle) noexcept;
 void clear_sessions() noexcept;

--- a/wasm/src/wasm_document.cpp
+++ b/wasm/src/wasm_document.cpp
@@ -1,0 +1,56 @@
+#include <odr_wasm.hpp>
+
+#include <odr/document.hpp>
+#include <odr/file.hpp>
+
+#include <emscripten/bind.h>
+
+#include <sstream>
+#include <string>
+
+namespace odr::wasm {
+
+namespace {
+
+/// `capabilities()` narrowed to this document.
+emscripten::val is_editable(const Handle handle) {
+  return guarded([&] {
+    return ok(emscripten::val(document_of(session(handle)).is_editable()));
+  });
+}
+
+emscripten::val is_savable(const Handle handle, const bool encrypted) {
+  return guarded([&] {
+    return ok(
+        emscripten::val(document_of(session(handle)).is_savable(encrypted)));
+  });
+}
+
+/// The document's bytes; there is no filesystem to save to.
+emscripten::val save(const Handle handle) {
+  return guarded([&] {
+    std::ostringstream out;
+    document_of(session(handle)).save(out);
+    return ok(to_uint8_array(out.str()));
+  });
+}
+
+emscripten::val save_encrypted(const Handle handle,
+                               const std::string &password) {
+  return guarded([&] {
+    std::ostringstream out;
+    document_of(session(handle)).save(out, password);
+    return ok(to_uint8_array(out.str()));
+  });
+}
+
+} // namespace
+
+} // namespace odr::wasm
+
+EMSCRIPTEN_BINDINGS(odr_document) {
+  emscripten::function("isEditable", &odr::wasm::is_editable);
+  emscripten::function("isSavable", &odr::wasm::is_savable);
+  emscripten::function("save", &odr::wasm::save);
+  emscripten::function("saveEncrypted", &odr::wasm::save_encrypted);
+}

--- a/wasm/src/wasm_file.cpp
+++ b/wasm/src/wasm_file.cpp
@@ -23,6 +23,7 @@ emscripten::val opened(DecodedFile file, const emscripten::val &config) {
   Session s{.file = std::move(file),
             .logger = default_logger(),
             .config = to_html_config(config),
+            .document = {},
             .service = {},
             .views = {}};
   return ok(emscripten::val(add_session(std::move(s))));
@@ -87,7 +88,8 @@ emscripten::val decrypt(const Handle handle, const std::string &password) {
   return guarded([&] {
     Session &s = session(handle);
     s.file = s.file.decrypt(password);
-    // whatever was translated came from the encrypted file
+    // whatever was decoded or translated came from the encrypted file
+    s.document.reset();
     s.service.reset();
     s.views.clear();
     return ok();

--- a/wasm/src/wasm_html.cpp
+++ b/wasm/src/wasm_html.cpp
@@ -51,7 +51,10 @@ void read_measure(const emscripten::val &value, const char *key,
 Session &warm(const Handle handle) {
   Session &s = session(handle);
   if (!s.service.has_value()) {
-    s.service = html::translate(s.file, s.config, s.logger);
+    // from the session's tree, not the file, which would decode a second one
+    s.service = s.file.is_document_file()
+                    ? html::translate(document_of(s), s.config, s.logger)
+                    : html::translate(s.file, s.config, s.logger);
     s.views = s.service->list_views();
   }
   return s;
@@ -135,6 +138,15 @@ emscripten::val read_path(const Handle handle, const std::string &path) {
   });
 }
 
+/// Applies what the rendered page's `odr.generateDiff()` collected.
+emscripten::val edit(const Handle handle, const std::string &diff) {
+  return guarded([&] {
+    Session &s = session(handle);
+    html::edit(document_of(s), diff, s.logger);
+    return ok();
+  });
+}
+
 } // namespace
 
 HtmlConfig to_html_config(const emscripten::val &value) {
@@ -207,4 +219,5 @@ EMSCRIPTEN_BINDINGS(odr_html) {
   emscripten::function("listViews", &odr::wasm::list_views);
   emscripten::function("renderView", &odr::wasm::render_view);
   emscripten::function("readPath", &odr::wasm::read_path);
+  emscripten::function("edit", &odr::wasm::edit);
 }

--- a/wasm/tests/edit.test.mjs
+++ b/wasm/tests/edit.test.mjs
@@ -1,0 +1,96 @@
+// The round trip: render editable, apply the page's diff, save the bytes back.
+
+import assert from 'node:assert/strict';
+import { after, before, describe, it } from 'node:test';
+
+import { Odr, OdrError, minimalOdt } from './helper.mjs';
+
+// Read out of the html rather than spelled, as the browser does.
+function firstEditablePath(html) {
+  const match = html.match(/data-odr-path="([^"]+)"/);
+  assert.ok(match, 'the editable render carries no data-odr-path');
+  return match[1];
+}
+
+describe('edit', () => {
+  let odr;
+  before(async () => {
+    odr = await Odr();
+  });
+  after(() => odr.closeAll());
+
+  it('reports what this document can do', () => {
+    const doc = odr.open(minimalOdt());
+    try {
+      assert.equal(doc.isEditable(), true);
+      assert.equal(doc.isSavable(), true);
+      assert.equal(doc.isSavable(true), false);
+    } finally {
+      doc.close();
+    }
+  });
+
+  it('applies a diff and saves the document it renders', () => {
+    const doc = odr.open(minimalOdt('hello'), { editable: true });
+    try {
+      const { html } = doc.render(0);
+      assert.match(html, /contenteditable/);
+
+      const path = firstEditablePath(html);
+      doc.edit(JSON.stringify({ modifiedText: { [path]: 'edited in the browser' } }));
+
+      // the edit is in the document, so the same service renders it
+      assert.match(doc.render(0).html, /edited in the browser/);
+
+      const saved = doc.save();
+      assert.ok(saved instanceof Uint8Array);
+      // a zip, i.e. the document rather than the rendered page
+      assert.deepEqual(Array.from(saved.subarray(0, 2)), [0x50, 0x4b]);
+
+      const reopened = odr.open(saved);
+      try {
+        assert.equal(reopened.fileType, odr.enums.FileType.odt);
+        assert.match(reopened.render(0).html, /edited in the browser/);
+      } finally {
+        reopened.close();
+      }
+    } finally {
+      doc.close();
+    }
+  });
+
+  it('saves without a render having happened', () => {
+    const doc = odr.open(minimalOdt('untouched'));
+    try {
+      assert.match(new TextDecoder().decode(doc.save()), /^PK/);
+    } finally {
+      doc.close();
+    }
+  });
+
+  it('refuses a file that is not a document', () => {
+    const doc = odr.open(new TextEncoder().encode('lorem ipsum dolor sit amet'));
+    try {
+      assert.throws(() => doc.save(), (error) => {
+        assert.ok(error instanceof OdrError);
+        assert.equal(error.name, 'NoDocumentFile');
+        return true;
+      });
+      assert.throws(() => doc.edit('{"modifiedText":{}}'), OdrError);
+    } finally {
+      doc.close();
+    }
+  });
+
+  it('refuses an encrypted save, which no format supports yet', () => {
+    const doc = odr.open(minimalOdt());
+    try {
+      assert.throws(() => doc.save('secret'), (error) => {
+        assert.equal(error.name, 'UnsupportedOperation');
+        return true;
+      });
+    } finally {
+      doc.close();
+    }
+  });
+});


### PR DESCRIPTION
🤖 Generated with [Claude Code](https://claude.com/claude-code)

Closes #777.

## The core change

`Document::save` took a path, and a browser has none. It now writes to a
`std::ostream`.

`abstract::Document::save` takes the stream rather than an `internal::Path`:
**no engine used the path for anything but opening an `ofstream`**. Only two
implement `save` at all (`odf::Document`, `ooxml::text::Document`) and both
already ended at `archive.save(ostream)`; the other eleven throw
`UnsupportedOperation` and ignored the argument. So the `ofstream` moves up one
layer instead of being repeated per engine, and the two savables in the library
are now stated the same way as `Archive::save(std::ostream &)`.

```cpp
void save(const std::string &path) const;                                // unchanged
void save(const std::string &path, const std::string &password) const;   // unchanged

void save(std::ostream &out) const;                                      // new
void save(std::ostream &out, const std::string &password) const;         // new

[[nodiscard]] File save_to_memory() const;                               // new
[[nodiscard]] File save_to_memory(const std::string &password) const;    // new
```

Two decisions worth stating:

- **`save_to_memory` returns `File`, not `std::string`.** `File` is the
  library's own currency for "bytes with no path": the caller can take
  `memory_data()`, `pipe` them, or hand the result straight back to
  `DecodedFile` to reopen and check. It mirrors `File::from_memory` at the
  other end of the round trip, and costs one move.
- **It isn't spelled `save()`.** `save(const std::string &)` is already the
  path overload, so a `save(password)` returning `File` would read as "save to
  a file named *hunter2*".

One behaviour change falls out of moving the `ofstream` up: the path overloads
would now create the file before the engine got to refuse the format, so they
check `is_savable` first. Every engine's `is_savable` already agrees exactly
with whether its `save` throws, so this restores the old "an unsavable format
leaves no file" precisely, and it is the honest check anyway.

## wasm — the round trip #777 asks for

`edit(diff)` applies what the rendered page's `odr.generateDiff()` collected;
`save()` answers with the document's bytes. The stream overload means no MEMFS
detour and no second copy of the document in the heap — the `ostringstream`
*is* the buffer, and `to_uint8_array` is the one copy that has to happen.

The part the issue doesn't mention: `Session` held a `DecodedFile`, and
`html::translate(const DecodedFile &)` calls `document_file.document()`, which
**decodes a fresh tree on every call**. A `save` that opened its own `Document`
would have written the document nobody edited. So the session now owns the one
`Document` that the render, the edit and the save all go through. `decrypt`
drops it along with the service.

`isEditable()` and `isSavable()` are bound too — the issue's complaint that
`capabilities()` reports `edit: true, save: true` for a binding that could do
neither is now answerable per document rather than per format.

## The other bindings

| | edit | save | save into memory |
|---|---|---|---|
| python | already | already | `save_to_memory() -> bytes` |
| jni | already | already | `saveToMemory() -> byte[]` |
| apple | already | already | `-saveToMemoryWithError:` → `NSData` |
| wasm | **new** | **new** | **new** |

Each follows its own binding's stated convention for a stream-based API —
`bytes` in python (as `Archive.save()` already does), `byte[]` in JNI, `NSData`
in ObjC.

## Test

Everything green, all five suites run locally:

- **C++** 1258 passed. New: a flat `.fodt` built from an inline string round
  trips through `save_to_memory` (no test data, and it is the branch that
  writes xml rather than a zip), `save(ostream)` writes what `save_to_memory`
  holds, a package round trips, and an unsavable format leaves no file behind.
- **wasm** 36 passed, 5 of them new: the whole round trip in memory — render
  editable, take the `data-odr-path` out of the html the way the browser does,
  edit, re-render, save, reopen the saved bytes and see the edit; plus saving
  without a render, a non-document refusing both, and the encrypted save.
- **python** 65 passed, **JNI** 43 passed, **Swift** 22 passed, each with a new
  memory round trip.

`clang-tidy` is clean on the changed files.