### PR TITLE
docs(wasm): hand the diff to edit as generateDiff returns it

### DIFF
--- a/wasm/README.md
+++ b/wasm/README.md
@@ -65,7 +65,9 @@ Editing is a round trip through the rendered page:
 const doc = odr.open(bytes, { editable: true });
 const { html } = doc.render(0);
 // ... the reader edits the page in the iframe ...
-doc.edit(JSON.stringify(iframe.contentWindow.odr.generateDiff()));
+// `generateDiff()` returns the json already; stringifying it again is a string
+// where `edit` wants an object, and it throws.
+doc.edit(iframe.contentWindow.odr.generateDiff());
 
 const saved = doc.save();   // the document, not the html
 download(new Blob([saved]));


### PR DESCRIPTION
🤖 Generated with [Claude Code](https://claude.com/claude-code)

`odr.generateDiff()` ends in `return JSON.stringify(result)`, so the README's
`JSON.stringify` around it hands `edit` a json *string* where `html::edit`
parses an object. `json["modifiedText"]` then throws:

```
[json.exception.type_error.305] cannot use operator[] with a string argument with string
```

Checked against 6.12.0 from npm, both ways, on a document rendered with
`editable: true`:

```
double-encoded -> OdrError: [json.exception.type_error.305] cannot use operator[] with a string argument with string
as returned    -> ok
```

Found while wiring the round trip into the opendocument.app viewer, which is
where the snippet gets copied from.

No `CHANGELOG.md` entry: the binding is unchanged, only what the README claims
about calling it.