### PR TITLE
feat(document): fit a printed sheet to the paper the file states

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,13 @@ The release run heads these entries with the version and opens a fresh
 
 ## Unreleased
 
+- New `Sheet::page_layout()`: the paper an ods states for a sheet, read from
+  the master page its table style names. Mirrored in the Python, JNI and Apple
+  bindings. Empty for xlsx, xls, numbers and csv.
+
+- A printed sheet is fitted to the paper the file states, at the file's own
+  column proportions. Towards #816.
+
 - A right-to-left document renders right-to-left. `style:writing-mode`,
   `w:bidi` and `a:pPr@rtl` are read into a new `TextDirection` on
   `ParagraphStyle` and `PageLayout`, and the view's root carries it as

--- a/apple/include/OdrCoreObjC/ODRDocumentElement.h
+++ b/apple/include/OdrCoreObjC/ODRDocumentElement.h
@@ -117,6 +117,8 @@ NS_SWIFT_NAME(Slide)
 NS_SWIFT_NAME(Sheet)
 @interface ODRSheet : ODRElement
 @property(nonatomic, readonly, copy) NSString *name;
+/// The paper the sheet is printed on, where the file states one.
+@property(nonatomic, readonly) ODRPageLayout *pageLayout;
 @property(nonatomic, readonly) ODRTableDimensions dimensions;
 /// The dimensions actually filled with content, optionally within `range`.
 - (ODRTableDimensions)contentDimensions NS_SWIFT_NAME(contentDimensions());

--- a/apple/src/ODRDocumentElement.mm
+++ b/apple/src/ODRDocumentElement.mm
@@ -308,6 +308,15 @@ NSArray<ODRElement *> *to_nsarray(ODRElement *const source,
       [&] { return to_nsstring(self.handle.as_sheet().name()); }, @"");
 }
 
