### PR TITLE
fix(html): scale the text with the fit, where webkit holds it back

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,10 @@ The release run heads these entries with the version and opens a fresh
 
 ## Unreleased
 
+- A fitted or zoomed view scales its text with the page in WebKit, where the
+  type used to stay at its unscaled size. `HtmlViewportMode::fit_width_by_view`
+  is usable on iOS. Closes #761.
+
 - A PDF `gs` applies the `/ExtGState` stroke parameters `/LW`, `/LC`, `/LJ`,
   `/ML` and `/D`. A producer that sets the line width only there — Canva does —
   used to have every stroke drawn at the initial width of 1.

--- a/src/odr/internal/html/common.cpp
+++ b/src/odr/internal/html/common.cpp
@@ -245,8 +245,10 @@ void html::write_zoom_style(HtmlWriter &out, const HtmlConfig &config,
     out.out() << "body{zoom:" << number(*zoom) << "}";
   }
 
-  // paper has its own geometry; beats the script's inline zoom
-  out.out() << "@media print{:root{--odr-zoom:1!important}"
+  // paper has its own geometry; beats the script's inline zoom and adjustment
+  out.out() << "@media print{:root{--odr-zoom:1!important;"
+               "-webkit-text-size-adjust:100%!important;"
+               "text-size-adjust:100%!important}"
                "body{zoom:1!important}}";
 
   out.write_header_style_end();

--- a/src/odr/internal/html/frontend.cpp
+++ b/src/odr/internal/html/frontend.cpp
@@ -372,13 +372,72 @@ constexpr std::string_view viewport_js = R"js(
     return pinned !== null ? pinned : fit;
   }
 
+  // Webkit divides a stated `text-size-adjust` by the css zoom, so restating
+  // the zoom as the percentage holds the type where its box is. Blink reads the
+  // same percentage as a plain multiplier, hence the probe below.
+  var adjustsText = false;
+  var adjusted = "";
+
+  function textAdjust(value) {
+    adjusted = value;
+    root.style.setProperty("-webkit-text-size-adjust", value);
+    root.style.setProperty("text-size-adjust", value);
+  }
+
+  // A run against a stated length, so no rect convention enters. True in webkit
+  // and in the engines that ignore the property; false where it scales the text
+  // a second time.
+  function textAdjustHolds() {
+    var ruler = document.createElement("div");
+    ruler.style.cssText =
+      "position:absolute;top:0;left:0;width:400px;height:0;overflow:hidden";
+    var run = document.createElement("span");
+    run.style.cssText = "font:100px/1 monospace;white-space:pre";
+    run.textContent = "MMMMMMMMMM";
+    ruler.appendChild(run);
+    body.appendChild(ruler);
+
+    function ratio() {
+      var length = ruler.getBoundingClientRect().width;
+      return length ? run.getBoundingClientRect().width / length : 0;
+    }
+
+    var zoom = body.style.zoom;
+    body.style.zoom = "1";
+    var unzoomed = ratio();
+    body.style.zoom = "0.5";
+    textAdjust("50%");
+    var zoomed = ratio();
+    textAdjust("");
+    body.style.zoom = zoom;
+    body.removeChild(ruler);
+
+    return unzoomed > 0 && Math.abs(zoomed - unzoomed) < unzoomed / 50;
+  }
+
+  function zoomBody(zoom) {
+    body.style.zoom = zoom;
+    root.style.setProperty("--odr-zoom", zoom);
+    if (adjustsText) {
+      textAdjust(zoom * 100 + "%");
+    }
+  }
+
   // The natural width of what the body holds, measured unscaled.
   function contentWidth() {
     var zoom = body.style.zoom;
+    var adjust = adjusted;
     // `1`, not empty: a stylesheet may carry a zoom of its own to fall back to.
     body.style.zoom = "1";
+    // the percentage compensates a zoom this measurement removes
+    if (adjust) {
+      textAdjust("100%");
+    }
     var natural = body.scrollWidth;
     body.style.zoom = zoom;
+    if (adjust) {
+      textAdjust(adjust);
+    }
     return natural;
   }
 
@@ -527,9 +586,7 @@ constexpr std::string_view viewport_js = R"js(
   }
 
   function apply(target) {
-    var zoom = applied();
-    body.style.zoom = zoom;
-    root.style.setProperty("--odr-zoom", zoom);
+    zoomBody(applied());
 
     settle(target);
     notify();
@@ -604,11 +661,15 @@ constexpr std::string_view viewport_js = R"js(
     return applied();
   };
 
+  // Before the first measurement, so every one of them reads the same state.
+  adjustsText = textAdjustHolds();
   width = root.clientWidth;
   if (measures && pinned === null) {
     fit = measureFit();
-    body.style.zoom = fit;
-    root.style.setProperty("--odr-zoom", fit);
+  }
+  // Restated inline so a css-stated zoom carries the adjustment with it.
+  if (applied() !== 1) {
+    zoomBody(applied());
   }
   remember();
 

--- a/test/browser/viewport/README.md
+++ b/test/browser/viewport/README.md
@@ -36,3 +36,9 @@ each printing its own verdict.
 Keep the tab on screen: the browser throttles `requestAnimationFrame` in a
 window that is not. The harness dispatches the scroll and resize events itself,
 but not the settling frames that follow them.
