### PR TITLE
refactor(document): give `internal::Document` the read-only defaults nine engines pasted

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -239,7 +239,9 @@ Dispatch `release.yml` against main, publish the draft that appears —
    alias is claimed twice, or if the declared capabilities exceed what the
    engines actually do.
 2. For documents: subclass `internal::Document`; in its constructor build an
-   `ElementRegistry` and an `ElementAdapter` (pattern above).
+   `ElementRegistry` and an `ElementAdapter` (pattern above). It defaults to
+   read-only — override `is_editable`/`is_savable`/`save` only for an engine
+   that can write.
 3. Implement the per-element adapters you can populate; the **generic HTML
    renderer then works for free**.
 4. Register the factory (e.g. `oldms_file.cpp::document()` switches on

--- a/src/odr/internal/common/document.cpp
+++ b/src/odr/internal/common/document.cpp
@@ -1,5 +1,7 @@
 #include <odr/internal/common/document.hpp>
 
+#include <odr/exceptions.hpp>
+
 #include <odr/internal/abstract/filesystem.hpp>
 
 namespace odr::internal {
@@ -10,6 +12,20 @@ Document::Document(const FileType file_type, const DocumentType document_type,
       m_files{std::move(files)} {}
 
 Document::~Document() = default;
+
+bool Document::is_editable() const noexcept { return false; }
+
+bool Document::is_savable(const bool /*encrypted*/) const noexcept {
+  return false;
+}
+
+void Document::save(std::ostream & /*out*/) const {
+  throw UnsupportedOperation();
+}
+
+void Document::save(std::ostream & /*out*/, const char * /*password*/) const {
+  throw UnsupportedOperation();
+}
 
 FileType Document::file_type() const noexcept { return m_file_type; }
 

--- a/src/odr/internal/common/document.hpp
+++ b/src/odr/internal/common/document.hpp
@@ -19,6 +19,12 @@ public:
            std::shared_ptr<abstract::ReadableFilesystem> files);
   ~Document() override;
 
+  /// Read-only, which every engine but odf and ooxml text is.
+  [[nodiscard]] bool is_editable() const noexcept override;
+  [[nodiscard]] bool is_savable(bool encrypted) const noexcept override;
+  void save(std::ostream &out) const override;
+  void save(std::ostream &out, const char *password) const override;
+
   [[nodiscard]] FileType file_type() const noexcept final;
   [[nodiscard]] DocumentType document_type() const noexcept final;
 

--- a/src/odr/internal/csv/csv_document.cpp
+++ b/src/odr/internal/csv/csv_document.cpp
@@ -306,22 +306,6 @@ CsvDocument::CsvDocument(const abstract::File &file,
   m_element_adapter = std::make_unique<ElementAdapter>(*this);
 }
 
-bool CsvDocument::is_editable() const noexcept { return false; }
-
-bool CsvDocument::is_savable(
-    [[maybe_unused]] const bool encrypted) const noexcept {
-  return false;
-}
-
-void CsvDocument::save(std::ostream & /*out*/) const {
-  throw UnsupportedOperation();
-}
-
-void CsvDocument::save(std::ostream & /*out*/,
-                       const char * /*password*/) const {
-  throw UnsupportedOperation();
-}
-
 std::string_view CsvDocument::cell(const std::uint32_t column,
                                    const std::uint32_t row) const {
   if (row >= m_rows.size()) {

--- a/src/odr/internal/csv/csv_document.hpp
+++ b/src/odr/internal/csv/csv_document.hpp
@@ -28,12 +28,6 @@ public:
   CsvDocument(const abstract::File &file, TextEncoding encoding,
               Dialect dialect, bool skip_first_line);
 
-  [[nodiscard]] bool is_editable() const noexcept override;
-  [[nodiscard]] bool is_savable(bool encrypted) const noexcept override;
-
-  void save(std::ostream &out) const override;
-  void save(std::ostream &out, const char *password) const override;
-
   /// The cell's text, empty where a row stops short.
   [[nodiscard]] std::string_view cell(std::uint32_t column,
                                       std::uint32_t row) const;

--- a/src/odr/internal/iwork/iwork_document.cpp
+++ b/src/odr/internal/iwork/iwork_document.cpp
@@ -53,21 +53,6 @@ const ElementRegistry &Document::element_registry() const {
   return m_element_registry;
 }
 
-bool Document::is_editable() const noexcept { return false; }
-
-bool Document::is_savable(const bool encrypted) const noexcept {
-  (void)encrypted;
-  return false;
-}
-
-void Document::save(std::ostream & /*out*/) const {
-  throw UnsupportedOperation();
-}
-
-void Document::save(std::ostream & /*out*/, const char * /*password*/) const {
-  throw UnsupportedOperation();
-}
-
 namespace {
 
 class ElementAdapter final : public abstract::ElementAdapter,

--- a/src/odr/internal/iwork/iwork_document.hpp
+++ b/src/odr/internal/iwork/iwork_document.hpp
@@ -19,12 +19,6 @@ public:
 
   [[nodiscard]] const ElementRegistry &element_registry() const;
 
-  [[nodiscard]] bool is_editable() const noexcept override;
-  [[nodiscard]] bool is_savable(bool encrypted) const noexcept override;
-
-  void save(std::ostream &out) const override;
-  void save(std::ostream &out, const char *password) const override;
-
 private:
   ElementRegistry m_element_registry;
 };

--- a/src/odr/internal/markdown/markdown_document.cpp
+++ b/src/odr/internal/markdown/markdown_document.cpp
@@ -34,21 +34,6 @@ const StyleRegistry &Document::style_registry() const {
   return m_style_registry;
 }
 
-bool Document::is_editable() const noexcept { return false; }
-
-bool Document::is_savable(const bool encrypted) const noexcept {
-  (void)encrypted;
-  return false;
-}
-
-void Document::save(std::ostream & /*out*/) const {
-  throw UnsupportedOperation();
-}
-
-void Document::save(std::ostream & /*out*/, const char * /*password*/) const {
-  throw UnsupportedOperation();
-}
-
 namespace {
 
 class ElementAdapter final : public abstract::ElementAdapter,

--- a/src/odr/internal/markdown/markdown_document.hpp
+++ b/src/odr/internal/markdown/markdown_document.hpp
@@ -18,12 +18,6 @@ public:
 
   [[nodiscard]] const StyleRegistry &style_registry() const;
 
-  [[nodiscard]] bool is_editable() const noexcept override;
-  [[nodiscard]] bool is_savable(bool encrypted) const noexcept override;
-
-  void save(std::ostream &out) const override;
-  void save(std::ostream &out, const char *password) const override;
-
 private:
   ElementRegistry m_element_registry;
   StyleRegistry m_style_registry;

--- a/src/odr/internal/oldms/presentation/ppt_document.cpp
+++ b/src/odr/internal/oldms/presentation/ppt_document.cpp
@@ -41,21 +41,6 @@ const StyleRegistry &Document::style_registry() const {
   return m_style_registry;
 }
 
-bool Document::is_editable() const noexcept { return false; }
-
-bool Document::is_savable(const bool encrypted) const noexcept {
-  (void)encrypted;
-  return false;
-}
-
-void Document::save(std::ostream & /*out*/) const {
-  throw UnsupportedOperation();
-}
-
-void Document::save(std::ostream & /*out*/, const char * /*password*/) const {
-  throw UnsupportedOperation();
-}
-
 namespace {
 
 class ElementAdapter final : public abstract::ElementAdapter,

--- a/src/odr/internal/oldms/presentation/ppt_document.hpp
+++ b/src/odr/internal/oldms/presentation/ppt_document.hpp
@@ -18,12 +18,6 @@ public:
 
   [[nodiscard]] const StyleRegistry &style_registry() const;
 
-  [[nodiscard]] bool is_editable() const noexcept override;
-  [[nodiscard]] bool is_savable(bool encrypted) const noexcept override;
-
-  void save(std::ostream &out) const override;
-  void save(std::ostream &out, const char *password) const override;
-
 private:
   ElementRegistry m_element_registry;
   StyleRegistry m_style_registry;

--- a/src/odr/internal/oldms/spreadsheet/xls_document.cpp
+++ b/src/odr/internal/oldms/spreadsheet/xls_document.cpp
@@ -37,21 +37,6 @@ const StyleRegistry &Document::style_registry() const {
   return m_style_registry;
 }
 
-bool Document::is_editable() const noexcept { return false; }
-
-bool Document::is_savable(const bool encrypted) const noexcept {
-  (void)encrypted;
-  return false;
-}
-
-void Document::save(std::ostream & /*out*/) const {
-  throw UnsupportedOperation();
-}
-
-void Document::save(std::ostream & /*out*/, const char * /*password*/) const {
-  throw UnsupportedOperation();
-}
-
 namespace {
 
 class ElementAdapter final : public abstract::ElementAdapter,

--- a/src/odr/internal/oldms/spreadsheet/xls_document.hpp
+++ b/src/odr/internal/oldms/spreadsheet/xls_document.hpp
@@ -18,12 +18,6 @@ public:
 
   [[nodiscard]] const StyleRegistry &style_registry() const;
 
-  [[nodiscard]] bool is_editable() const noexcept override;
-  [[nodiscard]] bool is_savable(bool encrypted) const noexcept override;
-
-  void save(std::ostream &out) const override;
-  void save(std::ostream &out, const char *password) const override;
-
 private:
   ElementRegistry m_element_registry;
   StyleRegistry m_style_registry;

--- a/src/odr/internal/oldms/text/doc_document.cpp
+++ b/src/odr/internal/oldms/text/doc_document.cpp
@@ -36,21 +36,6 @@ const StyleRegistry &Document::style_registry() const {
   return m_style_registry;
 }
 
-bool Document::is_editable() const noexcept { return false; }
-
-bool Document::is_savable(const bool encrypted) const noexcept {
-  (void)encrypted;
-  return false;
-}
-
-void Document::save(std::ostream & /*out*/) const {
-  throw UnsupportedOperation();
-}
-
-void Document::save(std::ostream & /*out*/, const char * /*password*/) const {
-  throw UnsupportedOperation();
-}
-
 namespace {
 
 class ElementAdapter final : public abstract::ElementAdapter,

--- a/src/odr/internal/oldms/text/doc_document.hpp
+++ b/src/odr/internal/oldms/text/doc_document.hpp
@@ -18,12 +18,6 @@ public:
 
   [[nodiscard]] const StyleRegistry &style_registry() const;
 
-  [[nodiscard]] bool is_editable() const noexcept override;
-  [[nodiscard]] bool is_savable(bool encrypted) const noexcept override;
-
-  void save(std::ostream &out) const override;
-  void save(std::ostream &out, const char *password) const override;
-
 private:
   ElementRegistry m_element_registry;
   StyleRegistry m_style_registry;

--- a/src/odr/internal/ooxml/presentation/ooxml_presentation_document.cpp
+++ b/src/odr/internal/ooxml/presentation/ooxml_presentation_document.cpp
@@ -1,7 +1,6 @@
 #include <odr/internal/ooxml/presentation/ooxml_presentation_document.hpp>
 
 #include <odr/document_path.hpp>
-#include <odr/exceptions.hpp>
 #include <odr/file.hpp>
 #include <odr/table_dimension.hpp>
 
@@ -136,20 +135,6 @@ Document::slide_page_layout(const ElementIdentifier element_id) const {
 
 const ElementRegistry &Document::element_registry() const {
   return m_element_registry;
-}
-
-bool Document::is_editable() const noexcept { return false; }
-
-bool Document::is_savable(const bool /*encrypted*/) const noexcept {
-  return false;
-}
-
-void Document::save(std::ostream & /*out*/) const {
-  throw UnsupportedOperation();
-}
-
-void Document::save(std::ostream & /*out*/, const char * /*password*/) const {
-  throw UnsupportedOperation();
 }
 
 namespace {

--- a/src/odr/internal/ooxml/presentation/ooxml_presentation_document.hpp
+++ b/src/odr/internal/ooxml/presentation/ooxml_presentation_document.hpp
@@ -28,12 +28,6 @@ public:
   [[nodiscard]] PageLayout
   slide_page_layout(ElementIdentifier element_id) const;
 
-  [[nodiscard]] bool is_editable() const noexcept override;
-  [[nodiscard]] bool is_savable(bool encrypted) const noexcept override;
-
-  void save(std::ostream &out) const override;
-  void save(std::ostream &out, const char *password) const override;
-
 private:
   pugi::xml_document m_document_xml;
   std::unordered_map<std::string, pugi::xml_document> m_slides_xml;

--- a/src/odr/internal/ooxml/spreadsheet/ooxml_spreadsheet_document.cpp
+++ b/src/odr/internal/ooxml/spreadsheet/ooxml_spreadsheet_document.cpp
@@ -1,7 +1,6 @@
 #include <odr/internal/ooxml/spreadsheet/ooxml_spreadsheet_document.hpp>
 
 #include <odr/document_path.hpp>
-#include <odr/exceptions.hpp>
 #include <odr/file.hpp>
 #include <odr/table_position.hpp>
 
@@ -67,20 +66,6 @@ const ElementRegistry &Document::element_registry() const {
 
 const StyleRegistry &Document::style_registry() const {
   return m_style_registry;
-}
-
-bool Document::is_editable() const noexcept { return false; }
-
-bool Document::is_savable(const bool /*encrypted*/) const noexcept {
-  return false;
-}
-
-void Document::save(std::ostream & /*out*/) const {
-  throw UnsupportedOperation();
-}
-
-void Document::save(std::ostream & /*out*/, const char * /*password*/) const {
-  throw UnsupportedOperation();
 }
 
 std::pair<pugi::xml_document &, Relations &>

--- a/src/odr/internal/ooxml/spreadsheet/ooxml_spreadsheet_document.hpp
+++ b/src/odr/internal/ooxml/spreadsheet/ooxml_spreadsheet_document.hpp
@@ -21,12 +21,6 @@ public:
   [[nodiscard]] const ElementRegistry &element_registry() const;
   [[nodiscard]] const StyleRegistry &style_registry() const;
 
-  [[nodiscard]] bool is_editable() const noexcept override;
-  [[nodiscard]] bool is_savable(bool encrypted) const noexcept override;
-
-  void save(std::ostream &out) const override;
-  void save(std::ostream &out, const char *password) const override;
-
 private:
   XmlDocumentsAndRelations m_xml_documents_and_relations;
   SharedStrings m_shared_strings;

--- a/src/odr/internal/rtf/rtf_document.cpp
+++ b/src/odr/internal/rtf/rtf_document.cpp
@@ -33,21 +33,6 @@ const ElementRegistry &Document::element_registry() const {
   return m_element_registry;
 }
 
-bool Document::is_editable() const noexcept { return false; }
-
-bool Document::is_savable(const bool encrypted) const noexcept {
-  (void)encrypted;
-  return false;
-}
-
-void Document::save(std::ostream & /*out*/) const {
-  throw UnsupportedOperation();
-}
-
-void Document::save(std::ostream & /*out*/, const char * /*password*/) const {
-  throw UnsupportedOperation();
-}
-
 namespace {
 
 class ElementAdapter final : public abstract::ElementAdapter,

--- a/src/odr/internal/rtf/rtf_document.hpp
+++ b/src/odr/internal/rtf/rtf_document.hpp
@@ -17,12 +17,6 @@ public:
 
   [[nodiscard]] const ElementRegistry &element_registry() const;
 
-  [[nodiscard]] bool is_editable() const noexcept override;
-  [[nodiscard]] bool is_savable(bool encrypted) const noexcept override;
-
-  void save(std::ostream &out) const override;
-  void save(std::ostream &out, const char *password) const override;
-
 private:
   ElementRegistry m_element_registry;
 };


### PR DESCRIPTION
🤖 Generated with [Claude Code](https://claude.com/claude-code)

Step 1 of #770, the order that issue suggests: the mechanical one, ten files, no behaviour change.

`internal::Document` now answers the read-only case itself:

```cpp
bool Document::is_editable() const noexcept { return false; }
bool Document::is_savable(bool) const noexcept { return false; }
void Document::save(std::ostream &) const { throw UnsupportedOperation(); }
void Document::save(std::ostream &, const char *) const { throw UnsupportedOperation(); }
```

and the nine engines that had pasted exactly that — csv, iwork, markdown, rtf, the three `oldms` documents, and the ooxml spreadsheet and presentation documents — drop both the declarations and the definitions. odf and ooxml text keep their overrides, which are the only two with anything real to say.

`AGENTS.md` gains a clause under *Adding / extending a document format* so the next engine does not paste them back.

Two `#include <odr/exceptions.hpp>` became unused with the stubs gone and are dropped with them.

No consumer-visible change, so no `CHANGELOG.md` entry.

## Verification

- `odr` and `odr_test` build clean.
- `./odr_test --gtest_filter='Document*:*Save*:*Edit*:*edit*:*save*'` — 56 tests, all pass.