+- (ODRPageLayout *)pageLayout {
+  return guarded_value(
+      [&]() -> ODRPageLayout * {
+        return [ODRPageLayout
+            layoutWithHandle:self.handle.as_sheet().page_layout()];
+      },
+      nil);
+}
+
 - (ODRTableDimensions)dimensions {
   return guarded_value(
       [&] { return to_dimensions(self.handle.as_sheet().dimensions()); },

--- a/jni/java/app/opendocument/core/Sheet.java
+++ b/jni/java/app/opendocument/core/Sheet.java
@@ -12,6 +12,11 @@ public final class Sheet extends Element {
     return nameNative(handle());
   }
 
+  /** The paper the sheet is printed on, where the file states one. */
+  public PageLayout pageLayout() {
+    return pageLayoutNative(handle());
+  }
+
   public TableDimensions dimensions() {
     return dimensionsNative(handle());
   }
@@ -50,6 +55,8 @@ public final class Sheet extends Element {
   }
 
   private native String nameNative(long handle);
+
+  private native PageLayout pageLayoutNative(long handle);
 
   private native TableDimensions dimensionsNative(long handle);
 

--- a/jni/src/jni_document.cpp
+++ b/jni/src/jni_document.cpp
@@ -396,6 +396,15 @@ Java_app_opendocument_core_Sheet_nameNative(JNIEnv *env, jobject,
 }
 
 extern "C" JNIEXPORT jobject JNICALL
+Java_app_opendocument_core_Sheet_pageLayoutNative(JNIEnv *env, jobject,
+                                                  jlong handle) {
+  return guarded(env, [&] {
+    return odr_jni::make_page_layout(env,
+                                     element(handle).as_sheet().page_layout());
+  });
+}
+
+extern "C" JNIEXPORT jobject JNICALL
 Java_app_opendocument_core_Sheet_dimensionsNative(JNIEnv *env, jobject,
                                                   jlong handle) {
   return guarded(env, [&] {

--- a/python/src/bind_document.cpp
+++ b/python/src/bind_document.cpp
@@ -191,6 +191,7 @@ void odr_python::bind_document(py::module_ &m) {
 
   bind_element<odr::Sheet>(m, "Sheet")
       .def("name", &odr::Sheet::name)
+      .def("page_layout", &odr::Sheet::page_layout)
       .def("dimensions", &odr::Sheet::dimensions)
       .def("content", &odr::Sheet::content, py::arg("range"))
       .def("cell", &odr::Sheet::cell, py::arg("column"), py::arg("row"),

--- a/src/odr/document_element.cpp
+++ b/src/odr/document_element.cpp
@@ -327,6 +327,10 @@ std::string Sheet::name() const {
   return exists_() ? m_adapter2->sheet_name(m_identifier) : "";
 }
 
+PageLayout Sheet::page_layout() const {
+  return exists_() ? m_adapter2->sheet_page_layout(m_identifier) : PageLayout();
+}
+
 TableDimensions Sheet::dimensions() const {
   return exists_() ? m_adapter2->sheet_dimensions(m_identifier)
                    : TableDimensions();

--- a/src/odr/document_element.hpp
+++ b/src/odr/document_element.hpp
@@ -312,6 +312,9 @@ public:
 
   [[nodiscard]] std::string name() const;
 
+  /// The paper the sheet is meant to be printed on, where the file states one.
+  [[nodiscard]] PageLayout page_layout() const;
+
   [[nodiscard]] TableDimensions dimensions() const;
   [[nodiscard]] TableDimensions
   content(std::optional<TableDimensions> range) const;

--- a/src/odr/internal/abstract/document.hpp
+++ b/src/odr/internal/abstract/document.hpp
@@ -258,6 +258,10 @@ public:
   [[nodiscard]] virtual std::string
   sheet_name(ElementIdentifier element_id) const = 0;
 
+  /// Empty where the file states no paper.
+  [[nodiscard]] virtual PageLayout
+  sheet_page_layout(ElementIdentifier element_id) const = 0;
+
   [[nodiscard]] virtual TableDimensions
   sheet_dimensions(ElementIdentifier element_id) const = 0;
   [[nodiscard]] virtual TableDimensions

--- a/src/odr/internal/csv/csv_document.cpp
+++ b/src/odr/internal/csv/csv_document.cpp
@@ -160,6 +160,10 @@ public:
       [[maybe_unused]] const ElementIdentifier element_id) const override {
     return "csv";
   }
+  [[nodiscard]] PageLayout sheet_page_layout(
+      [[maybe_unused]] const ElementIdentifier element_id) const override {
+    return {};
+  }
   [[nodiscard]] TableDimensions sheet_dimensions(
       [[maybe_unused]] const ElementIdentifier element_id) const override {
     return m_document->dimensions();

--- a/src/odr/internal/html/document_element.cpp
+++ b/src/odr/internal/html/document_element.cpp
@@ -183,6 +183,40 @@ TableDimensions html::sheet_rendered_extent(const Sheet &sheet,
   return {end_row, end_column};
 }
 
+namespace {
+
+/// How far a sheet has to shrink to fit the paper the file states; nothing
+/// where it fits already, or where no width is stated.
+std::optional<double> sheet_print_fit(const Sheet &sheet,
+                                      const std::uint32_t end_column) {
+  const PageLayout page_layout = sheet.page_layout();
+  const std::optional<double> page = html::css_pixels(page_layout.width);
+  if (!page.has_value()) {
+    return {};
+  }
+  const double printable =
+      *page - html::css_pixels(page_layout.margin.left).value_or(0) -
+      html::css_pixels(page_layout.margin.right).value_or(0);
+
+  // the ruler does not print
+  double content = 0;
+  for (std::uint32_t column = 0; column < end_column; ++column) {
+    const std::optional<double> width =
+        html::css_pixels(sheet.column_style(column).width);
+    if (!width.has_value()) {
+      return {};
+    }
+    content += *width;
+  }
+
+  if (printable <= 0 || content <= printable) {
+    return {};
+  }
+  return printable / content;
+}
+
+} // namespace
+
 std::optional<HtmlSheetCut> html::sheet_cut(const Sheet &sheet,
                                             const HtmlConfig &config) {
   const TableDimensions rendered = sheet_rendered_extent(sheet, config);
@@ -199,12 +233,24 @@ std::optional<HtmlSheetCut> html::sheet_cut(const Sheet &sheet,
 }
 
 void html::translate_sheet(const Sheet &sheet, const WritingState &state) {
-  state.out().write_element_begin("table",
-                                  HtmlElementOptions().set_class("odr-sheet"));
-
   const TableDimensions rendered = sheet_rendered_extent(sheet, state.config());
   const std::uint32_t end_column = rendered.columns;
   const std::uint32_t end_row = rendered.rows;
+
+  const std::optional<double> print_fit = sheet_print_fit(sheet, end_column);
+
+  state.out().write_element_begin(
+      "table", HtmlElementOptions()
+                   .set_class("odr-sheet")
+                   .set_style([&]() -> std::optional<HtmlWritable> {
+                     if (!print_fit.has_value()) {
+                       return std::nullopt;
+                     }
+                     // `Measure` renders no exponent form
+                     return "--odr-print-fit:" +
+                            Measure(*print_fit, DynamicUnit()).to_string() +
+                            ";";
+                   }()));
 
   state.out().write_element_begin("col",
                                   HtmlElementOptions()

--- a/src/odr/internal/html/frontend.cpp
+++ b/src/odr/internal/html/frontend.cpp
@@ -112,15 +112,15 @@ body{margin:0;background:var(--odr-sheet-canvas)}
 .odr-sheet-sort:hover{background:var(--odr-sheet-wash-ruler)}
 .odr-sheet-sort::after{content:"\25BE";font-size:15px;line-height:1}
 .odr-sheet-sort-asc::after{content:"\25B4"}
-/* Paper cannot scroll, so a sheet wider than the page is cut off; only
-   `!important` beats the inline column width. The ruler collapses rather than
-   `display:none`, which would take the cells out of their rows and shift every
-   column left. */
+/* `--odr-print-fit` is written per sheet by `translate_sheet`; `zoom` keeps
+   the rows breaking across pages. Only `!important` beats the inline column
+   width. The ruler collapses rather than `display:none`, which would take the
+   cells out of their rows and shift every column left. */
 @media print{
 .odr-sheet thead{display:none}
 .odr-sheet-gutter{visibility:collapse;width:0}
 .odr-sheet-row-header{visibility:collapse;padding:0;box-shadow:none}
-.odr-sheet{max-width:100%}
+.odr-sheet{zoom:var(--odr-print-fit,1);max-width:100%}
 .odr-sheet col{min-width:0!important}
 }
 )css";

--- a/src/odr/internal/iwork/iwork_document.cpp
+++ b/src/odr/internal/iwork/iwork_document.cpp
@@ -209,6 +209,11 @@ public:
   sheet_name(const ElementIdentifier element_id) const override {
     return m_registry->sheet_element_at(element_id).name;
   }
+  /// TODO the print setup of a `.numbers` sheet is not read.
+  [[nodiscard]] PageLayout sheet_page_layout(
+      [[maybe_unused]] const ElementIdentifier element_id) const override {
+    return {};
+  }
   [[nodiscard]] TableDimensions
   sheet_dimensions(const ElementIdentifier element_id) const override {
     const ElementRegistry::Sheet &sheet =

--- a/src/odr/internal/odf/odf_document.cpp
+++ b/src/odr/internal/odf/odf_document.cpp
@@ -460,6 +460,21 @@ public:
   sheet_name(const ElementIdentifier element_id) const override {
     return get_node(element_id).attribute("table:name").value();
   }
+  [[nodiscard]] PageLayout
+  sheet_page_layout(const ElementIdentifier element_id) const override {
+    // The table style names the master page (20.383); a sheet that names none
+    // takes the first.
+    ElementIdentifier master_page_id =
+        m_document->style_registry().master_page_of_style(
+            get_node(element_id).attribute("table:style-name").value());
+    if (master_page_id == null_element_id) {
+      master_page_id = m_document->style_registry().first_master_page();
+    }
+    if (master_page_id == null_element_id) {
+      return {};
+    }
+    return master_page_page_layout(master_page_id);
+  }
   [[nodiscard]] TableDimensions
   sheet_dimensions(const ElementIdentifier element_id) const override {
     return m_registry->sheet_element_at(element_id).dimensions;

--- a/src/odr/internal/oldms/spreadsheet/xls_document.cpp
+++ b/src/odr/internal/oldms/spreadsheet/xls_document.cpp
@@ -123,6 +123,11 @@ public:
   sheet_name(const ElementIdentifier element_id) const override {
     return m_registry->sheet_element_at(element_id).name;
   }
+  /// TODO `SETUP` ([MS-XLS] 2.4.257) is not read.
+  [[nodiscard]] PageLayout sheet_page_layout(
+      [[maybe_unused]] const ElementIdentifier element_id) const override {
+    return {};
+  }
   [[nodiscard]] TableDimensions
   sheet_dimensions(const ElementIdentifier element_id) const override {
     return m_registry->sheet_element_at(element_id).dimensions;

--- a/src/odr/internal/ooxml/spreadsheet/ooxml_spreadsheet_document.cpp
+++ b/src/odr/internal/ooxml/spreadsheet/ooxml_spreadsheet_document.cpp
@@ -184,6 +184,11 @@ public:
   sheet_name(const ElementIdentifier element_id) const override {
     return m_registry->sheet_element_at(element_id).name;
   }
+  /// TODO `pageSetup` is not read; a column width here is a `ch` either way.
+  [[nodiscard]] PageLayout sheet_page_layout(
+      [[maybe_unused]] const ElementIdentifier element_id) const override {
+    return {};
+  }
   [[nodiscard]] TableDimensions
   sheet_dimensions(const ElementIdentifier element_id) const override {
     return m_registry->sheet_element_at(element_id).dimensions;

--- a/test/src/document_test.cpp
+++ b/test/src/document_test.cpp
@@ -136,6 +136,43 @@ TEST(Document, docx_page_layout) {
   EXPECT_EQ(Measure("1in"), page_layout.margin.left);
 }
 
+// #816
+TEST(Document, ods_sheet_page_layout) {
+  const Logger logger = Logger::create_stdio("odr-test", LogLevel::verbose);
+
+  const DocumentFile document_file(
+      TestData::test_file_path("odr-public/ods/file_example_ODS_100.ods"),
+      logger);
+
+  const Document document = document_file.document();
+  const PageLayout page_layout =
+      (*document.root_element().children().begin()).as_sheet().page_layout();
+  EXPECT_EQ(Measure("8.2681in"), page_layout.width);
+  EXPECT_EQ(Measure("11.6929in"), page_layout.height);
+  EXPECT_EQ(PrintOrientation::portrait, page_layout.print_orientation);
+  EXPECT_EQ(Measure("0.7874in"), page_layout.margin.top);
+  EXPECT_EQ(Measure("0.7874in"), page_layout.margin.right);
+  EXPECT_EQ(Measure("0.7874in"), page_layout.margin.bottom);
+  EXPECT_EQ(Measure("0.7874in"), page_layout.margin.left);
+}
+
+// Producers commonly state margins only and leave the paper to the printer.
+TEST(Document, ods_sheet_page_layout_without_a_paper_size) {
+  const Logger logger = Logger::create_stdio("odr-test", LogLevel::verbose);
+
+  const DocumentFile document_file(
+      TestData::test_file_path("odr-public/ods/file_example_ODS_10.ods"),
+      logger);
+
+  const Document document = document_file.document();
+  const PageLayout page_layout =
+      (*document.root_element().children().begin()).as_sheet().page_layout();
+
+  EXPECT_FALSE(page_layout.width.has_value());
+  EXPECT_FALSE(page_layout.height.has_value());
+  EXPECT_EQ(Measure("0.7874in"), page_layout.margin.left);
+}
+
 TEST(Document, xlsx_sheet_names) {
   const Logger logger = Logger::create_stdio("odr-test", LogLevel::verbose);
 

--- a/test/src/html_test.cpp
+++ b/test/src/html_test.cpp
@@ -741,9 +741,80 @@ TEST(html, a_printed_sheet_drops_the_ruler_and_fits_the_page) {
   EXPECT_NE(sheet.find(".odr-sheet thead{display:none}"), std::string::npos);
   EXPECT_NE(sheet.find(".odr-sheet-gutter{visibility:collapse"),
             std::string::npos);
-  EXPECT_NE(sheet.find(".odr-sheet{max-width:100%}"), std::string::npos);
+  EXPECT_NE(
+      sheet.find(".odr-sheet{zoom:var(--odr-print-fit,1);max-width:100%}"),
+      std::string::npos);
   EXPECT_NE(sheet.find(".odr-sheet col{min-width:0!important}"),
             std::string::npos);
+}
+
+namespace {
+
+/// The print fit the sheet states, or nothing where it states none.
+std::optional<double> print_fit_of(const std::string &page) {
+  constexpr std::string_view key = "--odr-print-fit:";
+  const std::size_t at = page.find(key);
+  if (at == std::string::npos) {
+    return {};
+  }
+  return std::stod(page.substr(at + key.length()));
+}
+
+} // namespace
+
+// #816
+TEST(html, a_sheet_is_fitted_to_the_paper_the_file_states) {
+  // 8 columns of 0.889in against A4 less 0.7874in margins
+  const std::optional<double> fit = print_fit_of(
+      render("odr-public/ods/file_example_ODS_100.ods", HtmlConfig()));
+  ASSERT_TRUE(fit.has_value());
+  EXPECT_NEAR((8.2681 - 2 * 0.7874) / (8 * 0.889), *fit, 1e-4);
+}
+
+// Without a stated paper there is nothing to fit against.
+TEST(html, a_sheet_that_states_no_paper_states_no_fit) {
+  EXPECT_FALSE(print_fit_of(render("odr-public/ods/file_example_ODS_10.ods",
+                                   HtmlConfig()))
+                   .has_value());
+}
+
+namespace {
+
+/// A one-column flat ods on 8.5in paper with 1in margins.
+std::string flat_ods_sheet(const std::string &width) {
+  return R"(<?xml version="1.0" encoding="UTF-8"?>
+<office:document xmlns:office="urn:oasis:names:tc:opendocument:xmlns:office:1.0" xmlns:style="urn:oasis:names:tc:opendocument:xmlns:style:1.0" xmlns:table="urn:oasis:names:tc:opendocument:xmlns:table:1.0" xmlns:text="urn:oasis:names:tc:opendocument:xmlns:text:1.0" xmlns:fo="urn:oasis:names:tc:opendocument:xmlns:xsl-fo-compatible:1.0" office:version="1.2" office:mimetype="application/vnd.oasis.opendocument.spreadsheet">
+<office:automatic-styles>
+<style:page-layout style:name="pm1"><style:page-layout-properties fo:page-width="8.5in" fo:page-height="11in" fo:margin-top="1in" fo:margin-bottom="1in" fo:margin-left="1in" fo:margin-right="1in"/></style:page-layout>
+<style:style style:name="co1" style:family="table-column"><style:table-column-properties style:column-width=")" +
+         width + R"("/></style:style>
+<style:style style:name="ta1" style:family="table" style:master-page-name="Paper"/>
+</office:automatic-styles>
+<office:master-styles><style:master-page style:name="Paper" style:page-layout-name="pm1"/></office:master-styles>
+<office:body><office:spreadsheet><table:table table:name="Sheet" table:style-name="ta1">
+<table:table-column table:style-name="co1"/>
+<table:table-row><table:table-cell office:value-type="string"><text:p>a</text:p></table:table-cell></table:table-row>
+</table:table></office:spreadsheet></office:body></office:document>)";
+}
+
+std::optional<double> flat_ods_fit(const std::string &width) {
+  const DecodedFile file(File::from_memory(flat_ods_sheet(width)),
+                         FileType::opendocument_spreadsheet);
+  std::ostringstream out;
+  html::translate(file, HtmlConfig()).list_views().at(0).write_html(out);
+  return print_fit_of(std::move(out).str());
+}
+
+} // namespace
+
+// The printable width is 6.5in.
+TEST(html, a_sheet_is_only_ever_fitted_down) {
+  EXPECT_FALSE(flat_ods_fit("3in").has_value());
+  EXPECT_FALSE(flat_ods_fit("6.5in").has_value());
+
+  const std::optional<double> wide = flat_ods_fit("13in");
+  ASSERT_TRUE(wide.has_value());
+  EXPECT_NEAR(0.5, *wide, 1e-6);
 }
 
 TEST(html, a_view_that_renders_no_sheet_has_no_cut) {


### PR DESCRIPTION
🤖 Generated with [Claude Code](https://claude.com/claude-code)

**Stacked on #817** — review that first; this branch contains it.

The second part of #816: the file's own paper reaches the printed page. #817 fits the sheet to whatever paper it lands on, by capping the table's width — which never clips, but squeezes the column widths unevenly. This reads the paper the file states and scales the sheet by it, so the printed sheet keeps the proportions the document has.

## What was missing

`Sheet` had no page layout, and no engine parsed one. The paper, orientation and margins an ods states for a sheet live on the master page its *table style* names — the same indirection a paragraph's page uses, and `StyleRegistry::master_page_of_style` already walked it for text roots, slides and drawing pages. Nothing asked it for a sheet.

## What this adds

- **`Sheet::page_layout()`** — new on the public API, a new virtual on `abstract::SheetAdapter`, implemented by all five engines that provide sheets, and mirrored in the Python, JNI and Apple bindings (wasm binds no document elements). Real for ods; empty, with the reason, for xlsx, xls, `.numbers` and csv.
- **`translate_sheet` states the factor** the paper asks for, per sheet, as `--odr-print-fit` on the sheet's own table: the printable width (page less its side margins) over the sum of the column widths. Only ever down — a sheet that already fits is printed at its size, never enlarged.
- **The print stylesheet applies it** as `zoom`, which scales the layout, so rows still break across pages. #817's `max-width` cap stays behind it, as the guard for paper the file did not expect.

## Measured

A 6-column sheet of `3in,1in,3in,1in,3in,1in` on Letter with 1in margins, rendered by `translate`, printed with Chrome headless, columns measured from the PDF text positions:

| | printed column widths | ratio (file says 3:1) | type size |
|---|---|---|---|
| #817's cap alone | 127, 54, 128, 54, 127 pt | 2.35 : 1 | 10pt |
| with the fit | 117, 39, 117, 39, 117 pt | **3.00 : 1** | 5.4pt |

117pt is 216pt × 0.5417, and 0.5417 is exactly the 6.5in printable width over the 12in the sheet is wide — so the sheet prints at the scale the file's paper implies, undistorted.

## What it does not do

**Half the corpus states no paper.** 22 of the 52 ods here carry `fo:page-width`; the rest state margins only and leave the paper to the printer. Those get no factor and keep #817's behaviour exactly. Reading a frontend-supplied paper from `HtmlConfig` — the Android side knows its `PrintAttributes` — is the obvious next increment, and would cover them.

**No `@page` rule.** Declaring the file's paper to the printer would want one, but a print path that honours CSS page size over the framework's own attributes has to be established per frontend first, and a view that renders several sheets has several answers. Left out deliberately.

**xlsx is not wired up**, and its `pageSetup` alone would buy nothing: a column width there is a `ch`, so no absolute content width can be summed to compare against the paper. Both halves are one follow-up.

Pagination — a wide sheet continuing onto further pages at full size, the way a spreadsheet application prints it — remains the open half of #816.

## Tests

`Document.ods_sheet_page_layout` reads the paper off a real ods; `Document.ods_sheet_page_layout_without_a_paper_size` pins the common margins-only case. On the renderer, `html.a_sheet_is_fitted_to_the_paper_the_file_states` checks the factor against the file's numbers, and `html.a_sheet_is_only_ever_fitted_down` drives three inline flat-ods sheets — narrower than, exactly, and twice its paper.

Reference output is unchanged in what it renders: the new attribute is inert outside print, so no pixel moves and no pin advances.
