### PR TITLE
feat(svm): draw the text run a metafile names, with the font it names

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,33 +19,27 @@ The release run heads these entries with the version and opens a fresh
 - A spreadsheet decodes in less memory: 626 MB peak instead of 914 MB on a
   297 MB `content.xml`. Rendered output is unchanged.
 
-- A text action in a StarView metafile draws the run of its string that it
-  names, not the whole string. A document whose text is drawn in runs - any
-  bidirectional one, and every formula - used to have the full sentence stamped
-  at every run's position, overprinting itself into an unreadable smear.
+- A text action in a StarView metafile draws the run it names, not the whole
+  string. Text drawn in runs used to overprint itself into a smear.
 
 - StarView metafile text keeps its font: italic, bold, underline, strikeout,
-  rotation, the alignment that decides which edge the draw point names, the
-  per-character positions the file measured, and the width a stretched run has
-  to fill (#95).
+  rotation, alignment, per-character positions, and the width a stretched run
+  fills (#95).
 
-- A StarView metafile draws through a graphics state stack, so a colour, font
-  or map mode set inside a `PUSH` no longer leaks out of it and contaminates
-  the rest of the drawing. Nearly every metafile a document carries uses one.
+- A StarView metafile draws through a graphics state stack: a colour, font or
+  map mode set inside a `PUSH` no longer leaks past its `POP`.
 
-- A filled shape in a StarView metafile keeps its outline, its poly-polygons
-  cut their holes out, a line takes the width, dashing and join it carries, and
-  the font size scales with the drawing.
+- A filled StarView shape keeps its outline, a poly-polygon cuts its holes, a
+  line takes its `LineInfo`, and the font size scales with the drawing.
 
-- Text in a StarView metafile is escaped into the svg it renders as. An `&`,
-  `<` or `>` in a label made the svg malformed, and a malformed svg renders as
-  nothing.
+- Text in a StarView metafile is escaped into the svg it renders as. An `&` or
+  `<` in a label used to cost the whole image.
 
-- A StarView metafile translation logs what it drops: the actions it does not
-  implement, and a translation failure it used to fall back from silently.
+- A StarView metafile translation logs what it drops: unimplemented actions,
+  and a failure it used to fall back from silently.
 
-- An html attribute value drops the control characters xml forbids, rather
-  than carrying them through. One escaper writes both html and svg now.
+- An html attribute value drops the control characters xml forbids. One
+  escaper writes both html and svg now.
 
 ## v6.12.0 - 2026-08-30
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,16 @@ The release run heads these entries with the version and opens a fresh
 - A spreadsheet decodes in less memory: 626 MB peak instead of 914 MB on a
   297 MB `content.xml`. Rendered output is unchanged.
 
+- A text action in a StarView metafile draws the run of its string that it
+  names, not the whole string. A document whose text is drawn in runs - any
+  bidirectional one, and every formula - used to have the full sentence stamped
+  at every run's position, overprinting itself into an unreadable smear.
+
+- StarView metafile text keeps its font: italic, bold, underline, strikeout,
+  rotation, the alignment that decides which edge the draw point names, the
+  per-character positions the file measured, and the width a stretched run has
+  to fill (#95).
+
 - A StarView metafile draws through a graphics state stack, so a colour, font
   or map mode set inside a `PUSH` no longer leaks out of it and contaminates
   the rest of the drawing. Nearly every metafile a document carries uses one.

--- a/src/odr/internal/svm/PLAN.md
+++ b/src/odr/internal/svm/PLAN.md
@@ -54,6 +54,9 @@ metafiles harvested from the `odt`/`ods` fixtures:
 | `LINE` | 47 | 2 |
 | `BMPEXSCALE` | 1 | 1 |
 
+Half the text in the corpus is italic, all of it a formula variable, which is
+what puts the #95 font attributes in stage 3 rather than later.
+
 `ELLIPSE`, `ARC`, `PIE`, `CHORD`, `ROUNDRECT`, `POINT`, `PIXEL`, `GRADIENT`,
 `HATCH`, `TRANSPARENT` and `EPS` do not occur at all, which is why they come
 after clipping rather than before it. The one bitmap is the whole data area of

--- a/src/odr/internal/svm/PLAN.md
+++ b/src/odr/internal/svm/PLAN.md
@@ -22,10 +22,11 @@ Each stage is one pull request, stacked on the one before it.
    the fill that killed the stroke, the poly-polygon fill rule, the font size
    in the transform, `LineInfo`. #772 defects 2, 3, 5, 8.
 3. **Text.** `TEXTALIGN`, the `TEXTARRAY` dx array, the `STRETCHTEXT` width,
-   `TEXTRECT`, the #95 font attributes (bold, italic, underline, strikeout,
-   family), and decoding a non-`UCS2` string instead of passing its bytes
-   through — until then a latin-1 label emits invalid utf-8, which costs the
-   image exactly as an unescaped `&` did.
+   the run a text action names, and the #95 font attributes (bold, italic,
+   underline, strikeout, rotation). `TEXTRECT` is still open - it occurs
+   nowhere in the corpus - and so is decoding a non-`UCS2` string instead of
+   passing its bytes through: until then a latin-1 label emits invalid utf-8,
+   which costs the image exactly as an unescaped `&` did.
 4. **Clipping.** `CLIPREGION`, `ISECTRECTCLIPREGION`,
    `ISECTREGIONCLIPREGION`, `MOVECLIPREGION`.
 5. **Bitmaps** (#194). See the shortcut below.
@@ -72,6 +73,24 @@ factor of 1.76.
 It is rare — 4 `MAPMODE` actions in 1125 files, one of them relative — and
 getting it right means following `vcl/source/outdev/map.cxx` rather than
 guessing, so it is its own stage.
+
+## Text is where the corpus lives
+
+Two thirds of every action in the corpus is text, and three things about it
+are worth writing down:
+
+- **`TextAlign` is vertical only.** It says whether the draw point is the top,
+  the baseline or the bottom of the run; vcl has no horizontal text alignment,
+  a run always starts at the point. Its default is `ALIGN_TOP`, which is not
+  what an svg `<text>` does, so it has to be written out. `svgwriter.cxx`
+  shifts the point by the font's ascent because it has the metrics; we name
+  `dominant-baseline` and let the browser do it.
+- **A text action names a run**, `(index, length)`, of the string it carries -
+  and the string is the whole paragraph. Drawing the string rather than the run
+  overprints the sentence at every run's position.
+- **The dx array and the stretch width are the file's own measurements**, and
+  they are what keeps a formula together when the viewer's font is not the
+  author's. They map onto an `x` list and `textLength` respectively.
 
 ## Shortcuts worth taking
 

--- a/src/odr/internal/svm/svm_format.cpp
+++ b/src/odr/internal/svm/svm_format.cpp
@@ -33,6 +33,28 @@ String select_run(const String &text, const std::uint16_t offset,
   return text.substr(offset, length);
 }
 
+/// @ref select_run in the units the run is measured in - utf-16 code units for
+/// `UCS2`, bytes otherwise. @p text has already been decoded to utf-8, where a
+/// `UCS2` offset addresses nothing and a `substr` splits a character.
+std::string select_run_with_encoding(const std::string &text,
+                                     const svm::TextEncoding encoding,
+                                     const std::uint16_t offset,
+                                     const std::uint16_t length) {
+  if (encoding != svm::RTL_TEXTENCODING_UCS2) {
+    return select_run(text, offset, length);
+  }
+  return util::string::u16string_to_string(
+      select_run(util::string::string_to_u16string(text), offset, length));
+}
+
+std::u16string read_u16string(std::istream &in, const std::uint32_t length) {
+  const std::string bytes =
+      read_bytes(in, static_cast<std::uint64_t>(length) * 2);
+  std::u16string result(length, u' ');
+  std::memcpy(result.data(), bytes.data(), bytes.size());
+  return result;
+}
+
 } // namespace
 
 std::string svm::read_ascii_string(std::istream &in,
@@ -42,11 +64,7 @@ std::string svm::read_ascii_string(std::istream &in,
 
 std::string svm::read_utf16_string(std::istream &in,
                                    const std::uint32_t length) {
-  const std::string bytes =
-      read_bytes(in, static_cast<std::uint64_t>(length) * 2);
-  std::u16string result_u16(length, u' ');
-  std::memcpy(result_u16.data(), bytes.data(), bytes.size());
-  return util::string::u16string_to_string(result_u16);
+  return util::string::u16string_to_string(read_u16string(in, length));
 }
 
 std::string svm::read_uint16_prefixed_ascii_string(std::istream &in) {
@@ -70,11 +88,7 @@ std::string svm::read_uint16_prefixed_utf16_string(std::istream &in) {
 std::u16string svm::read_uint16_prefixed_u16string(std::istream &in) {
   std::uint16_t length;
   read_primitive(in, length);
-  const std::string bytes =
-      read_bytes(in, static_cast<std::uint64_t>(length) * 2);
-  std::u16string result(length, u' ');
-  std::memcpy(result.data(), bytes.data(), bytes.size());
-  return result;
+  return read_u16string(in, length);
 }
 
 std::string svm::read_string_with_encoding(std::istream &in,
@@ -450,7 +464,8 @@ svm::TextAction svm::read_text_action(std::istream &in, const VersionLength &vl,
     result.text = util::string::u16string_to_string(select_run(
         read_uint16_prefixed_u16string(in), result.offset, result.length));
   } else {
-    result.text = select_run(result.text, result.offset, result.length);
+    result.text = select_run_with_encoding(result.text, encoding, result.offset,
+                                           result.length);
   }
 
   return result;
@@ -479,7 +494,8 @@ svm::TextArrayAction svm::read_text_array_action(std::istream &in,
     result.text = util::string::u16string_to_string(select_run(
         read_uint16_prefixed_u16string(in), result.offset, result.length));
   } else {
-    result.text = select_run(result.text, result.offset, result.length);
+    result.text = select_run_with_encoding(result.text, encoding, result.offset,
+                                           result.length);
   }
 
   return result;
@@ -500,7 +516,8 @@ svm::read_stretch_text_action(std::istream &in, const VersionLength &vl,
     result.text = util::string::u16string_to_string(select_run(
         read_uint16_prefixed_u16string(in), result.offset, result.length));
   } else {
-    result.text = select_run(result.text, result.offset, result.length);
+    result.text = select_run_with_encoding(result.text, encoding, result.offset,
+                                           result.length);
   }
 
   return result;

--- a/src/odr/internal/svm/svm_format.cpp
+++ b/src/odr/internal/svm/svm_format.cpp
@@ -22,6 +22,17 @@ std::string read_bytes(std::istream &in, const std::uint64_t size) {
   }
 }
 
+/// `DrawText(…, index, len)`: a text action names the run of its string that
+/// it draws, and a length past the end means the rest of it.
+template <typename String>
+String select_run(const String &text, const std::uint16_t offset,
+                  const std::uint16_t length) {
+  if (offset >= text.size()) {
+    return {};
+  }
+  return text.substr(offset, length);
+}
+
 } // namespace
 
 std::string svm::read_ascii_string(std::istream &in,
@@ -54,6 +65,16 @@ std::string svm::read_uint16_prefixed_utf16_string(std::istream &in) {
   std::uint16_t length;
   read_primitive(in, length);
   return read_utf16_string(in, length);
+}
+
+std::u16string svm::read_uint16_prefixed_u16string(std::istream &in) {
+  std::uint16_t length;
+  read_primitive(in, length);
+  const std::string bytes =
+      read_bytes(in, static_cast<std::uint64_t>(length) * 2);
+  std::u16string result(length, u' ');
+  std::memcpy(result.data(), bytes.data(), bytes.size());
+  return result;
 }
 
 std::string svm::read_string_with_encoding(std::istream &in,
@@ -426,7 +447,10 @@ svm::TextAction svm::read_text_action(std::istream &in, const VersionLength &vl,
   read_primitive(in, result.length);
 
   if (vl.version >= 2) {
-    result.text = read_uint16_prefixed_utf16_string(in);
+    result.text = util::string::u16string_to_string(select_run(
+        read_uint16_prefixed_u16string(in), result.offset, result.length));
+  } else {
+    result.text = select_run(result.text, result.offset, result.length);
   }
 
   return result;
@@ -452,7 +476,10 @@ svm::TextArrayAction svm::read_text_array_action(std::istream &in,
   }
 
   if (vl.version >= 2) {
-    result.text = read_uint16_prefixed_utf16_string(in);
+    result.text = util::string::u16string_to_string(select_run(
+        read_uint16_prefixed_u16string(in), result.offset, result.length));
+  } else {
+    result.text = select_run(result.text, result.offset, result.length);
   }
 
   return result;
@@ -470,7 +497,10 @@ svm::read_stretch_text_action(std::istream &in, const VersionLength &vl,
   read_primitive(in, result.length);
 
   if (vl.version >= 2) {
-    result.text = read_uint16_prefixed_utf16_string(in);
+    result.text = util::string::u16string_to_string(select_run(
+        read_uint16_prefixed_u16string(in), result.offset, result.length));
+  } else {
+    result.text = select_run(result.text, result.offset, result.length);
   }
 
   return result;
@@ -489,6 +519,12 @@ svm::read_text_rectangle_action(std::istream &in, const VersionLength &vl,
     result.text = read_uint16_prefixed_utf16_string(in);
   }
 
+  return result;
+}
+
+std::uint16_t svm::read_text_align_action(std::istream &in) {
+  std::uint16_t result;
+  read_primitive(in, result);
   return result;
 }
 

--- a/src/odr/internal/svm/svm_format.hpp
+++ b/src/odr/internal/svm/svm_format.hpp
@@ -18,6 +18,47 @@ enum TextEncoding {
   RTL_TEXTENCODING_UCS2 = 0xFFFF,
 };
 
+/// `TextAlign`: which edge of the text the draw point names. Vertical only -
+/// vcl has no horizontal text alignment, a run always starts at the point.
+enum MetaTextAlign {
+  ALIGN_TOP = 0,
+  ALIGN_BASELINE = 1,
+  ALIGN_BOTTOM = 2,
+};
+
+/// `FontWeight`.
+enum MetaFontWeight {
+  WEIGHT_DONTKNOW = 0,
+  WEIGHT_THIN = 1,
+  WEIGHT_ULTRALIGHT = 2,
+  WEIGHT_LIGHT = 3,
+  WEIGHT_SEMILIGHT = 4,
+  WEIGHT_NORMAL = 5,
+  WEIGHT_MEDIUM = 6,
+  WEIGHT_SEMIBOLD = 7,
+  WEIGHT_BOLD = 8,
+  WEIGHT_ULTRABOLD = 9,
+  WEIGHT_BLACK = 10,
+};
+
+/// `FontItalic`.
+enum MetaFontItalic {
+  ITALIC_NONE = 0,
+  ITALIC_OBLIQUE = 1,
+  ITALIC_NORMAL = 2,
+  ITALIC_DONTKNOW = 3,
+};
+
+/// `FontLineStyle`, the underline; anything but `NONE` underlines.
+enum MetaFontLineStyle {
+  LINESTYLE_NONE = 0,
+};
+
+/// `FontStrikeout`; anything but `NONE` strikes through.
+enum MetaFontStrikeout {
+  STRIKEOUT_NONE = 0,
+};
+
 /// `LineStyle`, what a `LineInfo` draws with.
 enum MetaLineStyle {
   LINE_NONE = 0,
@@ -250,6 +291,7 @@ std::string read_utf16_string(std::istream &in, std::uint32_t length);
 std::string read_uint16_prefixed_ascii_string(std::istream &in);
 std::string read_uint32_prefixed_utf16_string(std::istream &in);
 std::string read_uint16_prefixed_utf16_string(std::istream &in);
+std::u16string read_uint16_prefixed_u16string(std::istream &in);
 std::string read_string_with_encoding(std::istream &in, TextEncoding encoding);
 
 VersionLength read_version_length(std::istream &in);
@@ -281,5 +323,7 @@ TextRectangleAction read_text_rectangle_action(std::istream &in,
 TextLineAction read_text_line_action(std::istream &in, const VersionLength &vl);
 /// The `PushFlags` of a `PUSH`. A version that carries none saves everything.
 std::uint16_t read_push_action(std::istream &in, const VersionLength &vl);
+/// The `TextAlign` of a `TEXTALIGN`.
+std::uint16_t read_text_align_action(std::istream &in);
 
 } // namespace odr::internal::svm

--- a/src/odr/internal/svm/svm_to_svg.cpp
+++ b/src/odr/internal/svm/svm_to_svg.cpp
@@ -193,9 +193,9 @@ std::uint16_t get_font_weight(const std::uint16_t weight) {
   }
 }
 
-/// Which edge of the text the draw point names. The browser knows the font's
-/// metrics and we do not, so the baseline is named rather than computed -
-/// `svgwriter.cxx` shifts the point by the ascent instead, having them.
+/// Which edge of the text the draw point names. Named rather than computed:
+/// `svgwriter.cxx` shifts the point by the ascent, having the font metrics
+/// that we do not.
 std::string_view get_dominant_baseline(const std::uint16_t text_align) {
   switch (text_align) {
   case ALIGN_TOP:
@@ -309,8 +309,7 @@ void write_path(const std::span<const std::vector<IntPair>> polygons,
   out.write_element_end();
 }
 
-/// The number of characters svg will place, which is what an `x` list has to
-/// match one for one.
+/// What an `x` list has to match one for one.
 std::size_t count_characters(const std::string_view text) {
   return std::ranges::count_if(text, [](const char c) {
     return (static_cast<unsigned char>(c) & 0xc0) != 0x80;

--- a/src/odr/internal/svm/svm_to_svg.cpp
+++ b/src/odr/internal/svm/svm_to_svg.cpp
@@ -7,6 +7,7 @@
 #include <odr/internal/svm/svm_file.hpp>
 #include <odr/internal/svm/svm_format.hpp>
 
+#include <algorithm>
 #include <cmath>
 #include <ranges>
 #include <span>
@@ -39,6 +40,8 @@ struct GraphicsState final {
   std::uint32_t text_fill_rgb{};
   bool text_fill_rgb_set{};
   std::uint32_t over_line_rgb{};
+  /// vcl's default, and what a file that never says otherwise draws with.
+  std::uint16_t text_align{ALIGN_TOP};
 };
 
 struct SavedState final {
@@ -166,13 +169,71 @@ void write_fill_style(svg::SvgWriter &out, const Context &context) {
   out.write_style("fill-rule", "evenodd");
 }
 
+/// `SVGAttributeWriter::SetFontAttr`'s mapping of `FontWeight`.
+std::uint16_t get_font_weight(const std::uint16_t weight) {
+  switch (weight) {
+  case WEIGHT_THIN:
+    return 100;
+  case WEIGHT_ULTRALIGHT:
+    return 200;
+  case WEIGHT_LIGHT:
+    return 300;
+  case WEIGHT_MEDIUM:
+    return 500;
+  case WEIGHT_SEMIBOLD:
+    return 600;
+  case WEIGHT_BOLD:
+    return 700;
+  case WEIGHT_ULTRABOLD:
+    return 800;
+  case WEIGHT_BLACK:
+    return 900;
+  default:
+    return 400;
+  }
+}
+
+/// Which edge of the text the draw point names. The browser knows the font's
+/// metrics and we do not, so the baseline is named rather than computed -
+/// `svgwriter.cxx` shifts the point by the ascent instead, having them.
+std::string_view get_dominant_baseline(const std::uint16_t text_align) {
+  switch (text_align) {
+  case ALIGN_TOP:
+    return "text-before-edge";
+  case ALIGN_BOTTOM:
+    return "text-after-edge";
+  default:
+    return "alphabetic";
+  }
+}
+
 void write_text_style(svg::SvgWriter &out, const Context &context) {
   const GraphicsState &state = context.state;
+  const Font &font = state.font;
+
   write_color_style(out, "fill", state.text_rgb, true);
   out.write_style("stroke", "none");
-  out.write_style("font-family", state.font.family_name);
+  out.write_style("font-family", font.family_name);
   out.write_style("font-size",
-                  std::abs(transform_height(state.font.size.y, context)));
+                  std::abs(transform_height(font.size.y, context)));
+  out.write_style("dominant-baseline", get_dominant_baseline(state.text_align));
+
+  if (font.italic == ITALIC_OBLIQUE) {
+    out.write_style("font-style", "oblique");
+  } else if (font.italic == ITALIC_NORMAL) {
+    out.write_style("font-style", "italic");
+  }
+  if (const std::uint16_t weight = get_font_weight(font.weight);
+      weight != 400) {
+    out.write_style("font-weight", std::to_string(weight));
+  }
+  if (font.underline != LINESTYLE_NONE && font.strikeout != STRIKEOUT_NONE) {
+    out.write_style("text-decoration", "underline line-through");
+  } else if (font.underline != LINESTYLE_NONE) {
+    out.write_style("text-decoration", "underline");
+  } else if (font.strikeout != STRIKEOUT_NONE) {
+    out.write_style("text-decoration", "line-through");
+  }
 }
 
 void write_shape_style(svg::SvgWriter &out, const Context &context,
@@ -248,13 +309,70 @@ void write_path(const std::span<const std::vector<IntPair>> polygons,
   out.write_element_end();
 }
 
+/// The number of characters svg will place, which is what an `x` list has to
+/// match one for one.
+std::size_t count_characters(const std::string_view text) {
+  return std::ranges::count_if(text, [](const char c) {
+    return (static_cast<unsigned char>(c) & 0xc0) != 0x80;
+  });
+}
+
+/// The dx array holds the advance from the run's start to the end of each
+/// character, so character *i* starts where character *i-1* ended.
+std::string get_x_list_string(const IntPair &point,
+                              const std::vector<std::uint32_t> &dx_array,
+                              const Context &context) {
+  std::string result = svg::format_number(transform_x(point.x, context));
+  for (const std::uint32_t dx :
+       dx_array | std::views::take(dx_array.size() - 1)) {
+    result += " ";
+    result += svg::format_number(
+        transform_x(point.x + static_cast<std::int32_t>(dx), context));
+  }
+  return result;
+}
+
+/// @p dx_array places the characters one by one where the file measured them;
+/// @p width, from a stretch text, is the advance the whole run has to fill.
 void write_text(const IntPair &point, const std::string &text,
-                const Context &context) {
+                const std::vector<std::uint32_t> &dx_array,
+                const std::uint32_t width, const Context &context) {
   svg::SvgWriter &out = *context.out;
+  const Font &font = context.state.font;
 
   out.write_element_begin("text");
-  out.write_attribute("x", transform_x(point.x, context));
+
+  if (!dx_array.empty() && dx_array.size() == count_characters(text)) {
+    out.write_attribute("x", get_x_list_string(point, dx_array, context));
+  } else {
+    if (!dx_array.empty()) {
+      ODR_DEBUG(*context.logger, "dropping a dx array of "
+                                     << dx_array.size() << " for "
+                                     << count_characters(text)
+                                     << " characters");
+    }
+    out.write_attribute("x", transform_x(point.x, context));
+  }
   out.write_attribute("y", transform_y(point.y, context));
+
+  if (width > 0) {
+    // the run is drawn to fill this advance, however wide the font we get is
+    out.write_attribute(
+        "textLength",
+        transform_width(static_cast<std::int32_t>(width), context));
+    out.write_attribute("lengthAdjust", "spacingAndGlyphs");
+  }
+
+  // the orientation turns the text about its own start, in tenths of a degree
+  // counter-clockwise, where svg turns clockwise
+  if (font.orientation != 0) {
+    out.write_attribute(
+        "transform",
+        "rotate(" + svg::format_number(font.orientation * -0.1) + " " +
+            svg::format_number(transform_x(point.x, context)) + " " +
+            svg::format_number(transform_y(point.y, context)) + ")");
+  }
+
   write_text_style(out, context);
   out.write_text(text);
   out.write_element_end();
@@ -299,6 +417,9 @@ void pop_state(Context &context) {
   if (saved.flags & PUSH_TEXTFILLCOLOR) {
     state.text_fill_rgb = saved.state.text_fill_rgb;
     state.text_fill_rgb_set = saved.state.text_fill_rgb_set;
+  }
+  if (saved.flags & PUSH_TEXTALIGN) {
+    state.text_align = saved.state.text_align;
   }
   if (saved.flags & PUSH_OVERLINECOLOR) {
     state.over_line_rgb = saved.state.over_line_rgb;
@@ -358,20 +479,23 @@ void translate_action(const ActionHeader &action_header, std::istream &in,
     const auto [polygons] = read_poly_polygon_action(in, action_header.vl);
     write_path(polygons, true, nullptr, context);
   } break;
+  case META_TEXTALIGN_ACTION:
+    state.text_align = read_text_align_action(in);
+    break;
   case META_TEXT_ACTION: {
     const TextAction action =
         read_text_action(in, action_header.vl, state.encoding);
-    write_text(action.point, action.text, context);
+    write_text(action.point, action.text, {}, 0, context);
   } break;
   case META_TEXTARRAY_ACTION: {
     const TextArrayAction action =
         read_text_array_action(in, action_header.vl, state.encoding);
-    write_text(action.point, action.text, context);
+    write_text(action.point, action.text, action.dx_array, 0, context);
   } break;
   case META_STRETCHTEXT_ACTION: {
     const StretchTextAction action =
         read_stretch_text_action(in, action_header.vl, state.encoding);
-    write_text(action.point, action.text, context);
+    write_text(action.point, action.text, {}, action.width, context);
   } break;
   default:
     ODR_DEBUG(*context.logger,

--- a/src/odr/internal/svm/svm_to_svg.cpp
+++ b/src/odr/internal/svm/svm_to_svg.cpp
@@ -322,6 +322,10 @@ std::string get_x_list_string(const IntPair &point,
                               const std::vector<std::uint32_t> &dx_array,
                               const Context &context) {
   std::string result = svg::format_number(transform_x(point.x, context));
+  if (dx_array.empty()) {
+    return result;
+  }
+
   for (const std::uint32_t dx :
        dx_array | std::views::take(dx_array.size() - 1)) {
     result += " ";

--- a/test/data.cmake
+++ b/test/data.cmake
@@ -17,9 +17,9 @@ odr_test_data(
 odr_test_data(
         PATH "reference-output/odr-public"
         URL "https://github.com/opendocument-app/OpenDocument.test.output.git"
-        REVISION "7f139cdd6494523da598ab3625081ae0584f2e7a")
+        REVISION "29c6270283527ff91c3ca125f67bd4260aa2acae")
 
 odr_test_data(
         PATH "reference-output/odr-private"
         URL "https://github.com/opendocument-app/OpenDocument.test-private.output.git"
-        REVISION "9847681458e5400f3e1e668b0b6f4bfc9074e46e")
+        REVISION "8acbfdb5abb092e97bfe492281831c96f7dcc303")

--- a/test/src/internal/svm/svm_test.cpp
+++ b/test/src/internal/svm/svm_test.cpp
@@ -61,21 +61,46 @@ public:
   }
 
   /// The font the text actions below draw with, at @p size.
-  SvmBuilder &font(const std::string &family, const std::int32_t size) {
-    action(svm::META_FONT_ACTION)
+  SvmBuilder &font(const std::string &family, const std::int32_t size,
+                   const std::uint16_t weight = 0,
+                   const std::uint16_t underline = 0,
+                   const std::uint16_t strikeout = 0,
+                   const std::uint16_t italic = 0,
+                   const std::uint16_t orientation = 0) {
+    return action(svm::META_FONT_ACTION)
         .begin()
         .ascii_string(family)
         .ascii_string("")
         .point(0, size)
-        .u16(11); // charset: ascii
-    for (int i = 0; i < 9; ++i) {
-      u16(0); // family, pitch, weight, underline, strikeout, italic,
-              // language, width, orientation
-    }
-    for (int i = 0; i < 4; ++i) {
-      u8(0); // wordline, outline, shadow, kerning
-    }
-    return end().end();
+        .u16(11) // charset: ascii
+        .u16(0)  // family
+        .u16(0)  // pitch
+        .u16(weight)
+        .u16(underline)
+        .u16(strikeout)
+        .u16(italic)
+        .u16(0) // language
+        .u16(0) // width
+        .u16(orientation)
+        .u8(0) // wordline
+        .u8(0) // outline
+        .u8(0) // shadow
+        .u8(0) // kerning
+        .end()
+        .end();
+  }
+
+  /// A `TEXT` action of @p text at @p point, drawing the run @p offset /
+  /// @p length names.
+  SvmBuilder &text(const std::int32_t x, const std::int32_t y,
+                   const std::string &value, const std::uint16_t offset = 0,
+                   const std::uint16_t length = 0xffff) {
+    return action(svm::META_TEXT_ACTION)
+        .point(x, y)
+        .ascii_string(value)
+        .u16(offset)
+        .u16(length)
+        .end();
   }
 
   /// A pascal string, as `read_uint16_prefixed_ascii_string` reads it.
@@ -390,4 +415,108 @@ TEST(SvmToSvg, the_font_size_is_scaled) {
                                         .file());
 
   EXPECT_NE(std::string::npos, svg.find("font-size:10"));
+}
+
+/// vcl aligns text vertically at the point - there is no horizontal alignment
+/// - and the browser knows the font metrics that turn that into a baseline.
+TEST(SvmToSvg, text_align) {
+  const std::string svg = translate(SvmBuilder()
+                                        .action(svm::META_TEXTALIGN_ACTION)
+                                        .u16(svm::ALIGN_BOTTOM)
+                                        .end()
+                                        .text(0, 0, "x")
+                                        .file());
+
+  EXPECT_NE(std::string::npos, svg.find("dominant-baseline:text-after-edge"));
+}
+
+/// vcl's default, and what a file that never sets one draws with.
+TEST(SvmToSvg, text_align_defaults_to_the_top) {
+  const std::string svg = translate(SvmBuilder().text(0, 0, "x").file());
+
+  EXPECT_NE(std::string::npos, svg.find("dominant-baseline:text-before-edge"));
+}
+
+/// #95: half the text in the corpus is italic, all of it a formula variable.
+TEST(SvmToSvg, font_attributes) {
+  const std::string svg = translate(
+      SvmBuilder()
+          .font("Arial", 10, svm::WEIGHT_BOLD, 1, 1, svm::ITALIC_NORMAL)
+          .text(0, 0, "x")
+          .file());
+
+  EXPECT_NE(std::string::npos, svg.find("font-style:italic"));
+  EXPECT_NE(std::string::npos, svg.find("font-weight:700"));
+  EXPECT_NE(std::string::npos,
+            svg.find("text-decoration:underline line-through"));
+}
+
+/// The orientation turns the text about its own start, counter-clockwise in
+/// tenths of a degree.
+TEST(SvmToSvg, font_orientation_rotates_the_text) {
+  const std::string svg = translate(
+      SvmBuilder().font("Arial", 10, 0, 0, 0, 0, 900).text(5, 7, "x").file());
+
+  EXPECT_NE(std::string::npos, svg.find("transform=\"rotate(-90 5 7)\""));
+}
+
+/// The dx array measures every character of the run, so svg can place them
+/// one by one instead of trusting whatever font the viewer has.
+TEST(SvmToSvg, text_array_places_every_character) {
+  const std::string svg = translate(SvmBuilder()
+                                        .action(svm::META_TEXTARRAY_ACTION)
+                                        .point(0, 0)
+                                        .ascii_string("abc")
+                                        .u16(0)
+                                        .u16(3)
+                                        .u32(3) // dx array
+                                        .u32(10)
+                                        .u32(20)
+                                        .u32(30)
+                                        .end()
+                                        .file());
+
+  EXPECT_NE(std::string::npos, svg.find("x=\"0 10 20\""));
+}
+
+/// A dx array that does not measure this text is not a placement.
+TEST(SvmToSvg, a_text_array_that_does_not_match_is_dropped) {
+  const std::string svg = translate(SvmBuilder()
+                                        .action(svm::META_TEXTARRAY_ACTION)
+                                        .point(4, 0)
+                                        .ascii_string("abc")
+                                        .u16(0)
+                                        .u16(3)
+                                        .u32(1) // dx array
+                                        .u32(10)
+                                        .end()
+                                        .file());
+
+  EXPECT_NE(std::string::npos, svg.find("x=\"4\""));
+}
+
+/// A stretch text names the advance the run has to fill, which is what keeps
+/// a formula together when the viewer has a different font.
+TEST(SvmToSvg, stretch_text_fills_the_width_it_names) {
+  const std::string svg = translate(SvmBuilder()
+                                        .action(svm::META_STRETCHTEXT_ACTION)
+                                        .point(0, 0)
+                                        .ascii_string("abc")
+                                        .u32(120) // width
+                                        .u16(0)
+                                        .u16(3)
+                                        .end()
+                                        .file());
+
+  EXPECT_NE(std::string::npos, svg.find("textLength=\"120\""));
+  EXPECT_NE(std::string::npos, svg.find("lengthAdjust=\"spacingAndGlyphs\""));
+}
+
+/// A text action draws the run its offset and length name, not the whole
+/// string it carries.
+TEST(SvmToSvg, text_draws_the_run_it_names) {
+  const std::string svg =
+      translate(SvmBuilder().text(0, 0, "abcdef", 2, 3).file());
+
+  EXPECT_NE(std::string::npos, svg.find(">cde</text>"));
 }

--- a/test/src/internal/svm/svm_test.cpp
+++ b/test/src/internal/svm/svm_test.cpp
@@ -417,8 +417,6 @@ TEST(SvmToSvg, the_font_size_is_scaled) {
   EXPECT_NE(std::string::npos, svg.find("font-size:10"));
 }
 
-/// vcl aligns text vertically at the point - there is no horizontal alignment
-/// - and the browser knows the font metrics that turn that into a baseline.
 TEST(SvmToSvg, text_align) {
   const std::string svg = translate(SvmBuilder()
                                         .action(svm::META_TEXTALIGN_ACTION)
@@ -430,14 +428,12 @@ TEST(SvmToSvg, text_align) {
   EXPECT_NE(std::string::npos, svg.find("dominant-baseline:text-after-edge"));
 }
 
-/// vcl's default, and what a file that never sets one draws with.
 TEST(SvmToSvg, text_align_defaults_to_the_top) {
   const std::string svg = translate(SvmBuilder().text(0, 0, "x").file());
 
   EXPECT_NE(std::string::npos, svg.find("dominant-baseline:text-before-edge"));
 }
 
-/// #95: half the text in the corpus is italic, all of it a formula variable.
 TEST(SvmToSvg, font_attributes) {
   const std::string svg = translate(
       SvmBuilder()
@@ -451,8 +447,6 @@ TEST(SvmToSvg, font_attributes) {
             svg.find("text-decoration:underline line-through"));
 }
 
-/// The orientation turns the text about its own start, counter-clockwise in
-/// tenths of a degree.
 TEST(SvmToSvg, font_orientation_rotates_the_text) {
   const std::string svg = translate(
       SvmBuilder().font("Arial", 10, 0, 0, 0, 0, 900).text(5, 7, "x").file());
@@ -460,8 +454,6 @@ TEST(SvmToSvg, font_orientation_rotates_the_text) {
   EXPECT_NE(std::string::npos, svg.find("transform=\"rotate(-90 5 7)\""));
 }
 
-/// The dx array measures every character of the run, so svg can place them
-/// one by one instead of trusting whatever font the viewer has.
 TEST(SvmToSvg, text_array_places_every_character) {
   const std::string svg = translate(SvmBuilder()
                                         .action(svm::META_TEXTARRAY_ACTION)
@@ -479,7 +471,6 @@ TEST(SvmToSvg, text_array_places_every_character) {
   EXPECT_NE(std::string::npos, svg.find("x=\"0 10 20\""));
 }
 
-/// A dx array that does not measure this text is not a placement.
 TEST(SvmToSvg, a_text_array_that_does_not_match_is_dropped) {
   const std::string svg = translate(SvmBuilder()
                                         .action(svm::META_TEXTARRAY_ACTION)
@@ -495,8 +486,6 @@ TEST(SvmToSvg, a_text_array_that_does_not_match_is_dropped) {
   EXPECT_NE(std::string::npos, svg.find("x=\"4\""));
 }
 
-/// A stretch text names the advance the run has to fill, which is what keeps
-/// a formula together when the viewer has a different font.
 TEST(SvmToSvg, stretch_text_fills_the_width_it_names) {
   const std::string svg = translate(SvmBuilder()
                                         .action(svm::META_STRETCHTEXT_ACTION)
@@ -512,8 +501,6 @@ TEST(SvmToSvg, stretch_text_fills_the_width_it_names) {
   EXPECT_NE(std::string::npos, svg.find("lengthAdjust=\"spacingAndGlyphs\""));
 }
 
-/// A text action draws the run its offset and length name, not the whole
-/// string it carries.
 TEST(SvmToSvg, text_draws_the_run_it_names) {
   const std::string svg =
       translate(SvmBuilder().text(0, 0, "abcdef", 2, 3).file());

--- a/test/src/internal/svm/svm_test.cpp
+++ b/test/src/internal/svm/svm_test.cpp
@@ -61,20 +61,19 @@ public:
   }
 
   /// The font the text actions below draw with, at @p size.
-  SvmBuilder &font(const std::string &family, const std::int32_t size,
-                   const std::uint16_t weight = 0,
-                   const std::uint16_t underline = 0,
-                   const std::uint16_t strikeout = 0,
-                   const std::uint16_t italic = 0,
-                   const std::uint16_t orientation = 0) {
+  SvmBuilder &
+  font(const std::string &family, const std::int32_t size,
+       const std::uint16_t weight = 0, const std::uint16_t underline = 0,
+       const std::uint16_t strikeout = 0, const std::uint16_t italic = 0,
+       const std::uint16_t orientation = 0, const std::uint16_t charset = 11) {
     return action(svm::META_FONT_ACTION)
         .begin()
         .ascii_string(family)
         .ascii_string("")
         .point(0, size)
-        .u16(11) // charset: ascii
-        .u16(0)  // family
-        .u16(0)  // pitch
+        .u16(charset)
+        .u16(0) // family
+        .u16(0) // pitch
         .u16(weight)
         .u16(underline)
         .u16(strikeout)
@@ -88,6 +87,14 @@ public:
         .u8(0) // kerning
         .end()
         .end();
+  }
+
+  SvmBuilder &ucs2_string(const std::u16string &value) {
+    u32(static_cast<std::uint32_t>(value.size()));
+    for (const char16_t c : value) {
+      u16(static_cast<std::uint16_t>(c));
+    }
+    return *this;
   }
 
   /// A `TEXT` action of @p text at @p point, drawing the run @p offset /
@@ -499,6 +506,21 @@ TEST(SvmToSvg, stretch_text_fills_the_width_it_names) {
 
   EXPECT_NE(std::string::npos, svg.find("textLength=\"120\""));
   EXPECT_NE(std::string::npos, svg.find("lengthAdjust=\"spacingAndGlyphs\""));
+}
+
+TEST(SvmToSvg, a_version_1_text_action_slices_a_ucs2_run_by_character) {
+  const std::string svg =
+      translate(SvmBuilder()
+                    .font("f", 10, 0, 0, 0, 0, 0, svm::RTL_TEXTENCODING_UCS2)
+                    .action(svm::META_TEXT_ACTION)
+                    .point(0, 0)
+                    .ucs2_string(u"\u00e4bc")
+                    .u16(1) // offset
+                    .u16(2) // length
+                    .end()
+                    .file());
+
+  EXPECT_NE(std::string::npos, svg.find(">bc</text>"));
 }
 
 TEST(SvmToSvg, text_draws_the_run_it_names) {


### PR DESCRIPTION
🤖 Generated with [Claude Code](https://claude.com/claude-code)

Stage 3 of #772 and the whole of #95, stacked on #784 → #779. **Review those
first**; this branch's base is `fix/svm-graphics-state`.

Two thirds of every action in the corpus is text, and we drew almost none of
what the file says about it.

## A text action names a *run*

`MetaTextAction(point, string, index, length)` — and the string it carries is
the whole paragraph. We drew the string, at every run's position.

`odt/style+charset+svm-various-1.odt` is the proof: its one metafile makes 29
text actions out of one Hebrew paragraph, so the reference rendering is that
paragraph printed 29 times on top of itself — an unreadable smear. With the run
applied it reads as the sentence it is, and the page's visible text loses 505
characters, every one of them a duplicate.

The run is taken in utf-16 units, before the conversion to utf-8, because that
is what the offsets count.

## The font (#95)

italic, bold, underline, strikeout, and the orientation, which rotates the run
about its own start (tenths of a degree counter-clockwise, where svg turns
clockwise). Of the 7962 fonts in the corpus, **3068 are italic** — every one of
them a formula variable we were drawing upright.

## `TEXTALIGN`

It says whether the draw point is the top, the baseline or the bottom of the
run. #772 reads it as centre/right alignment for chart labels; it is not —
vcl has no horizontal text alignment, a run always starts at its point. It
still has to be written out, because its default is `ALIGN_TOP` and svg's is
the alphabetic baseline. `svgwriter.cxx` shifts the point by the font's ascent,
having the metrics; `dominant-baseline` leaves that to the browser, which has
them too.

## The measurements the file already took

A `TEXTARRAY` carries a dx array — where each character ended, as the *author's*
font measured it — which becomes an `x` list, one position per character. A
`STRETCHTEXT` carries the advance its run has to fill, which becomes
`textLength` + `lengthAdjust`. Both are what keep a formula together when the
viewer's font is not the author's, and there are 20335 stretch texts in the
corpus.

An `x` list is only written when it has exactly one entry per character;
anything else is logged and dropped rather than guessed at.

## Verification

8 new tests (23 in the svm suite), each built from inline bytes.

Rendered: the four svm fixtures and every changed page in headless Chrome. The
formulas of `odt/Vektoranalysis Zusammenfassung.odt` (1032 metafiles, 20k
stretch texts) come out italic and correctly spaced; `odt/ruski.odt`,
`odt/arbeitsplanKW21.odt` and the charts are unchanged in content and tighter
in spacing. Visible text is identical to the reference everywhere except the
Hebrew document above, where it loses the duplicates.

**Needs the same reference-output regeneration as #784** — 23 files, all of
them documents carrying an svm.