+
+Two webkit rules nothing here reproduces, both about type under an applied
+`zoom` (#761): it holds the text at its unscaled size unless the zoom is stated
+back as `text-size-adjust`, by a factor its cluster heuristics decide, and it
+draws no text below 9px. Neither shows on 400 identical lines — the factor needs
+the shape of a real render. The oracle is a document served to a real webkit.

--- a/test/data.cmake
+++ b/test/data.cmake
@@ -22,4 +22,4 @@ odr_test_data(
 odr_test_data(
         PATH "reference-output/odr-private"
         URL "https://github.com/opendocument-app/OpenDocument.test-private.output.git"
-        REVISION "2f5964b9b8a5172aac2e4f0d893c6ccf625f8857")
+        REVISION "bcea37b997a045387b7069412ba668fa44a7e26b")

--- a/test/src/internal/html/common_test.cpp
+++ b/test/src/internal/html/common_test.cpp
@@ -92,7 +92,9 @@ std::string emit_zoom(const HtmlConfig &config, const ihtml::WidthFit fits,
 
 /// Written whatever the zoom is, so every case states it.
 constexpr const char *print =
-    "@media print{:root{--odr-zoom:1!important}body{zoom:1!important}}";
+    "@media print{:root{--odr-zoom:1!important;"
+    "-webkit-text-size-adjust:100%!important;text-size-adjust:100%!important}"
+    "body{zoom:1!important}}";
 
 std::string styled(const std::string &css) {
   return "<style>" + css + print + "</style>";


### PR DESCRIPTION
🤖 Generated with [Claude Code](https://claude.com/claude-code)

Closes #761.

## What was wrong

Not the meta tag, and not the script failing to run. In `fit_width_by_view` on iOS the view **does** fit: `body{zoom:0.4867}` is applied, `odr.getZoom()` returns 0.49, the A4 page box lands at the screen width. The type does not follow.

Webkit reads a css `zoom` as a scale the reader asked for and holds text at the size it would have had without one. It expresses that through `text-size-adjust`, dividing the stated percentage by the zoom:

| `text-size-adjust` under `zoom:k` | used font size |
|---|---|
| `auto` — the default, and what we ship | inflated by a factor its cluster heuristics pick; 12pt → 47px in the sample |
| `none` or `100%` | inflated by exactly `1/k` |
| **`k·100%`** | **the specified size** |

So #761's "heading unchanged, body text ~2×, reflowed" is a correctly fitted page with the text left behind. The same held for `odr.setZoom`, which was equally wrong on iOS.

## The change

`viewport_js` states the zoom back as the percentage whenever it applies one. Blink reads the same percentage as a plain multiplier — `50%` under `zoom:0.5` halves the text a second time — so a probe at startup measures whether stating it holds the type, and it is only stated where it does. `@media print` resets it beside the zoom.

`apply()` and the startup block go through one `zoomBody`, which also restates a zoom the css stated (`viewport_width`, `initial_zoom`), so those pages carry the adjustment too.

## Measured

iPhone 17 Pro / iOS 26 simulator, Pixel 9 Pro / Chrome 139 emulator, desktop Chrome, macOS WebKit — a WKWebView harness serving the emitted html, plus `test/browser/viewport`.

`--odr-fit:view`, the sample ODT, after:

| viewport | zoom | stated | font sizes |
|---|---|---|---|
| 402 | 0.487 | 48.67% | 12pt→16px, 16pt→21.3px, 26pt→34.7px |
| 600 | 0.726 | 72.64% | all exact |
| 874 | 1 | 100% | all exact |

- **Android**: probe declines, `text-size-adjust` stays `auto`, page fitted, type exact — unchanged.
- **Desktop Chrome**: `tests.html` all passed; both top-level banners PASS.
- **macOS WebKit**: both top-level banners PASS. The property does not exist there.
- `odr_test --gtest_filter='html*:*Html*'`: 346 passed, 6 pre-existing skips.

## Reference output

The print rule and `viewport.js` changed, so every emitted document moves by that one rule — on screen nothing does. `compare-html --driver chrome` over the private corpus: the differing set is not reproducible run to run (4, then 3, then 1 file, same pair of trees), and splitting the change proves it — the reference against the new script alone matches all files, the print rule alone flakes. Pre-existing rasterisation noise, not this change.

Regenerated anyway, so the reference stays what the renderer emits:

- **private** — regenerated, 1239 files, one line each, plus `resources/viewport.js`; nothing else moved. Pushed as `bcea37b`, and `test/data.cmake` advances to it.
- **public** — **not** touched. Its output main is at `d456f47`, the regen for the unlanded #803, so a regen from this branch would revert #803's docx output, and pinning a commit that contains #803 would fail CI on a main that has no #803. Its pin stays at `3dcc4fb`; the reference renders identically to what this branch emits, so CI is green either way, and #803 picks the rule up in its own regen.

## Two findings not acted on here

1. Webkit draws no text below 9 css px, and `text-size-adjust` cannot defeat it (16px at `zoom:0.25` → 36px; 40px → 40px). At the deepest fits this floors table text — 12pt at zoom 0.487 renders at 9px instead of 7.8px, laying the sample out 9% taller. Non-table text is unaffected.
2. Already shipping, separate: in `automatic` mode on iOS, webkit boosts body text — 12pt → 23px, 16pt → 24px, the sample 1949px tall against 1702px. iOS renders therefore do not match the reference renders. A static `text-size-adjust:100%` in the shipped css fixes it and is a measured no-op in Blink, but it also makes an A4 page's body text genuinely tiny on a phone, so it is left out of a bug fix.

## Not covered by the browser checks

`page.html`'s 400 identical lines do not produce the cluster shape that triggers the inflation, so a check added there detected only the 9px floor and was dropped. The limitation is recorded in the harness README instead; the oracle is a real document served to a real webkit.

