### PR TITLE
fix(html): print a sheet onto the page, without our ruler

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,10 @@ The release run heads these entries with the version and opens a fresh
 
 ## Unreleased
 
+- A printed sheet drops our row/column ruler and is capped to the page width
+  rather than cut off at the right edge. Print only; the on-screen view is
+  unchanged. Towards #816.
+
 - New `File::name()`: the file name on disk, the entry name inside an archive,
   or the name `File::from_memory(data, name)` was given. A named in-memory file
   gets the same name-derived type candidate a path does, so `notes.md` bytes

--- a/src/odr/internal/html/frontend.cpp
+++ b/src/odr/internal/html/frontend.cpp
@@ -112,6 +112,17 @@ body{margin:0;background:var(--odr-sheet-canvas)}
 .odr-sheet-sort:hover{background:var(--odr-sheet-wash-ruler)}
 .odr-sheet-sort::after{content:"\25BE";font-size:15px;line-height:1}
 .odr-sheet-sort-asc::after{content:"\25B4"}
+/* Paper cannot scroll, so a sheet wider than the page is cut off; only
+   `!important` beats the inline column width. The ruler collapses rather than
+   `display:none`, which would take the cells out of their rows and shift every
+   column left. */
+@media print{
+.odr-sheet thead{display:none}
+.odr-sheet-gutter{visibility:collapse;width:0}
+.odr-sheet-row-header{visibility:collapse;padding:0;box-shadow:none}
+.odr-sheet{max-width:100%}
+.odr-sheet col{min-width:0!important}
+}
 )css";
 
 constexpr std::string_view spreadsheet_dark_css = R"css(

--- a/test/src/html_test.cpp
+++ b/test/src/html_test.cpp
@@ -728,6 +728,24 @@ TEST(html, the_cell_budget_bounds_the_rows_by_the_width) {
   EXPECT_EQ(rendered(30, 3).rows, 5);
 }
 
+// #816
+TEST(html, a_printed_sheet_drops_the_ruler_and_fits_the_page) {
+  const std::string sheet =
+      render("odr-public/ods/file_example_ODS_10.ods", HtmlConfig());
+
+  // on screen the sheet keeps its stated width and its ruler
+  EXPECT_NE(sheet.find("<col style=\"width:"), std::string::npos);
+  EXPECT_NE(sheet.find("table-layout:fixed"), std::string::npos);
+  EXPECT_NE(sheet.find("class=\"odr-sheet-column-header\""), std::string::npos);
+
+  EXPECT_NE(sheet.find(".odr-sheet thead{display:none}"), std::string::npos);
+  EXPECT_NE(sheet.find(".odr-sheet-gutter{visibility:collapse"),
+            std::string::npos);
+  EXPECT_NE(sheet.find(".odr-sheet{max-width:100%}"), std::string::npos);
+  EXPECT_NE(sheet.find(".odr-sheet col{min-width:0!important}"),
+            std::string::npos);
+}
+
 TEST(html, a_view_that_renders_no_sheet_has_no_cut) {
   const DecodedFile file(File::from_memory("<a><b>c</b></a>"), FileType::xml);
   const HtmlService service = html::translate(file, HtmlConfig());


### PR DESCRIPTION
🤖 Generated with [Claude Code](https://claude.com/claude-code)

The first, self-contained part of #816: the sheet is fitted to the paper it is printed on, and the ruler stays off it. Print only — no public API, no parser, no change to what the screen shows.

## Why

`translate_sheet` writes one `<col>` per column carrying the document's own width as `width` and `min-width`, under `table-layout:fixed`, so the table is exactly as wide as the file says. On screen that is right, and the viewport fit hides it. On paper nothing relates it to the page: the only `@media print` rule we ship pins the zoom back to actual size, correctly, and nothing fits the sheet afterwards. What is left is the browser's own shrink-to-fit — silent when it gives up, bounded, and different per browser and print path. A desktop dialog has a scale control on top of it; the Android print framework offers the user none, which is the asymmetry in opendocument-app/OpenDocument.droid#644.

The ruler makes it worse: the gutter and the `<thead>` of column letters are ours, not the file's, and a spreadsheet application prints neither.

## What it does

```css
@media print{
.odr-sheet thead{display:none}
.odr-sheet-gutter{visibility:collapse;width:0}
.odr-sheet-row-header{visibility:collapse;padding:0;box-shadow:none}
.odr-sheet{max-width:100%}
.odr-sheet col{min-width:0!important}
}
```

- `max-width` fits the sheet to the page box; `!important` is what beats the width written inline per column. A sheet narrower than the page is untouched — `max-width` only bites above it.
- The gutter **collapses** rather than `display:none`: removing those cells takes them out of their rows and shifts every column one to the left, which I measured before settling on this. The cells state `visibility:collapse` too, for a browser that collapses no column.

## Measured

Chrome headless `--print-to-pdf`, Letter, text recovered with `gs -sDEVICE=txtwrite`. A 12-column × 1.5in sheet rendered by `translate` from a flat ODF:

| | columns printed |
|---|---|
| before | 8 of 12 |
| after | **12 of 12** |

`odr-public/ods/file_example_ODS_10.ods` (7.50in incl. ruler, fits today): identical printed text before and after **except** the ruler's letters and numbers — no cell gained or lost.

Across widths, on the same markup:

| column width (8 columns) | today | ruler off | this PR |
|---|---|---|---|
| 0.95in | 8/8 | 8/8 | 8/8 |
| 1.6in | 7/8 | 8/8 | 8/8 |
| 3in | 4/8 | 5/8 | 8/8 |

So dropping the ruler alone buys about one column of width and is not a fix by itself, as #816 says.

## What it does not do

The fit is a shrink, not what a spreadsheet application does. Columns narrow toward, but not below, their content, so relative widths compress rather than scale: at 8 × 3in on Letter every column comes out equal. A very wide sheet prints small rather than paginating column-wise. Honouring the file's page style — paper, orientation, fit-to-pages, print ranges, repeated headers — needs `Sheet::page_layout()`, which does not exist, and column-wise pagination needs slices html cannot express for a table. #816 stays open for that decision.

`visibility:collapse` on a `<col>` is verified in Blink; WebKit is the untested half, and the `width:0` plus the cells' own `visibility` are the fallback for a browser that only hides the column.

## Reference output

Unchanged, and no pin moves. The suite renders with `embed_shipped_resources = false`, so the stylesheet lives in `resources/` — which the CI comparison does not cover; it compares `output/`, and a print-only rule moves no screen pixel there.

## Test

`html.a_printed_sheet_drops_the_ruler_and_fits_the_page` renders an `.ods` and checks the print rules are emitted and the screen ones — the inline column widths, `table-layout:fixed`, the ruler markup — are still there.
