### PR TITLE
feat(html): warn on the element types the renderer drops, instead of dropping them silently

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,10 @@ The release run heads these entries with the version and opens a fresh
 
 ## Unreleased
 
+- The HTML renderer warns, rather than silently dropping, when it reaches an
+  element type it has no `translate_*` for. Across the test corpus that is
+  `page_break` and nothing else. Towards #150.
+
 - An ODF `draw:object` chart is drawn from the chart part's own markup, not
   from the replacement image beside it: bar, line, area, scatter, pie and ring,
   with their titles, legends, axes and series colours. An object holding no

--- a/src/odr/internal/html/document_element.cpp
+++ b/src/odr/internal/html/document_element.cpp
@@ -3,6 +3,7 @@
 #include <odr/document_element.hpp>
 #include <odr/document_path.hpp>
 #include <odr/html.hpp>
+#include <odr/logger.hpp>
 #include <odr/style.hpp>
 
 #include <odr/internal/common/path.hpp>
@@ -18,6 +19,72 @@
 #include <algorithm>
 
 namespace odr::internal {
+
+namespace {
+
+/// Names every enumerator, with no `default`, so a type added to
+/// @ref ElementType has to be named here too.
+const char *element_type_name(const ElementType type) {
+  switch (type) {
+  case ElementType::none:
+    return "none";
+  case ElementType::root:
+    return "root";
+  case ElementType::slide:
+    return "slide";
+  case ElementType::sheet:
+    return "sheet";
+  case ElementType::page:
+    return "page";
+  case ElementType::master_page:
+    return "master_page";
+  case ElementType::sheet_cell:
+    return "sheet_cell";
+  case ElementType::text:
+    return "text";
+  case ElementType::line_break:
+    return "line_break";
+  case ElementType::page_break:
+    return "page_break";
+  case ElementType::paragraph:
+    return "paragraph";
+  case ElementType::span:
+    return "span";
+  case ElementType::link:
+    return "link";
+  case ElementType::bookmark:
+    return "bookmark";
+  case ElementType::list:
+    return "list";
+  case ElementType::list_item:
+    return "list_item";
+  case ElementType::table:
+    return "table";
+  case ElementType::table_column:
+    return "table_column";
+  case ElementType::table_row:
+    return "table_row";
+  case ElementType::table_cell:
+    return "table_cell";
+  case ElementType::frame:
+    return "frame";
+  case ElementType::image:
+    return "image";
+  case ElementType::rect:
+    return "rect";
+  case ElementType::line:
+    return "line";
+  case ElementType::circle:
+    return "circle";
+  case ElementType::custom_shape:
+    return "custom_shape";
+  case ElementType::group:
+    return "group";
+  }
+  return "?";
+}
+
+} // namespace
 
 void html::translate_children(const ElementRange &range,
                               const WritingState &state) {
@@ -78,7 +145,11 @@ void html::translate_element(const Element &element,
     translate_children(element.children(), state);
     break;
   default:
-    // TODO log
+    // The element and its whole subtree are dropped. Logged rather than
+    // thrown: a renderer shows what it can, and the corpus run is what ranks
+    // the gaps by how often they actually occur.
+    ODR_WARNING(state.logger(), "html: dropped unhandled element "
+                                    << element_type_name(element.type()));
     break;
   }
 }

--- a/test/src/html_output_test.cpp
+++ b/test/src/html_output_test.cpp
@@ -194,7 +194,13 @@ TEST_P(HtmlOutputTests, html_meta) {
 
   const std::string output_path_tmp = output_path + "/tmp";
   fs::create_directories(output_path_tmp);
-  HtmlService service = html::translate(file, output_path_tmp, config);
+  // The renderer used to get the null logger, so nothing it reported was ever
+  // read. Warnings only: its debug output is per pdf operator and per svm
+  // action, and would bury the corpus log.
+  const Logger render_logger =
+      Logger::create_stdio("odr-test", LogLevel::warning);
+  HtmlService service =
+      html::translate(file, output_path_tmp, config, render_logger);
   Html html = service.bring_offline(output_path);
   fs::remove_all(output_path_tmp);
 


### PR DESCRIPTION
🤖 Generated with [Claude Code](https://claude.com/claude-code)

The render half of #150. `translate_element`'s `default:` carried a `// TODO log` and threw the element *and its whole subtree* away without a word. It now names the type through `state.logger()`, which `WritingState` has carried all along.

```cpp
default:
  ODR_WARNING(state.logger(), "html: dropped unhandled element "
                                  << element_type_name(element.type()));
  break;
```

`element_type_name` is a switch over every `ElementType` enumerator with no `default`, so a type added to the enum has to be named here too or the build stops.

## The corpus test was logging into the void

`html_output_test.cpp` called the three-argument `html::translate`, so the renderer got `Logger::null()` — nothing it has ever reported was read. It now gets a logger, at **warning** level: at verbose the pre-existing per-pdf-operator and per-svm-action debug lines take the run from 1.7k to 23k lines and bury everything. At warning it is 2.0k lines.

## What the corpus says

That is the point of the issue — turning "support X" into a ranking. Over all 281 corpus renders:

| type | dropped | files |
|---|---|---|
| `page_break` | 312 | 30 |

**Nothing else.** `page_break` is the renderer's only element-level gap, 240 of them in `odt` and 72 in `doc`. Worst offenders: `efficiency+style-big+various-1.odt` (87), `785KB.doc` (64), `style+svm-various-1.odt` (38).

That is #174, and it now has a number on it.

The only other warning the whole corpus raises is one pdf cross-reference recovery.

## Verification

- `./odr_test --gtest_filter='all_test_files/HtmlOutputTests.*'` — 281 tests, pass.
- No markup changes, so the reference output needs no regeneration.