### PR TITLE
feat(svm): clip the drawing to what the metafile clips it to

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,10 @@ The release run heads these entries with the version and opens a fresh
 - A spreadsheet decodes in less memory: 626 MB peak instead of 914 MB on a
   297 MB `content.xml`. Rendered output is unchanged.
 
+- A StarView metafile clips what it says it clips: `CLIPREGION` and the two
+  that intersect one into it. A drawing that ran outside the clip used to be
+  shown in full.
+
 - A StarView metafile draws its bitmaps (#194): `BMP`, `BMPEX` and their
   scaling and part variants, transparency mask included. Such a chart used to
   render as an empty frame.

--- a/src/odr/internal/svm/PLAN.md
+++ b/src/odr/internal/svm/PLAN.md
@@ -27,8 +27,8 @@ Each stage is one pull request, stacked on the one before it.
    nowhere in the corpus - and so is decoding a non-`UCS2` string instead of
    passing its bytes through: until then a latin-1 label emits invalid utf-8,
    which costs the image exactly as an unescaped `&` did.
-4. **Clipping.** `CLIPREGION`, `ISECTRECTCLIPREGION`,
-   `ISECTREGIONCLIPREGION`, `MOVECLIPREGION`.
+4. **Clipping** - done but for `MOVECLIPREGION`, which occurs nowhere and
+   would have to move path data that is already written out.
 5. **Bitmaps** (#194) - done for the `BMP` and `BMPEX` families; `MASK`,
    which stencils one colour through a bitmap, and `ZCOMPRESS`, which needs
    inflating first, are still open. See the shortcut below.
@@ -78,6 +78,25 @@ factor of 1.76.
 It is rare — 4 `MAPMODE` actions in 1125 files, one of them relative — and
 getting it right means following `vcl/source/outdev/map.cxx` rather than
 guessing, so it is its own stage.
+
+## Clipping is nested groups
+
+An svg `clip-path` names one shape, and `ISECT…` intersects. Two clips
+therefore become two groups, one inside the other, and the state's clip is a
+*stack* of shapes rather than one: `ensure_clip` keeps the groups that the
+next drawing action still wants, closes the ones it does not, and opens what
+is missing. A `POP` that restores the clip is then nothing special - the next
+action closes what it has to.
+
+A region streams as a band list, which is a union of rectangles, and from
+version 2 also as the poly-polygon those were rasterised from. The polygons
+are the better outline where they are there. Both go into one `<path>` -
+disjoint bands make union and even-odd the same thing, and a poly-polygon
+wants even-odd anyway, so `clip-rule="evenodd"` covers both.
+
+vcl does *not* re-scale a clip when the map mode changes (`SetMapMode`:
+"clip regions are not re-scaled"), so the shape is transformed once, when the
+action sets it.
 
 ## Text is where the corpus lives
 

--- a/src/odr/internal/svm/svm_format.cpp
+++ b/src/odr/internal/svm/svm_format.cpp
@@ -10,6 +10,7 @@
 #include <cstdint>
 #include <cstring>
 #include <stdexcept>
+#include <utility>
 
 namespace odr::internal {
 
@@ -22,6 +23,14 @@ std::string read_bytes(std::istream &in, const std::uint64_t size) {
     throw MalformedSvmFile();
   }
 }
+
+/// `RegionType`, what shape the region was streamed as.
+constexpr std::uint16_t region_null = 0;
+constexpr std::uint16_t region_empty = 1;
+/// `StreamEntryType`, what the band list holds.
+constexpr std::uint16_t band_header = 0;
+constexpr std::uint16_t band_separation = 1;
+constexpr std::uint16_t band_end = 2;
 
 /// A `.bmp` starts with `"BM"`; `"BA"`, an os/2 bitmap array, does not.
 constexpr std::uint16_t bmp_magic = 0x4d42;
@@ -775,6 +784,67 @@ svm::BitmapAction svm::read_bitmap_action(std::istream &in,
   }
 
   return result;
+}
+
+svm::Region svm::read_region(std::istream &in) {
+  Region result;
+
+  const VersionLength vl = read_version_length(in);
+  std::uint16_t content_version{};
+  std::uint16_t type{};
+  read_primitive(in, content_version);
+  read_primitive(in, type);
+
+  if (type == region_null) {
+    result.null = true;
+    return result;
+  }
+  if (type == region_empty) {
+    return result;
+  }
+
+  // the bands: a run of horizontal strips, each with the spans that are in
+  // the region, and together the union that covers it
+  std::int32_t top{};
+  std::int32_t bottom{};
+  while (true) {
+    std::uint16_t entry{};
+    read_primitive(in, entry);
+    if (entry == band_end) {
+      break;
+    }
+
+    std::int32_t first{};
+    std::int32_t second{};
+    read_primitive(in, first);
+    read_primitive(in, second);
+
+    if (entry == band_header) {
+      top = first;
+      bottom = second;
+    } else if (entry == band_separation) {
+      result.rectangles.push_back({first, top, second, bottom});
+    } else {
+      throw MalformedSvmFile();
+    }
+  }
+
+  if (vl.version >= 2) {
+    bool has_polygons{};
+    read_primitive(in, has_polygons);
+    if (has_polygons) {
+      result.polygons = read_poly_polygon(in);
+    }
+  }
+
+  return result;
+}
+
+std::pair<svm::Region, bool> svm::read_clip_region_action(std::istream &in) {
+  Region region = read_region(in);
+  bool clip{};
+  read_primitive(in, clip);
+  return {std::move(region), clip};
 }
 
 std::uint16_t svm::read_text_align_action(std::istream &in) {

--- a/src/odr/internal/svm/svm_format.cpp
+++ b/src/odr/internal/svm/svm_format.cpp
@@ -803,8 +803,7 @@ svm::Region svm::read_region(std::istream &in) {
     return result;
   }
 
-  // the bands: a run of horizontal strips, each with the spans that are in
-  // the region, and together the union that covers it
+  // horizontal strips, each with the spans inside the region
   std::int32_t top{};
   std::int32_t bottom{};
   while (true) {

--- a/src/odr/internal/svm/svm_format.cpp
+++ b/src/odr/internal/svm/svm_format.cpp
@@ -9,6 +9,7 @@
 #include <array>
 #include <cstdint>
 #include <cstring>
+#include <optional>
 #include <stdexcept>
 #include <utility>
 
@@ -786,9 +787,7 @@ svm::BitmapAction svm::read_bitmap_action(std::istream &in,
   return result;
 }
 
-svm::Region svm::read_region(std::istream &in) {
-  Region result;
-
+std::optional<svm::Region> svm::read_region(std::istream &in) {
   const VersionLength vl = read_version_length(in);
   std::uint16_t content_version{};
   std::uint16_t type{};
@@ -796,9 +795,10 @@ svm::Region svm::read_region(std::istream &in) {
   read_primitive(in, type);
 
   if (type == region_null) {
-    result.null = true;
-    return result;
+    return std::nullopt;
   }
+
+  Region result;
   if (type == region_empty) {
     return result;
   }
@@ -839,8 +839,9 @@ svm::Region svm::read_region(std::istream &in) {
   return result;
 }
 
-std::pair<svm::Region, bool> svm::read_clip_region_action(std::istream &in) {
-  Region region = read_region(in);
+std::pair<std::optional<svm::Region>, bool>
+svm::read_clip_region_action(std::istream &in) {
+  std::optional<Region> region = read_region(in);
   bool clip{};
   read_primitive(in, clip);
   return {std::move(region), clip};

--- a/src/odr/internal/svm/svm_format.hpp
+++ b/src/odr/internal/svm/svm_format.hpp
@@ -268,9 +268,8 @@ struct TextRectangleAction final {
   std::uint16_t style{};
 };
 
-/// A clip region. Its bands cover it as a union of rectangles; where the
-/// file also kept the shape those were rasterised from, @ref polygons is it
-/// and is the better outline.
+/// A clip region: bands covering it as a union of rectangles, and from
+/// version 2 the poly-polygon those were rasterised from.
 struct Region final {
   /// `REGION_NULL`: no clipping at all, as against a region that covers
   /// nothing and clips everything away.

--- a/src/odr/internal/svm/svm_format.hpp
+++ b/src/odr/internal/svm/svm_format.hpp
@@ -4,6 +4,7 @@
 
 #include <cstdint>
 #include <istream>
+#include <optional>
 #include <string>
 #include <string_view>
 #include <utility>
@@ -269,11 +270,10 @@ struct TextRectangleAction final {
 };
 
 /// A clip region: bands covering it as a union of rectangles, and from
-/// version 2 the poly-polygon those were rasterised from.
+/// version 2 the poly-polygon those were rasterised from. An *empty* region
+/// covers nothing and so clips everything away; `REGION_NULL`, which does not
+/// clip at all, is no region and reads as `std::nullopt`.
 struct Region final {
-  /// `REGION_NULL`: no clipping at all, as against a region that covers
-  /// nothing and clips everything away.
-  bool null{};
   std::vector<Rectangle> rectangles;
   std::vector<std::vector<IntPair>> polygons;
 };
@@ -366,10 +366,11 @@ std::uint16_t read_push_action(std::istream &in, const VersionLength &vl);
 /// The `TextAlign` of a `TEXTALIGN`.
 std::uint16_t read_text_align_action(std::istream &in);
 /// A region, as `ReadRegion` reads one: a band list, and from version 2 the
-/// poly-polygon it came from.
-Region read_region(std::istream &in);
+/// poly-polygon it came from. `std::nullopt` where it does not clip at all.
+std::optional<Region> read_region(std::istream &in);
 /// A `CLIPREGION`: the region, and whether it clips at all.
-std::pair<Region, bool> read_clip_region_action(std::istream &in);
+std::pair<std::optional<Region>, bool>
+read_clip_region_action(std::istream &in);
 /// A dib with its file header, as `ReadDIB(…, bFileHeader=true)` reads one.
 /// @p limit is what the enclosing action declared, so a length field cannot
 /// ask for more than the file holds.

--- a/src/odr/internal/svm/svm_format.hpp
+++ b/src/odr/internal/svm/svm_format.hpp
@@ -6,6 +6,7 @@
 #include <istream>
 #include <string>
 #include <string_view>
+#include <utility>
 #include <vector>
 
 // https://github.com/LibreOffice/core/blob/master/include/vcl/metaact.hxx
@@ -267,6 +268,17 @@ struct TextRectangleAction final {
   std::uint16_t style{};
 };
 
+/// A clip region. Its bands cover it as a union of rectangles; where the
+/// file also kept the shape those were rasterised from, @ref polygons is it
+/// and is the better outline.
+struct Region final {
+  /// `REGION_NULL`: no clipping at all, as against a region that covers
+  /// nothing and clips everything away.
+  bool null{};
+  std::vector<Rectangle> rectangles;
+  std::vector<std::vector<IntPair>> polygons;
+};
+
 /// A dib as something a browser reads. A metafile stores a dib *with* its
 /// `BITMAPFILEHEADER`, so its bytes already are a `.bmp` file; they are only
 /// unpacked where a png would be smaller, which for a chart is by fifty.
@@ -354,6 +366,11 @@ TextLineAction read_text_line_action(std::istream &in, const VersionLength &vl);
 std::uint16_t read_push_action(std::istream &in, const VersionLength &vl);
 /// The `TextAlign` of a `TEXTALIGN`.
 std::uint16_t read_text_align_action(std::istream &in);
+/// A region, as `ReadRegion` reads one: a band list, and from version 2 the
+/// poly-polygon it came from.
+Region read_region(std::istream &in);
+/// A `CLIPREGION`: the region, and whether it clips at all.
+std::pair<Region, bool> read_clip_region_action(std::istream &in);
 /// A dib with its file header, as `ReadDIB(…, bFileHeader=true)` reads one.
 /// @p limit is what the enclosing action declared, so a length field cannot
 /// ask for more than the file holds.

--- a/src/odr/internal/svm/svm_to_svg.cpp
+++ b/src/odr/internal/svm/svm_to_svg.cpp
@@ -309,7 +309,6 @@ get_path_data_string(const std::span<const std::vector<IntPair>> polygons,
   return result;
 }
 
-/// The rectangle as the four points that outline it.
 std::vector<IntPair> get_rectangle_polygon(const Rectangle &rect) {
   return {{rect.left, rect.top},
           {rect.right, rect.top},
@@ -332,9 +331,8 @@ std::string get_region_path_data(const Region &region, const Context &context) {
   return get_path_data_string(polygons, true, context);
 }
 
-/// Intersecting a clip with the shape it already has is a group that clips
-/// nothing, and a file does that: it sets the drawing area, then intersects
-/// the region of the same rectangle.
+/// A file that sets the drawing area and then intersects the same rectangle
+/// asks for a group that clips nothing; that one is dropped.
 void intersect_clip(std::string path_data, GraphicsState &state) {
   if (!state.clip.empty() && state.clip.back() == path_data) {
     return;
@@ -342,9 +340,8 @@ void intersect_clip(std::string path_data, GraphicsState &state) {
   state.clip.push_back(std::move(path_data));
 }
 
-/// Opens the groups the state's clip asks for and closes the ones it no
-/// longer does, keeping what the two have in common. Every drawing action
-/// goes through here first, so what it writes lands inside them.
+/// Reconciles the open groups with the state's clip, keeping the prefix they
+/// share. Every drawing action goes through here first.
 void ensure_clip(Context &context) {
   svg::SvgWriter &out = *context.out;
   const std::vector<std::string> &clip = context.state.clip;
@@ -368,7 +365,8 @@ void ensure_clip(Context &context) {
     out.write_attribute("id", id);
     out.write_element_begin("path");
     out.write_attribute("d", clip[i]);
-    // sub-polygons of one region are its holes, as they are in a shape
+    // holes, where the region kept the shape it was rasterised from; its
+    // bands never overlap, so they union under the same rule
     out.write_attribute("clip-rule", "evenodd");
     out.write_element_end();
     out.write_element_end();
@@ -725,9 +723,8 @@ void translate_action(const ActionHeader &action_header, std::istream &in,
   } break;
   case META_ISECTRECTCLIPREGION_ACTION: {
     const Rectangle action = read_rectangle(in);
-    intersect_clip(
-        get_path_data_string({get_rectangle_polygon(action)}, true, context),
-        state);
+    const std::vector<IntPair> polygon = get_rectangle_polygon(action);
+    intersect_clip(get_path_data_string({&polygon, 1}, true, context), state);
   } break;
   case META_ISECTREGIONCLIPREGION_ACTION: {
     const Region region = read_region(in);

--- a/src/odr/internal/svm/svm_to_svg.cpp
+++ b/src/odr/internal/svm/svm_to_svg.cpp
@@ -43,6 +43,9 @@ struct GraphicsState final {
   std::uint32_t over_line_rgb{};
   /// vcl's default, and what a file that never says otherwise draws with.
   std::uint16_t text_align{ALIGN_TOP};
+  /// What the drawing is clipped to, as path data, one entry per region the
+  /// file intersected in. Nesting a group per entry is what intersects them.
+  std::vector<std::string> clip;
 };
 
 struct SavedState final {
@@ -61,6 +64,10 @@ struct Context final {
   /// Names the masks and clip paths apart.
   std::uint32_t element_count{};
   bool inverter_written{};
+
+  /// The clip the open groups already apply - a prefix of the state's clip
+  /// once @ref ensure_clip has run.
+  std::vector<std::string> written_clip;
 };
 
 double scale(const IntPair fraction) {
@@ -300,6 +307,76 @@ get_path_data_string(const std::span<const std::vector<IntPair>> polygons,
   }
 
   return result;
+}
+
+/// The rectangle as the four points that outline it.
+std::vector<IntPair> get_rectangle_polygon(const Rectangle &rect) {
+  return {{rect.left, rect.top},
+          {rect.right, rect.top},
+          {rect.right, rect.bottom},
+          {rect.left, rect.bottom}};
+}
+
+/// The region's outline: the shape it came from where the file kept one, and
+/// the union its bands cover where it did not.
+std::string get_region_path_data(const Region &region, const Context &context) {
+  if (!region.polygons.empty()) {
+    return get_path_data_string(region.polygons, true, context);
+  }
+
+  std::vector<std::vector<IntPair>> polygons;
+  polygons.reserve(region.rectangles.size());
+  for (const Rectangle &rect : region.rectangles) {
+    polygons.push_back(get_rectangle_polygon(rect));
+  }
+  return get_path_data_string(polygons, true, context);
+}
+
+/// Intersecting a clip with the shape it already has is a group that clips
+/// nothing, and a file does that: it sets the drawing area, then intersects
+/// the region of the same rectangle.
+void intersect_clip(std::string path_data, GraphicsState &state) {
+  if (!state.clip.empty() && state.clip.back() == path_data) {
+    return;
+  }
+  state.clip.push_back(std::move(path_data));
+}
+
+/// Opens the groups the state's clip asks for and closes the ones it no
+/// longer does, keeping what the two have in common. Every drawing action
+/// goes through here first, so what it writes lands inside them.
+void ensure_clip(Context &context) {
+  svg::SvgWriter &out = *context.out;
+  const std::vector<std::string> &clip = context.state.clip;
+
+  std::size_t common = 0;
+  while (common < context.written_clip.size() && common < clip.size() &&
+         context.written_clip[common] == clip[common]) {
+    ++common;
+  }
+
+  while (context.written_clip.size() > common) {
+    out.write_element_end();
+    context.written_clip.pop_back();
+  }
+
+  for (std::size_t i = common; i < clip.size(); ++i) {
+    const std::string id =
+        "odr-clip-" + std::to_string(++context.element_count);
+
+    out.write_element_begin("clipPath");
+    out.write_attribute("id", id);
+    out.write_element_begin("path");
+    out.write_attribute("d", clip[i]);
+    // sub-polygons of one region are its holes, as they are in a shape
+    out.write_attribute("clip-rule", "evenodd");
+    out.write_element_end();
+    out.write_element_end();
+
+    out.write_element_begin("g");
+    out.write_attribute("clip-path", "url(#" + id + ")");
+    context.written_clip.push_back(clip[i]);
+  }
 }
 
 /// One path for all of them: the fill rule only cuts holes within a path.
@@ -560,6 +637,9 @@ void pop_state(Context &context) {
     state.text_fill_rgb = saved.state.text_fill_rgb;
     state.text_fill_rgb_set = saved.state.text_fill_rgb_set;
   }
+  if (saved.flags & PUSH_CLIPREGION) {
+    state.clip = saved.state.clip;
+  }
   if (saved.flags & PUSH_TEXTALIGN) {
     state.text_align = saved.state.text_align;
   }
@@ -606,19 +686,23 @@ void translate_action(const ActionHeader &action_header, std::istream &in,
     break;
   case META_RECT_ACTION: {
     const Rectangle action = read_rectangle(in);
+    ensure_clip(context);
     write_rectangle(action, context);
   } break;
   case META_POLYLINE_ACTION: {
     const auto [points, line_info] =
         read_poly_line_action(in, action_header.vl);
+    ensure_clip(context);
     write_path({&points, 1}, false, &line_info, context);
   } break;
   case META_POLYGON_ACTION: {
     const auto [points] = read_polygon_action(in, action_header.vl);
+    ensure_clip(context);
     write_path({&points, 1}, true, nullptr, context);
   } break;
   case META_POLYPOLYGON_ACTION: {
     const auto [polygons] = read_poly_polygon_action(in, action_header.vl);
+    ensure_clip(context);
     write_path(polygons, true, nullptr, context);
   } break;
   case META_BMP_ACTION:
@@ -629,7 +713,27 @@ void translate_action(const ActionHeader &action_header, std::istream &in,
   case META_BMPEXSCALEPART_ACTION: {
     const BitmapAction action =
         read_bitmap_action(in, action_header.type, action_header.vl);
+    ensure_clip(context);
     write_bitmap(action, context);
+  } break;
+  case META_CLIPREGION_ACTION: {
+    auto [region, clip] = read_clip_region_action(in);
+    state.clip.clear();
+    if (clip && !region.null) {
+      intersect_clip(get_region_path_data(region, context), state);
+    }
+  } break;
+  case META_ISECTRECTCLIPREGION_ACTION: {
+    const Rectangle action = read_rectangle(in);
+    intersect_clip(
+        get_path_data_string({get_rectangle_polygon(action)}, true, context),
+        state);
+  } break;
+  case META_ISECTREGIONCLIPREGION_ACTION: {
+    const Region region = read_region(in);
+    if (!region.null) {
+      intersect_clip(get_region_path_data(region, context), state);
+    }
   } break;
   case META_TEXTALIGN_ACTION:
     state.text_align = read_text_align_action(in);
@@ -637,16 +741,19 @@ void translate_action(const ActionHeader &action_header, std::istream &in,
   case META_TEXT_ACTION: {
     const TextAction action =
         read_text_action(in, action_header.vl, state.encoding);
+    ensure_clip(context);
     write_text(action.point, action.text, {}, 0, context);
   } break;
   case META_TEXTARRAY_ACTION: {
     const TextArrayAction action =
         read_text_array_action(in, action_header.vl, state.encoding);
+    ensure_clip(context);
     write_text(action.point, action.text, action.dx_array, 0, context);
   } break;
   case META_STRETCHTEXT_ACTION: {
     const StretchTextAction action =
         read_stretch_text_action(in, action_header.vl, state.encoding);
+    ensure_clip(context);
     write_text(action.point, action.text, {}, action.width, context);
   } break;
   default:
@@ -705,6 +812,10 @@ void svm::translate_to_svg(const SvmFile &file, std::ostream &out,
   if (!context.stack.empty()) {
     ODR_WARNING(logger, context.stack.size() << " pushes were never popped");
   }
+
+  // whatever the last clip left open
+  context.state.clip.clear();
+  ensure_clip(context);
 
   writer.write_element_end();
 }

--- a/src/odr/internal/svm/svm_to_svg.cpp
+++ b/src/odr/internal/svm/svm_to_svg.cpp
@@ -10,6 +10,7 @@
 
 #include <algorithm>
 #include <cmath>
+#include <optional>
 #include <ranges>
 #include <span>
 #include <string>
@@ -715,10 +716,10 @@ void translate_action(const ActionHeader &action_header, std::istream &in,
     write_bitmap(action, context);
   } break;
   case META_CLIPREGION_ACTION: {
-    auto [region, clip] = read_clip_region_action(in);
+    const auto [region, clip] = read_clip_region_action(in);
     state.clip.clear();
-    if (clip && !region.null) {
-      intersect_clip(get_region_path_data(region, context), state);
+    if (clip && region) {
+      intersect_clip(get_region_path_data(*region, context), state);
     }
   } break;
   case META_ISECTRECTCLIPREGION_ACTION: {
@@ -727,9 +728,8 @@ void translate_action(const ActionHeader &action_header, std::istream &in,
     intersect_clip(get_path_data_string({&polygon, 1}, true, context), state);
   } break;
   case META_ISECTREGIONCLIPREGION_ACTION: {
-    const Region region = read_region(in);
-    if (!region.null) {
-      intersect_clip(get_region_path_data(region, context), state);
+    if (const std::optional<Region> region = read_region(in)) {
+      intersect_clip(get_region_path_data(*region, context), state);
     }
   } break;
   case META_TEXTALIGN_ACTION:

--- a/test/data.cmake
+++ b/test/data.cmake
@@ -17,9 +17,9 @@ odr_test_data(
 odr_test_data(
         PATH "reference-output/odr-public"
         URL "https://github.com/opendocument-app/OpenDocument.test.output.git"
-        REVISION "29c6270283527ff91c3ca125f67bd4260aa2acae")
+        REVISION "05441f24b4fcc9398b5115718a7d812ab4d63cea")
 
 odr_test_data(
         PATH "reference-output/odr-private"
         URL "https://github.com/opendocument-app/OpenDocument.test-private.output.git"
-        REVISION "898f1d823afdca5008ebb4a6579e0d4d9e412554")
+        REVISION "3ef61b792470da12cfd76e74afa1e0fad0812617")

--- a/test/src/internal/svm/svm_test.cpp
+++ b/test/src/internal/svm/svm_test.cpp
@@ -110,6 +110,23 @@ public:
         .end();
   }
 
+  /// A region of one band, the shape `ReadRegion` reads a rectangle as.
+  SvmBuilder &region(const std::int32_t left, const std::int32_t top,
+                     const std::int32_t right, const std::int32_t bottom) {
+    return begin(2)
+        .u16(1) // content version
+        .u16(2) // type: rectangle
+        .u16(0) // band header
+        .i32(top)
+        .i32(bottom)
+        .u16(1) // separation
+        .i32(left)
+        .i32(right)
+        .u16(2) // end
+        .u8(0)  // no poly-polygon
+        .end();
+  }
+
   /// A 24-bit uncompressed dib with the `BITMAPFILEHEADER` a metafile stores
   /// it behind. @p pixels is @p width * @p height bgr triples, top row first;
   /// the rows go out bottom-up and padded, as a dib holds them.
@@ -618,4 +635,89 @@ TEST(SvmToSvg, a_bitmap_mask_is_inverted) {
   EXPECT_NE(std::string::npos, svg.find("<mask id=\"odr-mask-1\""));
   EXPECT_NE(std::string::npos, svg.find("filter=\"url(#odr-invert)\""));
   EXPECT_NE(std::string::npos, svg.find("mask=\"url(#odr-mask-1)\""));
+}
+
+/// What a clip covers is a group around everything drawn after it.
+TEST(SvmToSvg, a_clip_region_wraps_what_follows) {
+  const std::string svg =
+      translate(SvmBuilder()
+                    .action(svm::META_ISECTRECTCLIPREGION_ACTION)
+                    .rectangle(1, 2, 11, 22)
+                    .end()
+                    .action(svm::META_RECT_ACTION)
+                    .rectangle(0, 0, 100, 100)
+                    .end()
+                    .file());
+
+  EXPECT_NE(std::string::npos,
+            svg.find("<clipPath id=\"odr-clip-1\">"
+                     "<path d=\"M 1,2 L 11,2 11,22 1,22 Z\""));
+  EXPECT_NE(std::string::npos,
+            svg.find("<g clip-path=\"url(#odr-clip-1)\"><rect"));
+  EXPECT_NE(std::string::npos, svg.find("</g></svg>"));
+}
+
+/// One region intersected into another is one group inside the other, which
+/// is how svg intersects two clips.
+TEST(SvmToSvg, clips_intersect_by_nesting) {
+  const std::string svg =
+      translate(SvmBuilder()
+                    .action(svm::META_ISECTRECTCLIPREGION_ACTION)
+                    .rectangle(0, 0, 10, 10)
+                    .end()
+                    .action(svm::META_ISECTREGIONCLIPREGION_ACTION)
+                    .region(2, 2, 8, 8)
+                    .end()
+                    .action(svm::META_RECT_ACTION)
+                    .rectangle(0, 0, 100, 100)
+                    .end()
+                    .file());
+
+  EXPECT_NE(std::string::npos, svg.find("<g clip-path=\"url(#odr-clip-1)\">"
+                                        "<clipPath id=\"odr-clip-2\">"));
+  EXPECT_NE(std::string::npos, svg.find("M 2,2 L 8,2 8,8 2,8 Z"));
+  EXPECT_NE(std::string::npos, svg.find("</g></g></svg>"));
+}
+
+/// A pop that restores the clip closes the group the push was drawn in.
+TEST(SvmToSvg, a_pop_restores_the_clip) {
+  const std::string svg =
+      translate(SvmBuilder()
+                    .action(svm::META_PUSH_ACTION)
+                    .u16(svm::PUSH_CLIPREGION)
+                    .end()
+                    .action(svm::META_ISECTRECTCLIPREGION_ACTION)
+                    .rectangle(1, 1, 2, 2)
+                    .end()
+                    .action(svm::META_RECT_ACTION)
+                    .rectangle(0, 0, 100, 100)
+                    .end()
+                    .action(svm::META_POP_ACTION)
+                    .end()
+                    .action(svm::META_RECT_ACTION)
+                    .rectangle(0, 0, 100, 100)
+                    .end()
+                    .file());
+
+  // the second rectangle is outside the group the first one is in
+  EXPECT_NE(std::string::npos, svg.find("/></g><rect"));
+}
+
+/// A file sets the drawing area and then intersects the region of the same
+/// rectangle; the second is a group that clips nothing.
+TEST(SvmToSvg, the_same_clip_twice_is_one_group) {
+  const std::string svg =
+      translate(SvmBuilder()
+                    .action(svm::META_ISECTRECTCLIPREGION_ACTION)
+                    .rectangle(0, 0, 10, 10)
+                    .end()
+                    .action(svm::META_ISECTREGIONCLIPREGION_ACTION)
+                    .region(0, 0, 10, 10)
+                    .end()
+                    .action(svm::META_RECT_ACTION)
+                    .rectangle(0, 0, 100, 100)
+                    .end()
+                    .file());
+
+  EXPECT_EQ(1, count_of(svg, "<clipPath"));
 }


### PR DESCRIPTION
🤖 Generated with [Claude Code](https://claude.com/claude-code)

Stage 5 of #772, stacked on #786 → #785 → #784 → #779 — **review those first**;
this branch's base is `feat/svm-bitmaps`.

Clipping was the largest gap left by occurrence: of 1125 metafiles harvested
from the fixtures, **1124 intersect a clip rectangle** and 50 intersect a
region. All of it was skipped, so anything a metafile drew outside its own clip
was shown in full.

## Intersecting clips are nested groups

An svg `clip-path` names one shape, and `ISECT…` *intersects*, so two clips
become two groups, one inside the other. The state's clip is therefore a stack
of shapes rather than one: `ensure_clip` keeps the groups the next drawing
action still wants, closes the ones it does not, and opens what is missing.
That also makes a `POP` restoring the clip nothing special — the next action
closes what it has to, and the document's last groups close before `</svg>`.

## Reading a region

A region streams as a band list (`RegionBand::load`) — a union of rectangles —
and, from version 2, as the poly-polygon those bands were rasterised from. The
polygons are the better outline where they are there. Both end up in one
`<path>` with `clip-rule="evenodd"`: bands are disjoint, so union and even-odd
agree, and a poly-polygon wants even-odd anyway.

Two details worth naming:

- **vcl does not re-scale a clip when the map mode changes** — `SetMapMode`'s
  own comment says "clip regions are not re-scaled" — so the shape is
  transformed once, where the action sets it.
- **A file sets its drawing area and then intersects the region of the same
  rectangle.** That is one group, not two; intersecting a clip with the shape
  it already has is skipped.

`MOVECLIPREGION` stays unimplemented: it occurs nowhere in the corpus and would
have to move path data that is already written out.

## Verification

4 new tests (29 in the svm suite): a clip wraps what follows, two clips nest,
a pop closes the group its push drew in, and the same clip twice is one group.

Rendered every changed page against the reference with `compare-html --driver
chrome`: 1388 matched, 15 differ, and every one of those differs by **0.001% to
0.03% of its pixels** — the antialiased edge where a clip now trims a hairline
at the drawing's border. Cropping the largest of them side by side shows two
identical charts. No text changed anywhere.

Reference output regenerated (19 private, 4 public) and the pin advanced in
this branch.
