### PR TITLE
perf(html): stop a sheet repeating itself, and keep a cell's text on one line

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,15 @@ The release run heads these entries with the version and opens a fresh
   had set a global locale with a comma decimal separator. Adds a `fmt`
   dependency.
 
+- A sheet cell keeps its text on one line unless the file says to wrap it, read
+  into a new `TableCellStyle::wrap_text`. A line too long for its cell spills
+  over the empty cells beside it and is cut where the next has content. #238
+
+- A spreadsheet view writes far less html for the same rendering: repeated style
+  blocks become classes, and a plain cell drops the run around it. The register
+  file's 500,000 cells fall from 121 MB to 38 MB. New
+  `HtmlConfig::spreadsheet_style_buffer`. #822
+
 - New `Sheet::page_layout()`: the paper an ods states for a sheet, read from
   the master page its table style names. Mirrored in the Python, JNI and Apple
   bindings. Empty for xlsx, xls, numbers and csv.

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -156,6 +156,7 @@ set(ODR_SOURCE_FILES
         "src/odr/internal/html/image_file.cpp"
         "src/odr/internal/html/media_file.cpp"
         "src/odr/internal/html/pdf_file.cpp"
+        "src/odr/internal/html/style_registry.cpp"
         "src/odr/internal/html/text_file.cpp"
         "src/odr/internal/html/xml_file.cpp"
 

--- a/apple/include/OdrCoreObjC/ODRHtml.h
+++ b/apple/include/OdrCoreObjC/ODRHtml.h
@@ -96,6 +96,9 @@ NS_SWIFT_NAME(HtmlConfig)
     NSNumber *spreadsheetCellLimit NS_REFINED_FOR_SWIFT;
 @property(nonatomic) BOOL spreadsheetLimitByContent;
 @property(nonatomic) ODRHtmlTableGridlines spreadsheetGridlines;
+/// How much of a sheet's body is held back while `<head>` collects the classes
+/// its cells name.
+@property(nonatomic) unsigned long long spreadsheetStyleBuffer;
 
 @property(nonatomic) ODRHtmlViewportMode viewportMode;
 /// Overrides `viewportMode` for spreadsheets when set.

--- a/apple/include/OdrCoreObjC/ODRStyle.h
+++ b/apple/include/OdrCoreObjC/ODRStyle.h
@@ -227,6 +227,8 @@ NS_SWIFT_NAME(TableCellStyle)
 @property(nonatomic, readonly) ODRDirectionalString *border;
 /// `double`, boxed.
 @property(nonatomic, readonly, nullable) NSNumber *textRotation;
+/// `BOOL`, boxed.
+@property(nonatomic, readonly, nullable) NSNumber *wrapText;
 
 - (instancetype)init NS_UNAVAILABLE;
 + (instancetype)new NS_UNAVAILABLE;

--- a/apple/src/ODRHtml.mm
+++ b/apple/src/ODRHtml.mm
@@ -104,6 +104,8 @@ std::vector<std::string> to_strings(NSArray<NSString *> *strings) {
   _spreadsheetLimitByContent = config.spreadsheet_limit_by_content ? YES : NO;
   _spreadsheetGridlines =
       static_cast<ODRHtmlTableGridlines>(config.spreadsheet_gridlines);
+  _spreadsheetStyleBuffer =
+      static_cast<unsigned long long>(config.spreadsheet_style_buffer);
   _viewportMode = static_cast<ODRHtmlViewportMode>(config.viewport_mode);
   _spreadsheetViewportMode =
       config.spreadsheet_viewport_mode.has_value()
@@ -176,6 +178,8 @@ std::vector<std::string> to_strings(NSArray<NSString *> *strings) {
   config.spreadsheet_limit_by_content = _spreadsheetLimitByContent == YES;
   config.spreadsheet_gridlines =
       static_cast<odr::HtmlTableGridlines>(_spreadsheetGridlines);
+  config.spreadsheet_style_buffer =
+      static_cast<std::uint64_t>(_spreadsheetStyleBuffer);
   config.viewport_mode = static_cast<odr::HtmlViewportMode>(_viewportMode);
   if (_spreadsheetViewportMode != nil) {
     config.spreadsheet_viewport_mode = static_cast<odr::HtmlViewportMode>(

--- a/apple/src/ODRStyle.mm
+++ b/apple/src/ODRStyle.mm
@@ -276,6 +276,7 @@ NSString *_Nullable box_string(const std::optional<T> &value) {
       [ODRDirectionalMeasure directionalWithHandle:handle.padding];
   result->_border = [ODRDirectionalString directionalWithHandle:handle.border];
   result->_textRotation = box_number(handle.text_rotation);
+  result->_wrapText = box_number(handle.wrap_text);
   return result;
 }
 

--- a/jni/java/app/opendocument/core/HtmlConfig.java
+++ b/jni/java/app/opendocument/core/HtmlConfig.java
@@ -37,6 +37,8 @@ public final class HtmlConfig {
 
   public boolean spreadsheetLimitByContent = true;
   public HtmlTableGridlines spreadsheetGridlines = HtmlTableGridlines.SOFT;
+  /** How much of a sheet's body is held back while the head collects its classes. */
+  public long spreadsheetStyleBuffer = 128L << 20;
 
   /** Initial zoom on mobile. */
   public HtmlViewportMode viewportMode = HtmlViewportMode.AUTOMATIC;

--- a/jni/java/app/opendocument/core/TableCellStyle.java
+++ b/jni/java/app/opendocument/core/TableCellStyle.java
@@ -8,6 +8,7 @@ public final class TableCellStyle {
   public final DirectionalMeasure padding;
   public final DirectionalString border;
   public final Double textRotation;
+  public final Boolean wrapText;
 
   TableCellStyle(
       int horizontalAlign,
@@ -15,12 +16,14 @@ public final class TableCellStyle {
       Color backgroundColor,
       DirectionalMeasure padding,
       DirectionalString border,
-      Double textRotation) {
+      Double textRotation,
+      Boolean wrapText) {
     this.horizontalAlign = HorizontalAlign.fromNative(horizontalAlign);
     this.verticalAlign = VerticalAlign.fromNative(verticalAlign);
     this.backgroundColor = backgroundColor;
     this.padding = padding;
     this.border = border;
     this.textRotation = textRotation;
+    this.wrapText = wrapText;
   }
 }

--- a/jni/src/jni_style.cpp
+++ b/jni/src/jni_style.cpp
@@ -310,12 +310,13 @@ jobject make_table_cell_style(JNIEnv *env, const odr::TableCellStyle &style) {
       env, "app/opendocument/core/TableCellStyle",
       "(IILapp/opendocument/core/Color;"
       "Lapp/opendocument/core/DirectionalMeasure;"
-      "Lapp/opendocument/core/DirectionalString;Ljava/lang/Double;)V",
+      "Lapp/opendocument/core/DirectionalString;Ljava/lang/Double;"
+      "Ljava/lang/Boolean;)V",
       enum_code(style.horizontal_align), enum_code(style.vertical_align),
       make_color(env, style.background_color),
       make_directional_measure(env, style.padding),
       make_directional_string(env, style.border),
-      box_double(env, style.text_rotation));
+      box_double(env, style.text_rotation), box_boolean(env, style.wrap_text));
 }
 
 jobject make_graphic_style(JNIEnv *env, const odr::GraphicStyle &style) {
@@ -421,6 +422,9 @@ jobject html_config_to_java(JNIEnv *env, const odr::HtmlConfig &config) {
   const auto set_double = [&](const char *name, const double value) {
     env->SetDoubleField(result, env->GetFieldID(cls, name, "D"), value);
   };
+  const auto set_long = [&](const char *name, const jlong value) {
+    env->SetLongField(result, env->GetFieldID(cls, name, "J"), value);
+  };
   const auto set_object = [&](const char *name, const char *signature,
                               jobject value) {
     env->SetObjectField(result, env->GetFieldID(cls, name, signature), value);
@@ -446,6 +450,8 @@ jobject html_config_to_java(JNIEnv *env, const odr::HtmlConfig &config) {
   set_object("spreadsheetCellLimit", "Ljava/lang/Long;",
              box_long(env, config.spreadsheet_cell_limit));
   set_boolean("spreadsheetLimitByContent", config.spreadsheet_limit_by_content);
+  set_long("spreadsheetStyleBuffer",
+           static_cast<jlong>(config.spreadsheet_style_buffer));
   set_object("spreadsheetGridlines",
              "Lapp/opendocument/core/HtmlTableGridlines;",
              enum_from_code(env, "app/opendocument/core/HtmlTableGridlines",
@@ -538,6 +544,9 @@ odr::HtmlConfig html_config_from_java(JNIEnv *env, jobject config) {
   const auto get_double = [&](const char *name) {
     return env->GetDoubleField(config, env->GetFieldID(cls, name, "D"));
   };
+  const auto get_long = [&](const char *name) {
+    return env->GetLongField(config, env->GetFieldID(cls, name, "J"));
+  };
   const auto get_object = [&](const char *name, const char *signature) {
     return env->GetObjectField(config, env->GetFieldID(cls, name, signature));
   };
@@ -592,6 +601,8 @@ odr::HtmlConfig html_config_from_java(JNIEnv *env, jobject config) {
       env->DeleteLocalRef(long_cls);
     }
   }
+  result.spreadsheet_style_buffer =
+      static_cast<std::uint64_t>(get_long("spreadsheetStyleBuffer"));
   result.spreadsheet_limit_by_content =
       get_boolean("spreadsheetLimitByContent");
   {

--- a/python/src/bind_html.cpp
+++ b/python/src/bind_html.cpp
@@ -89,6 +89,8 @@ void odr_python::bind_html(py::module_ &m) {
                      &odr::HtmlConfig::spreadsheet_limit_by_content)
       .def_readwrite("spreadsheet_gridlines",
                      &odr::HtmlConfig::spreadsheet_gridlines)
+      .def_readwrite("spreadsheet_style_buffer",
+                     &odr::HtmlConfig::spreadsheet_style_buffer)
       .def_readwrite("viewport_mode", &odr::HtmlConfig::viewport_mode)
       .def_readwrite("spreadsheet_viewport_mode",
                      &odr::HtmlConfig::spreadsheet_viewport_mode)

--- a/python/src/bind_style.cpp
+++ b/python/src/bind_style.cpp
@@ -186,7 +186,8 @@ void odr_python::bind_style(py::module_ &m) {
       .def_readwrite("background_color", &odr::TableCellStyle::background_color)
       .def_readwrite("padding", &odr::TableCellStyle::padding)
       .def_readwrite("border", &odr::TableCellStyle::border)
-      .def_readwrite("text_rotation", &odr::TableCellStyle::text_rotation);
+      .def_readwrite("text_rotation", &odr::TableCellStyle::text_rotation)
+      .def_readwrite("wrap_text", &odr::TableCellStyle::wrap_text);
 
   py::class_<odr::GraphicStyle>(m, "GraphicStyle")
       .def(py::init<>())

--- a/src/odr/html.hpp
+++ b/src/odr/html.hpp
@@ -148,6 +148,10 @@ struct HtmlConfig {
   bool spreadsheet_limit_by_content{true};
   /// Which gridlines a sheet paints.
   HtmlTableGridlines spreadsheet_gridlines{HtmlTableGridlines::soft};
+  /// How much of a sheet's body is held back while `<head>` collects the
+  /// classes its cells name. Past it the head goes out with what it has, and a
+  /// style block first seen later stays inline.
+  std::uint64_t spreadsheet_style_buffer{128u << 20};
 
   /// The zoom the view opens at; see @ref HtmlViewportMode.
   HtmlViewportMode viewport_mode{HtmlViewportMode::automatic};

--- a/src/odr/internal/html/common.hpp
+++ b/src/odr/internal/html/common.hpp
@@ -24,16 +24,21 @@ class File;
 
 namespace odr::internal::html {
 
+class StyleRegistry;
+
 struct WritingState {
   WritingState(HtmlWriter &out, const HtmlConfig &config,
-               HtmlResources &resources, const Logger &logger)
+               HtmlResources &resources, const Logger &logger,
+               StyleRegistry *styles = nullptr)
       : m_out{&out}, m_config{&config}, m_resources(&resources),
-        m_logger{&logger} {}
+        m_logger{&logger}, m_styles{styles} {}
 
   [[nodiscard]] HtmlWriter &out() const { return *m_out; }
   [[nodiscard]] const HtmlConfig &config() const { return *m_config; }
   [[nodiscard]] HtmlResources &resources() const { return *m_resources; }
   [[nodiscard]] const Logger &logger() const { return *m_logger; }
+  /// Where repeated style blocks are deduplicated, or null where they are not.
+  [[nodiscard]] StyleRegistry *styles() const { return m_styles; }
 
   /// The view's base direction, stated on its root.
   [[nodiscard]] TextDirection direction() const { return m_direction; }
@@ -44,6 +49,7 @@ private:
   const HtmlConfig *m_config;
   HtmlResources *m_resources;
   const Logger *m_logger;
+  StyleRegistry *m_styles;
   TextDirection m_direction{TextDirection::left_to_right};
 };
 

--- a/src/odr/internal/html/document.cpp
+++ b/src/odr/internal/html/document.cpp
@@ -15,6 +15,8 @@
 #include <odr/internal/html/frontend.hpp>
 #include <odr/internal/html/html_service.hpp>
 #include <odr/internal/html/html_writer.hpp>
+#include <odr/internal/html/style_registry.hpp>
+#include <odr/internal/util/stream_util.hpp>
 #include <odr/internal/util/string_util.hpp>
 
 #include <algorithm>
@@ -151,16 +153,13 @@ viewport_mode_override(const Document &document, const HtmlConfig &config) {
              : std::nullopt;
 }
 
-/// @p name titles the view; empty when the whole document is written as one
-/// file, which no one view names.
-void front(const Document &document, WritingState &state,
-           const std::string &name,
-           const std::optional<double> content_pixels) {
+/// @p name titles the view; empty for the file that holds every view.
+void write_head(const Document &document, const WritingState &state,
+                const std::string &name,
+                const std::optional<double> content_pixels) {
   HtmlWriter &out = state.out();
 
   const bool paged_content = is_paged_content(document, state.config());
-
-  state.set_direction(document_direction(document));
 
   out.write_begin(HtmlElementOptions().set_attributes(HtmlAttributesVector{
       {"dir", translate_text_direction(state.direction())}}));
@@ -188,8 +187,21 @@ void front(const Document &document, WritingState &state,
     write_spreadsheet_style(state);
     write_spreadsheet_dark_style(state);
   }
+  // Last, after the sheets whose rules they stand in for.
+  if (StyleRegistry *styles = state.styles();
+      styles != nullptr && styles->has_rules()) {
+    out.write_header_style_begin();
+    styles->write_rules(out.out());
+    out.write_header_style_end();
+  }
 
   out.write_header_end();
+}
+
+void write_body_begin(const Document &document, const WritingState &state) {
+  HtmlWriter &out = state.out();
+
+  const bool paged_content = is_paged_content(document, state.config());
 
   std::string body_clazz = "odr-body";
   if (paged_content) {
@@ -217,7 +229,7 @@ void front(const Document &document, WritingState &state,
   }
 }
 
-void back(const Document &document, const WritingState &state) {
+void write_body_end(const Document &document, const WritingState &state) {
   HtmlWriter &out = state.out();
 
   if (is_paged_content(document, state.config())) {
@@ -232,7 +244,53 @@ void back(const Document &document, const WritingState &state) {
   write_viewport_script(state);
 
   out.write_body_end();
+}
+
+/// Writes one view. A spreadsheet's body goes into a buffer so `<head>` can
+/// name the classes its cells use, which one walk cannot do in order.
+template <typename Write>
+HtmlResources
+render(const Document &document, const HtmlConfig &config, const Logger &logger,
+       HtmlWriter &out, const std::string &name,
+       const std::optional<double> content_pixels, Write &&write) {
+  HtmlResources resources;
+
+  const auto body = [&](const WritingState &state) {
+    write_body_begin(document, state);
+    write(state);
+    write_body_end(document, state);
+  };
+
+  if (document.document_type() != DocumentType::spreadsheet) {
+    WritingState state(out, config, resources, logger);
+    state.set_direction(document_direction(document));
+    write_head(document, state, name, content_pixels);
+    body(state);
+    out.write_end();
+    return resources;
+  }
+
+  StyleRegistry styles;
+  WritingState head_state(out, config, resources, logger, &styles);
+  head_state.set_direction(document_direction(document));
+
+  util::stream::DeferredBuffer buffer(
+      out.out(), static_cast<std::size_t>(config.spreadsheet_style_buffer),
+      [&] {
+        styles.close();
+        write_head(document, head_state, name, content_pixels);
+      });
+  {
+    std::ostream deferred(&buffer);
+    HtmlWriter body_out(deferred, config);
+    WritingState state(body_out, config, resources, logger, &styles);
+    state.set_direction(head_state.direction());
+    body(state);
+  }
+  buffer.release();
+
   out.write_end();
+  return resources;
 }
 
 class HtmlFragmentBase {
@@ -247,8 +305,10 @@ public:
   [[nodiscard]] const std::string &name() const { return m_name; }
   [[nodiscard]] std::size_t index() const { return m_index; }
   [[nodiscard]] const std::string &path() const { return m_path; }
+  [[nodiscard]] const Document &document() const { return m_document; }
 
-  virtual void write_fragment(HtmlWriter &out, WritingState &state) const = 0;
+  virtual void write_fragment(HtmlWriter &out,
+                              const WritingState &state) const = 0;
 
   /// The width this one view lays out, which is what it is fitted against.
   [[nodiscard]] virtual std::optional<double>
@@ -263,13 +323,6 @@ public:
       m_cut_measured = true;
     }
     return m_cut;
-  }
-
-  void write_document(HtmlWriter &out, WritingState &state) const {
-    const std::optional<double> content = content_pixels(state.config());
-    front(m_document, state, m_name, content);
-    write_fragment(out, state);
-    back(m_document, state);
   }
 
 protected:
@@ -313,10 +366,12 @@ public:
   }
 
   HtmlResources write_html(HtmlWriter &out) const override {
-    HtmlResources resources;
-    WritingState state(out, service().config(), resources, service().logger());
-    m_fragment->write_document(out, state);
-    return resources;
+    return render(m_fragment->document(), service().config(),
+                  service().logger(), out, m_fragment->name(),
+                  m_fragment->content_pixels(service().config()),
+                  [this](const WritingState &state) {
+                    m_fragment->write_fragment(state.out(), state);
+                  });
   }
 
 private:
@@ -448,21 +503,14 @@ public:
   }
 
   HtmlResources write_document(HtmlWriter &out) const {
-    HtmlResources resources;
-
-    WritingState state(out, config(), resources, logger());
-
     // every page in one file, so the column is as wide as the widest of them
-    const std::optional<double> content =
-        document_content_pixels(m_document, config());
-
-    front(m_document, state, "", content);
-    for (const auto &fragment : m_fragments) {
-      fragment->write_fragment(out, state);
-    }
-    back(m_document, state);
-
-    return resources;
+    return render(m_document, config(), logger(), out, "",
+                  document_content_pixels(m_document, config()),
+                  [this](const WritingState &state) {
+                    for (const auto &fragment : m_fragments) {
+                      fragment->write_fragment(state.out(), state);
+                    }
+                  });
   }
 
 protected:
@@ -505,7 +553,8 @@ public:
                                    config);
   }
 
-  void write_fragment(HtmlWriter &out, WritingState &state) const override {
+  void write_fragment(HtmlWriter &out,
+                      const WritingState &state) const override {
     const Element root = m_document.root_element();
     const TextRoot element = root.as_text_root();
 
@@ -593,7 +642,7 @@ public:
     return fragment_content_pixels(m_element, config);
   }
 
-  void write_fragment(HtmlWriter &, WritingState &state) const override {
+  void write_fragment(HtmlWriter &, const WritingState &state) const override {
     Translate(m_element, state);
   }
 

--- a/src/odr/internal/html/document_element.cpp
+++ b/src/odr/internal/html/document_element.cpp
@@ -13,10 +13,12 @@
 #include <odr/internal/html/html_service.hpp>
 #include <odr/internal/html/html_writer.hpp>
 #include <odr/internal/html/image_file.hpp>
+#include <odr/internal/html/style_registry.hpp>
 #include <odr/internal/util/number_util.hpp>
 #include <odr/internal/xml/xml_util.hpp>
 
 #include <algorithm>
+#include <vector>
 
 namespace odr::internal {
 
@@ -185,6 +187,42 @@ TableDimensions html::sheet_rendered_extent(const Sheet &sheet,
 
 namespace {
 
+/// Whether a reader sees anything. A bookmark marks a place rather than filling
+/// one, and a span or a link is a style around what it holds, so a paragraph
+/// holding only those is still an empty line.
+bool has_content(const ElementRange &children) {
+  for (const Element child : children) {
+    switch (child.type()) {
+    case ElementType::bookmark:
+      break;
+    case ElementType::span:
+    case ElementType::link:
+      if (has_content(child.children())) {
+        return true;
+      }
+      break;
+    case ElementType::text:
+      if (!child.as_text().content().empty()) {
+        return true;
+      }
+      break;
+    default:
+      return true;
+    }
+  }
+  return false;
+}
+
+/// A break where the paragraph holds nothing, so a blank line survives being
+/// pasted elsewhere; otherwise a break opportunity, or content all out of flow
+/// leaves no line box.
+void write_paragraph_line_box(const bool empty,
+                              const html::WritingState &state) {
+  state.out().write_element_begin(
+      empty ? "br" : "wbr",
+      html::HtmlElementOptions().set_close_type(html::HtmlCloseType::none));
+}
+
 /// How far a sheet has to shrink to fit the paper the file states; nothing
 /// where it fits already, or where no width is stated.
 std::optional<double> sheet_print_fit(const Sheet &sheet,
@@ -213,6 +251,166 @@ std::optional<double> sheet_print_fit(const Sheet &sheet,
     return {};
   }
   return printable / content;
+}
+
+/// A run whose style the box around it can carry instead. Not a background, a
+/// raised run or an editable one: each means something else on the box.
+std::optional<Text> plain_text(const Element &element,
+                               const html::WritingState &state) {
+  if (element.type() != ElementType::text) {
+    return {};
+  }
+  if (state.config().editable && element.is_editable()) {
+    return {};
+  }
+
+  const Text text = element.as_text();
+  if (text.content().empty()) {
+    return {};
+  }
+  const TextStyle style = text.style();
+  if (style.background_color.has_value() || style.font_position.has_value()) {
+    return {};
+  }
+  return text;
+}
+
+/// @ref plain_text where @p paragraph holds one and nothing else.
+std::optional<Text> plain_run(const Paragraph &paragraph,
+                              const html::WritingState &state) {
+  const ElementRange children = paragraph.children();
+  ElementIterator child = children.begin();
+  if (child == children.end()) {
+    return {};
+  }
+  const Element element = *child;
+  if (++child != children.end()) {
+    return {};
+  }
+  return plain_text(element, state);
+}
+
+/// Nothing a reader would see, so the cell beside it may spill over it.
+bool is_blank(const SheetCell &cell) {
+  for (const Element child : cell.children()) {
+    if (child.type() != ElementType::paragraph ||
+        has_content(child.children())) {
+      return false;
+    }
+  }
+  return true;
+}
+
+/// A shape or picture anchored in a cell reaches past it by design.
+bool holds_only_text(const SheetCell &cell) {
+  for (const Element child : cell.children()) {
+    switch (child.type()) {
+    case ElementType::paragraph:
+    case ElementType::text:
+    case ElementType::span:
+    case ElementType::link:
+    case ElementType::bookmark:
+    case ElementType::line_break:
+      break;
+    default:
+      return false;
+    }
+  }
+  return true;
+}
+
+bool is_zero(const std::optional<Quantity<double>> &margin) {
+  return !margin.has_value() || margin->magnitude() == 0;
+}
+
+/// What the run computed to, under the two properties the paragraph's block
+/// carries.
+TextStyle run_style(const Paragraph &paragraph, const Text &run) {
+  TextStyle result;
+  result.font_name = paragraph.text_style().font_name;
+  result.font_size = paragraph.text_style().font_size;
+  result.override(run.style());
+  return result;
+}
+
+struct FoldedCell {
+  std::string style;
+  std::string text;
+};
+
+/// The `td` carries the styles of the boxes it stands in for. A stated row
+/// height keeps the paragraph: `contain:size`, `max-height`, `overflow` and
+/// `content-visibility` are all ignored on a table cell.
+std::optional<FoldedCell> fold_cell(const SheetCell &cell,
+                                    const html::WritingState &state,
+                                    const bool wraps, const bool anchors_shapes,
+                                    const std::optional<Measure> &row_height) {
+  if (wraps || anchors_shapes) {
+    return {};
+  }
+
+  const ElementRange children = cell.children();
+  ElementIterator child = children.begin();
+  if (child == children.end()) {
+    return {};
+  }
+  const Element only = *child;
+  if (++child != children.end()) {
+    return {};
+  }
+
+  if (only.type() == ElementType::text) {
+    const std::optional<Text> run = plain_text(only, state);
+    if (!run.has_value()) {
+      return {};
+    }
+    return FoldedCell{html::translate_text_style(run->style()),
+                      html::escape_text(run->content())};
+  }
+
+  if (only.type() != ElementType::paragraph || row_height.has_value()) {
+    return {};
+  }
+  const Paragraph paragraph = only.as_paragraph();
+  const std::optional<Text> run = plain_run(paragraph, state);
+  if (!run.has_value()) {
+    return {};
+  }
+  const ParagraphStyle style = paragraph.style();
+  if (!is_zero(style.margin.left) || !is_zero(style.margin.right) ||
+      !is_zero(style.margin.top) || !is_zero(style.margin.bottom)) {
+    return {};
+  }
+
+  return FoldedCell{html::translate_paragraph_style(style, state.direction()) +
+                        html::translate_text_style(run_style(paragraph, *run)),
+                    html::escape_text(run->content())};
+}
+
+/// A paragraph holding one plain string carries what the run's `x-s` carried.
+void translate_cell_children(const SheetCell &cell,
+                             const html::WritingState &state) {
+  for (const Element child : cell.children()) {
+    const std::optional<Text> run = child.type() == ElementType::paragraph
+                                        ? plain_run(child.as_paragraph(), state)
+                                        : std::nullopt;
+    if (!run.has_value()) {
+      html::translate_element(child, state);
+      continue;
+    }
+    const Paragraph paragraph = child.as_paragraph();
+
+    state.out().write_element_begin(
+        "x-p", html::HtmlElementOptions().set_inline(true).set_style(
+                   "display:block;" +
+                       html::translate_paragraph_style(paragraph.style(),
+                                                       state.direction()) +
+                       html::translate_text_style(run_style(paragraph, *run)),
+                   state.styles()));
+    state.out().out() << html::escape_text(run->content());
+    write_paragraph_line_box(false, state);
+    state.out().write_element_end("x-p");
+  }
 }
 
 } // namespace
@@ -257,16 +455,22 @@ void html::translate_sheet(const Sheet &sheet, const WritingState &state) {
                                       .set_close_type(HtmlCloseType::none)
                                       .set_class("odr-sheet-gutter"));
 
+  // `table-layout:fixed` still sizes the table from its content, so an unbroken
+  // line would widen its column; `max-width:0` takes the cell out of that sum.
+  // Only where a width is stated: a column that states none is its content's.
+  std::vector<std::optional<double>> column_pixels(end_column);
+
   for (std::uint32_t column_index = 0; column_index < end_column;
        ++column_index) {
     const TableColumnStyle table_column_style =
         sheet.column_style(column_index);
+    column_pixels[column_index] = css_pixels(table_column_style.width);
 
     state.out().write_element_begin(
-        "col",
-        HtmlElementOptions()
-            .set_close_type(HtmlCloseType::none)
-            .set_style(translate_table_column_style(table_column_style)));
+        "col", HtmlElementOptions()
+                   .set_close_type(HtmlCloseType::none)
+                   .set_style(translate_table_column_style(table_column_style),
+                              state.styles()));
   }
 
   // No `scope`: the letters and numbers are a ruler, not headers of what they
@@ -304,6 +508,9 @@ void html::translate_sheet(const Sheet &sheet, const WritingState &state) {
 
   state.out().write_element_begin("tbody");
 
+  const ElementRange shapes = sheet.shapes();
+  const bool has_shapes = shapes.begin() != shapes.end();
+
   TableCursor cursor;
   for (std::uint32_t row_index = cursor.row(); row_index < end_row;
        row_index = cursor.row()) {
@@ -311,27 +518,33 @@ void html::translate_sheet(const Sheet &sheet, const WritingState &state) {
 
     state.out().write_element_begin(
         "tr", HtmlElementOptions().set_style(
-                  translate_table_row_style(table_row_style)));
+                  translate_table_row_style(table_row_style), state.styles()));
 
     state.out().write_element_begin(
         "th", HtmlElementOptions()
                   .set_inline(true)
                   .set_class("odr-sheet-row-header")
-                  .set_style([&]() -> std::optional<HtmlWritable> {
-                    const std::optional<Measure> height =
-                        table_row_style.height;
-                    if (!height.has_value()) {
-                      return std::nullopt;
-                    }
-                    return "height:" + height->to_string() +
-                           ";max-height:" + height->to_string() + ";";
-                  }()));
+                  .set_style(
+                      [&]() -> std::string {
+                        const std::optional<Measure> height =
+                            table_row_style.height;
+                        if (!height.has_value()) {
+                          return {};
+                        }
+                        return "height:" + height->to_string() +
+                               ";max-height:" + height->to_string() + ";";
+                      }(),
+                      state.styles()));
     state.out().write_raw(TablePosition::to_row_string(row_index));
     state.out().write_element_end("th");
 
+    // Carried forward, so no position is read twice.
+    std::optional<SheetCell> pending;
     for (std::uint32_t column_index = cursor.column();
          column_index < end_column; column_index = cursor.column()) {
-      const SheetCell cell = sheet.cell(column_index, row_index);
+      const SheetCell cell =
+          pending.has_value() ? *pending : sheet.cell(column_index, row_index);
+      pending.reset();
 
       if (cell.is_covered()) {
         // normally unreachable: the cursor skips positions covered by an
@@ -348,9 +561,66 @@ void html::translate_sheet(const Sheet &sheet, const WritingState &state) {
       const TableDimensions cell_span = cell.span();
       const ValueType cell_value_type = cell.value_type();
 
+      // `style:wrap-option` is `no-wrap` by default, and `wrapText` is off.
+      const bool wraps = cell_style.wrap_text.value_or(false);
+      const std::uint32_t next_column = column_index + cell_span.columns;
+      std::optional<SheetCell> next;
+      if (next_column < end_column) {
+        next = sheet.cell(next_column, row_index);
+      }
+
+      const bool anchors_shapes =
+          has_shapes && column_index == 0 && row_index == 0;
+      const bool cuts_its_text = !anchors_shapes && holds_only_text(cell);
+
+      std::string cell_css;
+      if (!wraps && cuts_its_text) {
+        cell_css += "white-space:nowrap;";
+      }
+      if (wraps && cuts_its_text) {
+        // Its block is held at the row's height, so a broken line runs past
+        // the bottom and would paint over the row below.
+        cell_css += "overflow:hidden;";
+      }
+      // Over the empty cells beside it, cut where the next one has something
+      // to show, unbounded where nothing follows. Each blank cell is walked by
+      // the one cell that may spill over it, so the row costs one pass.
+      if (!wraps && cuts_its_text && column_pixels[column_index].has_value()) {
+        std::optional<double> spill(0);
+        bool bounded = false;
+        for (std::uint32_t ahead = next_column; ahead < end_column; ++ahead) {
+          const SheetCell cell_ahead = ahead == next_column && next.has_value()
+                                           ? *next
+                                           : sheet.cell(ahead, row_index);
+          if (!is_blank(cell_ahead)) {
+            bounded = true;
+            break;
+          }
+          if (!column_pixels[ahead].has_value()) {
+            spill.reset();
+            bounded = true;
+            break;
+          }
+          *spill += *column_pixels[ahead];
+        }
+        if (bounded) {
+          if (!spill.has_value() || *spill == 0) {
+            cell_css += "overflow:hidden;";
+          } else {
+            cell_css += "clip-path:inset(0 " +
+                        util::number::to_string_significant(-*spill, 7) +
+                        "px 0 0);";
+          }
+        }
+      }
+
+      const std::optional<FoldedCell> folded =
+          fold_cell(cell, state, wraps, anchors_shapes, table_row_style.height);
+
       state.out().write_element_begin(
           "td",
           HtmlElementOptions()
+              .set_inline(folded.has_value())
               .set_attributes([&](const HtmlAttributeWriterCallback &clb) {
                 if (cell_span.columns > 1) {
                   clb("colspan", std::to_string(cell_span.columns));
@@ -359,7 +629,13 @@ void html::translate_sheet(const Sheet &sheet, const WritingState &state) {
                   clb("rowspan", std::to_string(cell_span.rows));
                 }
               })
-              .set_style(translate_table_cell_style(cell_style))
+              .set_style(
+                  translate_table_cell_style(cell_style) +
+                      (column_pixels[column_index].has_value() ? "max-width:0;"
+                                                               : "") +
+                      cell_css +
+                      (folded.has_value() ? folded->style : std::string()),
+                  state.styles())
               .set_class([&]() -> std::optional<HtmlWritable> {
                 if (cell_value_type == ValueType::float_number) {
                   return "odr-value-type-float";
@@ -371,10 +647,17 @@ void html::translate_sheet(const Sheet &sheet, const WritingState &state) {
           translate_element(shape, state);
         }
       }
-      translate_children(cell.children(), state);
+      if (folded.has_value()) {
+        state.out().out() << folded->text;
+      } else {
+        translate_cell_children(cell, state);
+      }
       state.out().write_element_end("td");
 
       cursor.add_cell(cell_span.columns, cell_span.rows);
+      if (cursor.column() == next_column) {
+        pending = next;
+      }
     }
 
     state.out().write_element_end("tr");
@@ -428,15 +711,16 @@ void html::translate_text(const Element &element, const WritingState &state) {
   const Text text = element.as_text();
 
   state.out().write_element_begin(
-      "x-s", HtmlElementOptions()
-                 .set_inline(true)
-                 .set_attributes([&](const HtmlAttributeWriterCallback &clb) {
-                   if (state.config().editable && element.is_editable()) {
-                     clb("contenteditable", "true");
-                     clb("data-odr-path", element.document_path().to_string());
-                   }
-                 })
-                 .set_style(translate_text_style(text.style())));
+      "x-s",
+      HtmlElementOptions()
+          .set_inline(true)
+          .set_attributes([&](const HtmlAttributeWriterCallback &clb) {
+            if (state.config().editable && element.is_editable()) {
+              clb("contenteditable", "true");
+              clb("data-odr-path", element.document_path().to_string());
+            }
+          })
+          .set_style(translate_text_style(text.style()), state.styles()));
   state.out().out() << escape_text(text.content());
   state.out().write_element_end("x-s");
 }
@@ -453,35 +737,7 @@ void html::translate_line_break(const Element &element,
   state.out().write_element_end("x-s");
 }
 
-namespace {
-
-/// Whether a reader sees anything. A bookmark marks a place rather than filling
-/// one, and a span or a link is a style around what it holds, so a paragraph
-/// holding only those is still an empty line.
-bool has_content(const ElementRange &children) {
-  for (const Element child : children) {
-    switch (child.type()) {
-    case ElementType::bookmark:
-      break;
-    case ElementType::span:
-    case ElementType::link:
-      if (has_content(child.children())) {
-        return true;
-      }
-      break;
-    case ElementType::text:
-      if (!child.as_text().content().empty()) {
-        return true;
-      }
-      break;
-    default:
-      return true;
-    }
-  }
-  return false;
-}
-
-} // namespace
+namespace {} // namespace
 
 void html::translate_page_break(const Element & /*element*/,
                                 const WritingState &state) {
@@ -501,8 +757,9 @@ void html::translate_paragraph(const Element &element,
       "x-p",
       HtmlElementOptions().set_inline(true).set_style(
           "display:block;" +
-          translate_paragraph_style(paragraph.style(), state.direction()) +
-          translate_block_font_style(paragraph.text_style())));
+              translate_paragraph_style(paragraph.style(), state.direction()) +
+              translate_block_font_style(paragraph.text_style()),
+          state.styles()));
   if (!marker.empty()) {
     state.out().write_element_begin(
         "x-s", HtmlElementOptions()
@@ -514,16 +771,8 @@ void html::translate_paragraph(const Element &element,
     state.out().write_element_end("x-s");
   }
   translate_children(paragraph.children(), state);
-  if (marker.empty() && !has_content(paragraph.children())) {
-    // A line break, not a break opportunity: only a break is copied, so a blank
-    // line between two paragraphs survives being pasted somewhere else.
-    state.out().write_element_begin(
-        "br", HtmlElementOptions().set_close_type(HtmlCloseType::none));
-  } else {
-    // A paragraph whose content is all out of flow has no line box of its own.
-    state.out().write_element_begin(
-        "wbr", HtmlElementOptions().set_close_type(HtmlCloseType::none));
-  }
+  write_paragraph_line_box(marker.empty() && !has_content(paragraph.children()),
+                           state);
   state.out().write_element_end("x-p");
 }
 
@@ -532,7 +781,7 @@ void html::translate_span(const Element &element, const WritingState &state) {
 
   state.out().write_element_begin(
       "x-s", HtmlElementOptions().set_inline(true).set_style(
-                 translate_text_style(span.style())));
+                 translate_text_style(span.style()), state.styles()));
   translate_children(span.children(), state);
   state.out().write_element_end("x-s");
 }

--- a/src/odr/internal/html/frontend.cpp
+++ b/src/odr/internal/html/frontend.cpp
@@ -80,17 +80,19 @@ constexpr std::string_view spreadsheet_css = R"css(
 --odr-sheet-wash-pinned:rgba(0,0,0,.09);
 --odr-sheet-wash-ruler:rgba(0,0,0,.10);
 --odr-sheet-focus:#3c78dc;
+--odr-sheet-raised:#ffffff;
 --odr-sheet-font:-apple-system,BlinkMacSystemFont,"Segoe UI",Roboto,"Helvetica Neue",Arial,sans-serif;
 }
 /* A sheet is not a page: past the last row and column is canvas. */
 body{margin:0;background:var(--odr-sheet-canvas)}
 .odr-sheet{background:#fff;border-collapse:collapse;table-layout:fixed}
-/* The sheet's own cells, not a table the document itself drew inside one. */
-.odr-sheet>tbody>tr>td{vertical-align:bottom;height:inherit;padding:1px 6px}
+/* The sheet's own cells, not a table the document itself drew inside one. The
+   font is what anything in a cell falls back to, a string written straight
+   into it included. */
+.odr-sheet>tbody>tr>td{vertical-align:bottom;height:inherit;padding:1px 6px;font-family:var(--odr-sheet-font);font-size:10pt}
+/* Exactly the cell's height, which is what holds a row to the height the file
+   states. `translate_sheet` says per cell what a line too long for it does. */
 .odr-sheet>tbody>tr>td>x-p{height:inherit}
-/* The font anything in a cell falls back to, a shape's text included, where the
-   file names none of its own. */
-.odr-sheet>tbody>tr>td x-p{font-family:var(--odr-sheet-font);font-size:10pt}
 /* Sticky cells in a collapsed border model do not repaint their borders in
    Chrome or WebKit, so the ruler uses inset shadows. */
 .odr-sheet th{position:sticky;background:var(--odr-sheet-ruler);color:var(--odr-sheet-ruler-text);font:500 12px/1.6 var(--odr-sheet-font);text-align:center;vertical-align:middle;padding:0 4px;white-space:nowrap;user-select:none}
@@ -106,6 +108,13 @@ body{margin:0;background:var(--odr-sheet-canvas)}
 .odr-sheet tbody tr.odr-sheet-pinned>*{background-image:linear-gradient(var(--odr-sheet-wash-pinned),var(--odr-sheet-wash-pinned))}
 .odr-sheet tbody tr:hover>th,.odr-sheet tbody tr.odr-sheet-pinned>th{background-image:linear-gradient(var(--odr-sheet-wash-ruler),var(--odr-sheet-wash-ruler))}
 .odr-sheet .odr-sheet-pinned-cell{outline:2px solid var(--odr-sheet-focus);outline-offset:-2px}
+/* The clipped cell a reader asked to see: out of flow so the row cannot move,
+   sized to the string, over its neighbours. `.odr-sheet-raised-box` is the
+   wrapper the script adds to a cell that writes its string without one. */
+.odr-sheet td.odr-sheet-raised{overflow:visible!important;clip-path:none!important;z-index:4}
+.odr-sheet td.odr-sheet-raised.odr-sheet-pinned-cell{outline:none}
+.odr-sheet td.odr-sheet-raised>x-p,.odr-sheet td.odr-sheet-raised>.odr-sheet-raised-box{position:absolute!important;left:0;top:0;z-index:4;height:auto!important;min-width:100%;width:max-content;max-width:60vw;padding:1px 6px;margin:-1px -6px;background:var(--odr-sheet-raised)!important;box-shadow:0 1px 4px rgba(0,0,0,.35);outline:2px solid var(--odr-sheet-focus);outline-offset:-2px;overflow:visible!important;white-space:normal!important}
+.odr-sheet-raised-box{display:block}
 /* The header's `position:sticky` already makes it a containing block. */
 .odr-sheet-sort{position:absolute;top:1px;right:1px;bottom:1px;width:17px;display:flex;align-items:center;justify-content:center;border-radius:2px;opacity:0;cursor:pointer}
 .odr-sheet-column-header:hover .odr-sheet-sort,.odr-sheet-sort-asc,.odr-sheet-sort-desc{opacity:1}
@@ -136,6 +145,7 @@ constexpr std::string_view spreadsheet_dark_css = R"css(
 --odr-sheet-wash-pinned:rgba(255,255,255,.10);
 --odr-sheet-wash-ruler:rgba(255,255,255,.12);
 --odr-sheet-focus:#4c8dff;
+--odr-sheet-raised:#1c2128;
 }
 .odr-sheet{background-color:#161b22!important}
 )css";
@@ -1001,7 +1011,90 @@ constexpr std::string_view spreadsheet_js = R"js(
     return cell !== null && !merged ? cell.cellIndex : -1;
   }
 
+  var raisedCell = null;
+  var raisedWrapper = null;
+  var raisedContent = null;
+
+  // The block the cell writes, or the cell where it writes none. `null` for
+  // anything else — a shape, several blocks — which is not raised.
+  function boxOf(cell) {
+    if (cell.childElementCount === 0) {
+      return cell;
+    }
+    var only = cell.firstElementChild;
+    return cell.childElementCount === 1 && only.tagName === "X-P" ? only : null;
+  }
+
+  // Past the cell's edge by the spill `translate_sheet` measured, at the edge
+  // where it clips, unbounded where it does neither.
+  function visibleRight(cell) {
+    var style = getComputedStyle(cell);
+    var right = cell.getBoundingClientRect().right;
+    var inset = /inset\(([^)]*)\)/.exec(style.clipPath || "");
+    if (inset !== null) {
+      var sides = inset[1].trim().split(/\s+/);
+      return sides.length > 1 ? right - parseFloat(sides[1]) : right;
+    }
+    return style.overflow === "visible" ? Infinity : right;
+  }
+
+  // On the text, not the box: what is cut off is the string running past where
+  // the cell still paints.
+  function cutOff(cell, box) {
+    var range = document.createRange();
+    range.selectNodeContents(box);
+    var ink = range.getBoundingClientRect();
+    var rect = cell.getBoundingClientRect();
+    return (
+      ink.width > 0 &&
+      (ink.right > visibleRight(cell) + 1 ||
+        (getComputedStyle(cell).overflow !== "visible" &&
+          ink.bottom > rect.bottom + 1))
+    );
+  }
+
+  function lower() {
+    if (raisedCell === null) {
+      return;
+    }
+    raisedCell.classList.remove("odr-sheet-raised");
+    if (raisedWrapper !== null) {
+      while (raisedWrapper.firstChild) {
+        raisedCell.insertBefore(raisedWrapper.firstChild, raisedWrapper);
+      }
+      raisedWrapper.remove();
+      raisedWrapper = null;
+    }
+    raisedContent = null;
+    raisedCell = null;
+  }
+
+  // Over its neighbours rather than pushing them aside.
+  function raise(cell) {
+    lower();
+    if (cell === null || cell.tagName !== "TD") {
+      return;
+    }
+    var box = boxOf(cell);
+    if (box === null || !cutOff(cell, box)) {
+      return;
+    }
+    if (box === cell) {
+      raisedWrapper = document.createElement("span");
+      raisedWrapper.className = "odr-sheet-raised-box";
+      while (cell.firstChild) {
+        raisedWrapper.appendChild(cell.firstChild);
+      }
+      cell.appendChild(raisedWrapper);
+      box = raisedWrapper;
+    }
+    cell.classList.add("odr-sheet-raised");
+    raisedCell = cell;
+    raisedContent = box;
+  }
+
   function pin(column, row, cell) {
+    lower();
     if (pinnedRow !== null) {
       pinnedRow.classList.remove("odr-sheet-pinned");
     }
@@ -1018,6 +1111,7 @@ constexpr std::string_view spreadsheet_js = R"js(
     }
     if (pinnedCell !== null) {
       pinnedCell.classList.add("odr-sheet-pinned-cell");
+      raise(pinnedCell);
     }
     paint();
   }
@@ -1036,6 +1130,11 @@ constexpr std::string_view spreadsheet_js = R"js(
   });
 
   table.addEventListener("click", function (event) {
+    // Selecting inside what is raised must not put the cell back.
+    if (raisedContent !== null && raisedContent.contains(event.target)) {
+      return;
+    }
+
     var cell = event.target.closest("td,th");
     if (cell === null) {
       return;
@@ -1055,6 +1154,13 @@ constexpr std::string_view spreadsheet_js = R"js(
       pin(-1, null, null);
     } else {
       pin(columnOf(cell), cell.parentElement, cell);
+    }
+  });
+
+  // The canvas around the sheet included.
+  document.addEventListener("click", function (event) {
+    if (event.target.closest(".odr-sheet") === null) {
+      pin(-1, null, null);
     }
   });
 

--- a/src/odr/internal/html/html_writer.cpp
+++ b/src/odr/internal/html/html_writer.cpp
@@ -1,6 +1,7 @@
 #include <odr/internal/html/html_writer.hpp>
 
 #include <odr/internal/html/common.hpp>
+#include <odr/internal/html/style_registry.hpp>
 #include <odr/internal/util/string_util.hpp>
 
 #include <algorithm>
@@ -64,9 +65,18 @@ void write_attributes(std::ostream &out, const HtmlAttributes &attributes) {
 
 void write_element_options(std::ostream &out,
                            const HtmlElementOptions &options) {
-  if (options.clazz && !is_empty(*options.clazz)) {
+  const bool has_clazz = options.clazz && !is_empty(*options.clazz);
+  if (has_clazz || options.style_class) {
     out << " class=\"";
-    write_writable(out, *options.clazz);
+    if (has_clazz) {
+      write_writable(out, *options.clazz);
+    }
+    if (options.style_class) {
+      if (has_clazz) {
+        out << " ";
+      }
+      out << *options.style_class;
+    }
     out << "\"";
   }
   if (options.style && !is_empty(*options.style)) {
@@ -105,6 +115,20 @@ HtmlElementOptions::set_attributes(std::optional<HtmlAttributes> _attributes) {
 HtmlElementOptions &
 HtmlElementOptions::set_style(std::optional<HtmlWritable> _style) {
   style = std::move(_style);
+  return *this;
+}
+
+HtmlElementOptions &HtmlElementOptions::set_style(std::string _style,
+                                                  StyleRegistry *registry) {
+  if (registry != nullptr) {
+    if (const std::string *name = registry->use(_style); name != nullptr) {
+      style_class = *name;
+      return *this;
+    }
+  }
+  if (!_style.empty()) {
+    style = std::move(_style);
+  }
   return *this;
 }
 

--- a/src/odr/internal/html/html_writer.hpp
+++ b/src/odr/internal/html/html_writer.hpp
@@ -11,6 +11,8 @@
 
 namespace odr::internal::html {
 
+class StyleRegistry;
+
 enum class HtmlCloseType {
   standard,
   trailing,
@@ -35,6 +37,8 @@ struct HtmlElementOptions {
 
   std::optional<HtmlWritable> style{};
   std::optional<HtmlWritable> clazz{};
+  /// The class a deduplicated style block resolved to, written after `clazz`.
+  std::optional<std::string> style_class{};
 
   std::optional<HtmlWritable> extra{};
 
@@ -42,6 +46,10 @@ struct HtmlElementOptions {
   HtmlElementOptions &set_close_type(HtmlCloseType _close_type);
   HtmlElementOptions &set_attributes(std::optional<HtmlAttributes> _attributes);
   HtmlElementOptions &set_style(std::optional<HtmlWritable> _style);
+  /// Either an inline `style` attribute or, where @p registry names the block,
+  /// a class beside whatever `set_class` says. A null @p registry — every view
+  /// but a spreadsheet's — keeps it inline.
+  HtmlElementOptions &set_style(std::string _style, StyleRegistry *registry);
   HtmlElementOptions &set_class(std::optional<HtmlWritable> _class);
   HtmlElementOptions &set_extra(std::optional<HtmlWritable> _extra);
 };

--- a/src/odr/internal/html/style_registry.cpp
+++ b/src/odr/internal/html/style_registry.cpp
@@ -1,0 +1,55 @@
+#include <odr/internal/html/style_registry.hpp>
+
+#include <ostream>
+#include <string_view>
+
+namespace odr::internal::html {
+
+namespace {
+
+/// Base 36, so the first 36 blocks fit in two characters. Each name is written
+/// once per element carrying the block.
+std::string name(std::size_t index) {
+  static constexpr std::string_view digits =
+      "0123456789abcdefghijklmnopqrstuvwxyz";
+  std::string suffix;
+  do {
+    suffix.insert(suffix.begin(), digits[index % digits.size()]);
+    index /= digits.size();
+  } while (index != 0);
+  return 'c' + suffix;
+}
+
+} // namespace
+
+const std::string *StyleRegistry::use(const std::string &style) {
+  if (style.empty()) {
+    return nullptr;
+  }
+
+  if (m_closed) {
+    const auto it = m_entries.find(style);
+    return it == m_entries.end() ? nullptr : &it->second;
+  }
+
+  const auto [it, inserted] = m_entries.try_emplace(style);
+  if (inserted) {
+    it->second = name(m_order.size());
+    m_order.push_back(&*it);
+  }
+  return &it->second;
+}
+
+void StyleRegistry::write_rules(std::ostream &out) const {
+  for (const auto *entry : m_order) {
+    // Named three times for the specificity an inline `style` had. Still under
+    // `!important`, which the dark sheet needs.
+    const std::string &name = entry->second;
+    out << "\n." << name << '.' << name << '.' << name << '{';
+    const std::string_view block = entry->first;
+    out << (block.back() == ';' ? block.substr(0, block.size() - 1) : block);
+    out << '}';
+  }
+}
+
+} // namespace odr::internal::html

--- a/src/odr/internal/html/style_registry.hpp
+++ b/src/odr/internal/html/style_registry.hpp
@@ -1,0 +1,34 @@
+#pragma once
+
+#include <cstddef>
+#include <iosfwd>
+#include <string>
+#include <unordered_map>
+#include <vector>
+
+namespace odr::internal::html {
+
+/// Names each distinct style block a class, defined once in `<head>`. An
+/// inline `style` is the one shape a browser cannot share across the cells of
+/// a sheet.
+class StyleRegistry {
+public:
+  /// The class @p style is written as; `nullptr` leaves it inline.
+  const std::string *use(const std::string &style);
+
+  /// Names nothing further, so a block first seen after this stays inline.
+  void close() { m_closed = true; }
+
+  [[nodiscard]] bool has_rules() const { return !m_order.empty(); }
+
+  /// One rule per line, each preceded by a newline.
+  void write_rules(std::ostream &out) const;
+
+private:
+  /// Node-based: the pointers in `m_order` outlive every insertion.
+  std::unordered_map<std::string, std::string> m_entries;
+  std::vector<const std::pair<const std::string, std::string> *> m_order;
+  bool m_closed{false};
+};
+
+} // namespace odr::internal::html

--- a/src/odr/internal/odf/odf_style.cpp
+++ b/src/odr/internal/odf/odf_style.cpp
@@ -507,6 +507,10 @@ void Style::resolve_table_cell_style_(const pugi::xml_node node,
           table_cell_properties.attribute("style:vertical-align"))) {
     result.vertical_align = vertical_align;
   }
+  if (const pugi::xml_attribute wrap_option =
+          table_cell_properties.attribute("style:wrap-option")) {
+    result.wrap_text = std::strcmp("wrap", wrap_option.value()) == 0;
+  }
   if (const std::optional<Color> background_color =
           read_color(table_cell_properties.attribute("fo:background-color"))) {
     result.background_color = background_color;

--- a/src/odr/internal/oldms/spreadsheet/xls_style.cpp
+++ b/src/odr/internal/oldms/spreadsheet/xls_style.cpp
@@ -87,6 +87,8 @@ StyleRegistry::StyleRegistry(std::vector<Font> fonts,
     text.font_line_through = font.fixed.fStrikeOut != 0;
     text.font_color = icv_color(font.fixed.icv, palette);
 
+    style.table_cell_style.wrap_text = xf.fWrap != 0;
+
     // For the solid pattern only icvFore is rendered; the other patterns are
     // approximated by their foreground color as well.
     if (xf.fls != 0) {

--- a/src/odr/internal/ooxml/spreadsheet/ooxml_spreadsheet_style.cpp
+++ b/src/odr/internal/ooxml/spreadsheet/ooxml_spreadsheet_style.cpp
@@ -116,6 +116,8 @@ ResolvedStyle StyleRegistry::cell_style(const std::uint32_t i) const {
         read_horizontal(alignment.attribute("horizontal"));
     result.table_cell_style.vertical_align =
         read_vertical(alignment.attribute("vertical"));
+    result.table_cell_style.wrap_text =
+        alignment.attribute("wrapText").as_bool();
     if (const float text_rotation =
             alignment.attribute("textRotation").as_float();
         text_rotation != 0) {

--- a/src/odr/internal/util/stream_util.cpp
+++ b/src/odr/internal/util/stream_util.cpp
@@ -155,6 +155,43 @@ protected:
 
 } // namespace
 
+DeferredBuffer::DeferredBuffer(std::ostream &out, const std::size_t cap,
+                               std::function<void()> release)
+    : m_out{&out}, m_cap{cap}, m_release{std::move(release)} {}
+
+void DeferredBuffer::release() {
+  if (m_released) {
+    return;
+  }
+  m_released = true;
+  m_release();
+  m_out->write(m_held.data(), static_cast<std::streamsize>(m_held.size()));
+  m_held.clear();
+  m_held.shrink_to_fit();
+}
+
+std::streamsize DeferredBuffer::xsputn(const char *data,
+                                       const std::streamsize size) {
+  if (m_released) {
+    m_out->write(data, size);
+    return size;
+  }
+  m_held.append(data, static_cast<std::size_t>(size));
+  if (m_held.size() > m_cap) {
+    release();
+  }
+  return size;
+}
+
+int DeferredBuffer::overflow(const int c) {
+  if (c == traits_type::eof()) {
+    return traits_type::not_eof(c);
+  }
+  const char value = traits_type::to_char_type(c);
+  xsputn(&value, 1);
+  return c;
+}
+
 ViewStream::ViewStream(std::string_view view)
     : std::istream(nullptr), m_sbuf{std::make_unique<ViewStreamBuf>(view)} {
   rdbuf(m_sbuf.get());

--- a/src/odr/internal/util/stream_util.hpp
+++ b/src/odr/internal/util/stream_util.hpp
@@ -1,7 +1,10 @@
 #pragma once
 
+#include <cstddef>
+#include <functional>
 #include <istream>
 #include <memory>
+#include <streambuf>
 #include <string>
 #include <string_view>
 
@@ -18,6 +21,29 @@ std::string read_line(std::istream &in, bool inclusive);
 std::istream &pipe_until(std::istream &in, std::ostream &out, char until_char,
                          bool inclusive);
 std::string read_until(std::istream &in, char until_char, bool inclusive);
+
+/// Holds what is written until `release`d, then passes it and everything after
+/// straight through. `cap` bytes release it early.
+class DeferredBuffer final : public std::streambuf {
+public:
+  /// @p release runs once, before the held bytes reach @p out: it writes the
+  /// prologue they need in front of them.
+  DeferredBuffer(std::ostream &out, std::size_t cap,
+                 std::function<void()> release);
+
+  void release();
+
+protected:
+  std::streamsize xsputn(const char *data, std::streamsize size) override;
+  int overflow(int c) override;
+
+private:
+  std::ostream *m_out{nullptr};
+  std::size_t m_cap{0};
+  std::function<void()> m_release;
+  std::string m_held;
+  bool m_released{false};
+};
 
 class ViewStream : public std::istream {
 public:

--- a/src/odr/style.cpp
+++ b/src/odr/style.cpp
@@ -93,6 +93,7 @@ void TableCellStyle::override(const TableCellStyle &other) {
   padding.override(other.padding);
   border.override(other.border);
   override_if_set(text_rotation, other.text_rotation);
+  override_if_set(wrap_text, other.wrap_text);
 }
 
 void GraphicStyle::override(const GraphicStyle &other) {

--- a/src/odr/style.hpp
+++ b/src/odr/style.hpp
@@ -225,6 +225,9 @@ struct TableCellStyle final {
   DirectionalStyle<Measure> padding;
   DirectionalStyle<std::string> border;
   std::optional<double> text_rotation;
+  /// Whether the cell breaks its text into lines. Off in every spreadsheet
+  /// format unless the file turns it on.
+  std::optional<bool> wrap_text;
 
   void override(const TableCellStyle &other);
 };

--- a/test/browser/sheet/.gitignore
+++ b/test/browser/sheet/.gitignore
@@ -1,0 +1,3 @@
+document.css
+spreadsheet.css
+spreadsheet.js

--- a/test/browser/sheet/README.md
+++ b/test/browser/sheet/README.md
@@ -1,0 +1,20 @@
+# sheet checks
+
+What the emitted sheet script does with a cell too narrow for its text can only
+be seen in a browser, so these are run by hand rather than by `odr_test`.
+
+```bash
+test/browser/sheet/serve         # extracts the css and the script, serves on :8732
+open http://localhost:8732/tests.html
+```
+
+`serve` lifts `document_css`, `spreadsheet_css` and `spreadsheet_js` out of
+`src/odr/internal/html/frontend.cpp`, so what runs is what ships. The markup is
+what `translate_sheet` writes, cut down to the shapes the script has to tell
+apart: a cell that spills over an empty neighbour, one that is cut at its edge,
+one that keeps the block a stated row height needs, and one that writes its
+string straight into the `td`.
+
+The point of the checks is that raising a cell shows all of it **without moving
+anything**: the box goes out of flow, so no row changes height, and a click
+inside it is for the text rather than for the cell.

--- a/test/browser/sheet/serve
+++ b/test/browser/sheet/serve
@@ -1,0 +1,42 @@
+#!/usr/bin/env python3
+"""Extracts the emitted sheet stylesheet and script and serves the checks."""
+
+import functools
+import http.server
+import pathlib
+import socketserver
+
+PORT = 8732
+
+HERE = pathlib.Path(__file__).resolve().parent
+SOURCE = HERE.parents[2] / "src" / "odr" / "internal" / "html" / "frontend.cpp"
+PARTS = {
+    "document.css": 'constexpr std::string_view document_css = R"css(',
+    "spreadsheet.css": 'constexpr std::string_view spreadsheet_css = R"css(',
+    "spreadsheet.js": 'constexpr std::string_view spreadsheet_js = R"js(',
+}
+
+
+def extract(source: str, begin: str) -> str:
+    at = source.index(begin)
+    end = ')css";' if begin.endswith('R"css(') else ')js";'
+    return source[at + len(begin) : source.index(end, at)]
+
+
+def main() -> None:
+    source = SOURCE.read_text()
+    for name, begin in PARTS.items():
+        (HERE / name).write_text(extract(source, begin))
+    print(f"{SOURCE.name} -> {', '.join(PARTS)}")
+
+    handler = functools.partial(
+        http.server.SimpleHTTPRequestHandler, directory=str(HERE)
+    )
+    socketserver.TCPServer.allow_reuse_address = True
+    with socketserver.TCPServer(("127.0.0.1", PORT), handler) as server:
+        print(f"http://localhost:{PORT}/tests.html")
+        server.serve_forever()
+
+
+if __name__ == "__main__":
+    main()

--- a/test/browser/sheet/tests.html
+++ b/test/browser/sheet/tests.html
@@ -1,0 +1,148 @@
+<!doctype html>
+<html>
+  <head>
+    <meta charset="utf-8" />
+    <title>sheet checks</title>
+    <link rel="stylesheet" href="document.css" />
+    <link rel="stylesheet" href="spreadsheet.css" />
+    <style>
+      #report {
+        font: 13px/1.6 monospace;
+        margin: 16px;
+      }
+      .pass::before {
+        content: "PASS ";
+        color: #2a7;
+      }
+      .fail::before {
+        content: "FAIL ";
+        color: #c33;
+      }
+    </style>
+  </head>
+  <body class="odr-body odr-gridlines-soft">
+    <!-- What `translate_sheet` writes, cut down to the shapes the script has to
+         tell apart: a cell that spills, one that is cut, one that keeps its
+         block, and one that writes its string without one. -->
+    <table class="odr-sheet">
+      <col class="odr-sheet-gutter" />
+      <col style="width:80px;min-width:80px" />
+      <col style="width:80px;min-width:80px" />
+      <thead>
+        <tr>
+          <th class="odr-sheet-corner" style="width:3ch"></th>
+          <th class="odr-sheet-column-header">A</th>
+          <th class="odr-sheet-column-header">B</th>
+        </tr>
+      </thead>
+      <tbody>
+        <tr style="height:20px">
+          <th class="odr-sheet-row-header" style="height:20px;max-height:20px">
+            1
+          </th>
+          <td id="cut-block" style="max-width:0;white-space:nowrap;overflow:hidden">
+            <x-p style="display:block">a string far too long for its cell</x-p>
+          </td>
+          <td><x-p style="display:block">next</x-p></td>
+        </tr>
+        <tr style="height:20px">
+          <th class="odr-sheet-row-header" style="height:20px;max-height:20px">
+            2
+          </th>
+          <td
+            id="spilling"
+            style="max-width:0;white-space:nowrap;clip-path:inset(0 -80px 0 0)"
+          >
+            <x-p style="display:block">short</x-p>
+          </td>
+          <td></td>
+        </tr>
+        <tr>
+          <th class="odr-sheet-row-header">3</th>
+          <td id="cut-folded" style="max-width:0;white-space:nowrap;overflow:hidden">
+            a string far too long for its cell
+          </td>
+          <td>next</td>
+        </tr>
+      </tbody>
+    </table>
+
+    <div id="report"></div>
+    <script src="spreadsheet.js"></script>
+    <script>
+      var report = document.getElementById("report");
+      function check(name, condition) {
+        var line = document.createElement("div");
+        line.className = condition ? "pass" : "fail";
+        line.textContent = name;
+        report.appendChild(line);
+      }
+      function click(element) {
+        element.dispatchEvent(new MouseEvent("click", { bubbles: true }));
+        document.body.offsetHeight;
+      }
+      function raised(cell) {
+        return cell.classList.contains("odr-sheet-raised");
+      }
+
+      var cutBlock = document.getElementById("cut-block");
+      var spilling = document.getElementById("spilling");
+      var cutFolded = document.getElementById("cut-folded");
+      var rowsBefore = [].map.call(
+        document.querySelectorAll(".odr-sheet tbody tr"),
+        function (tr) {
+          return Math.round(tr.getBoundingClientRect().height);
+        }
+      );
+
+      click(cutBlock);
+      check("a cut cell is raised", raised(cutBlock));
+      var box = cutBlock.querySelector("x-p");
+      check(
+        "the raised block is out of flow",
+        getComputedStyle(box).position === "absolute"
+      );
+      check(
+        "and wider than the cell",
+        box.getBoundingClientRect().width >
+          cutBlock.getBoundingClientRect().width
+      );
+      check(
+        "the rows do not move",
+        [].every.call(
+          document.querySelectorAll(".odr-sheet tbody tr"),
+          function (tr, i) {
+            return Math.round(tr.getBoundingClientRect().height) ===
+              rowsBefore[i];
+          }
+        )
+      );
+      click(box);
+      check("a click inside it keeps it up", raised(cutBlock));
+
+      click(spilling);
+      check("a cell that shows all of its text is not raised", !raised(spilling));
+      check("and the cut one is lowered again", !raised(cutBlock));
+
+      click(cutFolded);
+      check("a cell holding its string alone is raised too", raised(cutFolded));
+      var wrapper = cutFolded.querySelector(".odr-sheet-raised-box");
+      check("by a box the script adds", wrapper !== null);
+      check(
+        "which is out of flow",
+        wrapper !== null && getComputedStyle(wrapper).position === "absolute"
+      );
+      click(wrapper);
+      check("a click inside that one keeps it up too", raised(cutFolded));
+
+      var text = cutFolded.textContent;
+      click(spilling);
+      check("lowering takes the box away again", cutFolded.childElementCount === 0);
+      check("leaving the string as it was", cutFolded.textContent === text);
+
+      click(cutBlock);
+      click(report);
+      check("a click outside the sheet lowers it", !raised(cutBlock));
+    </script>
+  </body>
+</html>

--- a/test/src/html_output_test.cpp
+++ b/test/src/html_output_test.cpp
@@ -300,8 +300,11 @@ std::vector<std::pair<std::string, ConfigVariant>> list_variant_cases() {
       {"odr-public/odt/about.odt", reflow},
       {"odr-public/docx/physics.docx", reflow},
 
-      // The output a reader gets rather than an editor.
+      // The output a reader gets rather than an editor. A sheet is pinned
+      // too: a cell holding one plain string drops the run around it only
+      // where nothing has to carry `contenteditable`.
       {"odr-public/odt/style-various-1.odt", read_only},
+      {"odr-public/ods/file_example_ODS_100.ods", read_only},
   };
 }
 

--- a/test/src/html_test.cpp
+++ b/test/src/html_test.cpp
@@ -597,6 +597,79 @@ DecodedFile csv_file(const std::uint32_t rows, const std::uint32_t columns) {
   return DecodedFile(File::from_memory(csv), FileType::comma_separated_values);
 }
 
+/// A flat ODF sheet holding @p rows, each a `table:table-row`, under the
+/// `table:table-column`s in @p columns. The one cell style, `ce1`, aligns a
+/// cell to the top, so every cell that names it writes the same style block.
+DecodedFile fods_file(const std::string &rows,
+                      const std::string &columns = "") {
+  const std::string fods =
+      R"(<?xml version="1.0" encoding="UTF-8"?>)"
+      R"(<office:document)"
+      R"( xmlns:office="urn:oasis:names:tc:opendocument:xmlns:office:1.0")"
+      R"( xmlns:table="urn:oasis:names:tc:opendocument:xmlns:table:1.0")"
+      R"( xmlns:text="urn:oasis:names:tc:opendocument:xmlns:text:1.0")"
+      R"( xmlns:style="urn:oasis:names:tc:opendocument:xmlns:style:1.0")"
+      R"( office:version="1.3")"
+      R"( office:mimetype="application/vnd.oasis.opendocument.spreadsheet">)"
+      R"(<office:automatic-styles>)"
+      R"(<style:style style:name="ce1" style:family="table-cell">)"
+      R"(<style:table-cell-properties style:vertical-align="top"/>)"
+      R"(</style:style>)"
+      R"(<style:style style:name="co1" style:family="table-column">)"
+      R"(<style:table-column-properties style:column-width="1in"/>)"
+      R"(</style:style>)"
+      R"(<style:style style:name="ce2" style:family="table-cell">)"
+      R"(<style:table-cell-properties style:vertical-align="top")"
+      R"( style:wrap-option="wrap"/>)"
+      R"(</style:style>)"
+      R"(</office:automatic-styles>)"
+      R"(<office:body><office:spreadsheet><table:table table:name="Sheet1">)" +
+      columns + rows +
+      R"(</table:table></office:spreadsheet></office:body>)"
+      R"(</office:document>)";
+  return DecodedFile(File::from_memory(fods),
+                     FileType::opendocument_spreadsheet);
+}
+
+/// A cell holding @p text, styled by `ce1`, or by `ce2` where it wraps.
+std::string fods_cell(const std::string &text, const bool wraps = false) {
+  return R"(<table:table-cell table:style-name=")" +
+         std::string(wraps ? "ce2" : "ce1") +
+         R"(" office:value-type="string"><text:p>)" + text +
+         R"(</text:p></table:table-cell>)";
+}
+
+/// An empty cell, which the cell beside it may spill over.
+std::string fods_blank() { return "<table:table-cell/>"; }
+
+/// @p count columns of one inch, which is 96 css pixels. Without them a column
+/// is exactly its content's width and nothing can overflow it.
+std::string fods_columns(const std::uint32_t count) {
+  return R"(<table:table-column table:style-name="co1")"
+         R"( table:number-columns-repeated=")" +
+         std::to_string(count) + R"("/>)";
+}
+
+std::string fods_row(const std::string &cells) {
+  return "<table:table-row>" + cells + "</table:table-row>";
+}
+
+/// How many times @p needle occurs in @p haystack, without overlap.
+std::size_t count(const std::string &haystack, const std::string_view needle) {
+  std::size_t result = 0;
+  for (std::size_t at = haystack.find(needle); at != std::string::npos;
+       at = haystack.find(needle, at + needle.size())) {
+    ++result;
+  }
+  return result;
+}
+
+std::string render_sheet(const DecodedFile &file, const HtmlConfig &config) {
+  std::ostringstream out;
+  html::translate(file, config).list_views().at(0).write_html(out);
+  return std::move(out).str();
+}
+
 const HtmlView &view_at(const HtmlService &service,
                         const std::string_view path) {
   const auto it =
@@ -728,13 +801,121 @@ TEST(html, the_cell_budget_bounds_the_rows_by_the_width) {
   EXPECT_EQ(rendered(30, 3).rows, 5);
 }
 
+// #822: an inline `style` is the one shape a browser cannot share across the
+// cells of a sheet.
+TEST(html, a_sheet_defines_a_repeated_style_once_and_names_it) {
+  const std::string page =
+      render_sheet(fods_file(fods_row(fods_cell("one") + fods_cell("two") +
+                                      fods_cell("three"))),
+                   HtmlConfig());
+
+  // Named three times: the class stands in for an inline style, which outranks
+  // every rule the sheet stylesheets carry.
+  EXPECT_NE(page.find(".c0.c0.c0{vertical-align:top;white-space:nowrap}"),
+            std::string::npos);
+  EXPECT_EQ(count(page, R"(<td class="c0">)"), 3);
+}
+
+// #822: a block is named the first time it is written, because the view is
+// walked once — nothing knows yet that this one will not be written again.
+TEST(html, a_sheet_names_a_style_it_writes_only_once_too) {
+  const std::string page =
+      render_sheet(fods_file(fods_row(fods_cell("one"))), HtmlConfig());
+
+  EXPECT_NE(page.find(".c0.c0.c0{vertical-align:top;white-space:nowrap}"),
+            std::string::npos);
+  EXPECT_EQ(page.find(R"(<td style=")"), std::string::npos);
+}
+
+// #822: `td > x-p > x-s > text` is four nodes per cell before any content.
+TEST(html, a_cell_holding_one_plain_string_writes_no_box_of_its_own) {
+  const std::string page =
+      render_sheet(fods_file(fods_row(fods_cell("one"))), HtmlConfig());
+
+  EXPECT_NE(page.find(">one</td>"), std::string::npos);
+  EXPECT_EQ(page.find("<x-s"), std::string::npos);
+  EXPECT_EQ(page.find("<x-p"), std::string::npos);
+}
+
+// The run is what an editor addresses, so it stays wherever it is written.
+TEST(html, an_editable_cell_keeps_the_run_it_is_addressed_by) {
+  HtmlConfig config;
+  config.editable = true;
+
+  const std::string page = render_sheet(
+      fods_file(fods_row(fods_cell("one") + fods_cell("two"))), config);
+
+  EXPECT_NE(page.find(R"(<x-s contenteditable="true")"), std::string::npos);
+}
+
+// #822: a sheet cell does not break its text into lines unless the file says
+// to — `style:wrap-option` is `no-wrap` by default, and so is `wrapText`.
+TEST(html, a_sheet_cell_keeps_its_text_on_one_line) {
+  const std::string page =
+      render_sheet(fods_file(fods_row(fods_cell("one"))), HtmlConfig());
+
+  EXPECT_NE(page.find(".c0.c0.c0{vertical-align:top;white-space:nowrap}"),
+            std::string::npos);
+}
+
+// #822: and it keeps the block it breaks into lines in, which is what holds the
+// row to the height the file states. The cell cuts what runs past its bottom
+// rather than letting it paint over the row below.
+TEST(html, a_cell_the_file_says_to_wrap_wraps) {
+  const std::string page =
+      render_sheet(fods_file(fods_row(fods_cell("one", true))), HtmlConfig());
+
+  EXPECT_NE(page.find(".c0.c0.c0{vertical-align:top;overflow:hidden}"),
+            std::string::npos);
+  EXPECT_NE(page.find(R"(<td class="c0"><x-p )"), std::string::npos);
+}
+
+// #822: what a spreadsheet does with a line too long for its cell — over the
+// cell beside it while that one is empty, cut where the next one has something
+// to show. The spill is bounded, so it never paints over that content.
+TEST(html, a_cell_spills_over_a_blank_neighbour_and_is_cut_by_a_full_one) {
+  const std::string cut = render_sheet(
+      fods_file(fods_row(fods_cell("one") + fods_cell("two")), fods_columns(2)),
+      HtmlConfig());
+  const std::string spills = render_sheet(
+      fods_file(fods_row(fods_cell("one") + fods_blank() + fods_cell("three")),
+                fods_columns(3)),
+      HtmlConfig());
+
+  EXPECT_NE(cut.find("max-width:0;white-space:nowrap;overflow:hidden"),
+            std::string::npos);
+  EXPECT_NE(spills.find("max-width:0;white-space:nowrap;"
+                        "clip-path:inset(0 -96px 0 0)"),
+            std::string::npos);
+}
+
+// #822: and where nothing follows it at all, out onto the canvas — there is no
+// content to the right of the last column for it to paint over.
+TEST(html, a_cell_at_the_end_of_its_row_is_not_cut) {
+  const std::string page = render_sheet(
+      fods_file(fods_row(fods_cell("one")), fods_columns(1)), HtmlConfig());
+
+  EXPECT_EQ(page.find("nowrap;overflow:hidden"), std::string::npos);
+  EXPECT_EQ(page.find("nowrap;clip-path"), std::string::npos);
+}
+
+// #822 is a sheet's problem: nothing else repeats a style block often enough.
+TEST(html, a_text_document_keeps_its_styles_inline) {
+  const std::string page = render_markdown("one\n\ntwo\n");
+
+  EXPECT_NE(page.find(R"(<x-p style="display:block;")"), std::string::npos);
+  EXPECT_EQ(page.find(".c1.c1.c1"), std::string::npos);
+}
+
 // #816
 TEST(html, a_printed_sheet_drops_the_ruler_and_fits_the_page) {
   const std::string sheet =
       render("odr-public/ods/file_example_ODS_10.ods", HtmlConfig());
 
-  // on screen the sheet keeps its stated width and its ruler
-  EXPECT_NE(sheet.find("<col style=\"width:"), std::string::npos);
+  // on screen the sheet keeps its stated width and its ruler. Every column of
+  // this sheet is the same width, so that width is a class (#822).
+  EXPECT_NE(sheet.find("<col class=\"c"), std::string::npos);
+  EXPECT_NE(sheet.find("{width:"), std::string::npos);
   EXPECT_NE(sheet.find("table-layout:fixed"), std::string::npos);
   EXPECT_NE(sheet.find("class=\"odr-sheet-column-header\""), std::string::npos);
 

--- a/test/src/internal/util/stream_util_test.cpp
+++ b/test/src/internal/util/stream_util_test.cpp
@@ -1,6 +1,7 @@
 #include <odr/internal/util/stream_util.hpp>
 
 #include <ios>
+#include <sstream>
 #include <string>
 #include <string_view>
 
@@ -39,4 +40,47 @@ TEST(ViewStream, seek_out_of_range) {
   in.clear();
   in.seekg(-1, std::ios::beg);
   EXPECT_TRUE(in.fail());
+}
+
+// Nothing reaches the stream until the buffer is released, and the release
+// writes the prologue the held bytes need in front of them.
+TEST(DeferredBuffer, holds_until_released) {
+  std::ostringstream out;
+  stream::DeferredBuffer buffer(out, 1024, [&out] { out << "head"; });
+  std::ostream deferred(&buffer);
+
+  deferred << "body";
+  EXPECT_EQ(out.str(), "");
+
+  buffer.release();
+  EXPECT_EQ(out.str(), "headbody");
+
+  deferred << "tail";
+  EXPECT_EQ(out.str(), "headbodytail");
+}
+
+// Past the cap it releases itself, so what it holds is bounded.
+TEST(DeferredBuffer, releases_itself_past_the_cap) {
+  std::ostringstream out;
+  stream::DeferredBuffer buffer(out, 4, [&out] { out << "head"; });
+  std::ostream deferred(&buffer);
+
+  deferred << "abc";
+  EXPECT_EQ(out.str(), "");
+
+  deferred << "de";
+  EXPECT_EQ(out.str(), "headabcde");
+}
+
+// Releasing twice writes the prologue once.
+TEST(DeferredBuffer, releases_once) {
+  std::ostringstream out;
+  stream::DeferredBuffer buffer(out, 1024, [&out] { out << "head"; });
+  std::ostream deferred(&buffer);
+
+  deferred << "body";
+  buffer.release();
+  buffer.release();
+
+  EXPECT_EQ(out.str(), "headbody");
 }

--- a/wasm/src/wasm_html.cpp
+++ b/wasm/src/wasm_html.cpp
@@ -183,6 +183,11 @@ HtmlConfig to_html_config(const emscripten::val &value) {
                                          limit["rows"].as<std::uint32_t>(),
                                          limit["columns"].as<std::uint32_t>()));
   }
+  if (const emscripten::val buffer = value["spreadsheetStyleBuffer"];
+      !buffer.isUndefined() && !buffer.isNull()) {
+    config.spreadsheet_style_buffer =
+        static_cast<std::uint64_t>(buffer.as<double>());
+  }
   if (const emscripten::val limit = value["spreadsheetCellLimit"];
       !limit.isUndefined()) {
     // as a `number`, not a BigInt - a cell budget is nowhere near 2^53


### PR DESCRIPTION
🤖 Generated with [Claude Code](https://claude.com/claude-code)

Closes #822 and #238 ("handle spreadsheet cell overflow" — html tables and
ods/xlsx differ on overflow, which is what the wrap and spill rules settle).

A rendered sheet spent more than half its bytes on `style` attributes it wrote
over and over — 26 distinct blocks across 259,957 attributes in
`Supervised_Business_Register_300425.ods` — and four nodes per cell before any
content. It also broke every cell's text into lines, which no spreadsheet does
unless the file says to, and the second line then painted over the row below.

Everything here is a spreadsheet view. A text document, a presentation and a
drawing emit byte-identical html.

## A repeated style block becomes a class

`StyleRegistry` counts every block a view writes and names the ones written more
than once, `<head>` defining them once:

```html
<style>
.c1.c1.c1{width:0.889in;min-width:0.889in}
.c4.c4.c4{vertical-align:top;max-width:0;white-space:nowrap;overflow:hidden}
</style>
...
<td class="c4">01/04/2022</td>
```

The class names itself three times. That is not decoration: an inline `style`
outranks every rule in our own stylesheets, and `.c4` alone would lose
`vertical-align` to `.odr-sheet>tbody>tr>td` and a cell border to
`.odr-gridlines-soft .odr-sheet td`. Three classes buy the specificity back
while staying under `!important`, which is what the dark sheet relies on.

A block is named the first time it is written. `<head>` has to name the classes
before the cells that use them and the renderer streams, so a spreadsheet's body
is written into a buffer and the head goes out in front of it — one walk, where
a second would have cost as much as the first. The buffer is capped at 8 MB:
past that it is released early, and a block first seen afterwards stays inline,
which is what an unnamed one would have been anyway. That is the same shape the
pdf view has, where a page model holds the classes until the head is written.

## A cell holding one plain string writes no box of its own

`td > x-p > x-s > text` was four nodes before any content, and the `x-s` style
mostly repeated the `x-p` above it. The run always goes; the block goes too
where the file states no row height.

Where it states one, the block stays — it is the only thing that holds the row
to that height. Measured in Chrome: `contain: size`, `contain: strict`,
`max-height`, `overflow: hidden` on the cell or the row, and
`content-visibility` are **all** ignored on internal table elements, and a row's
`height` is a minimum by spec. Whether a line would have fitted depends on font
metrics the renderer does not have, so guessing was not an option either.

## A cell keeps its text on one line

`style:wrap-option` (ODF), `alignment@wrapText` (OOXML) and the XF `fWrap` bit
(XLS) are read into a new `TableCellStyle::wrap_text`, mirrored in the Python,
JNI and Apple bindings. All three formats default to no wrapping, which is what
Calc and Excel show.

A line too long for its cell then runs over the cells beside it while they hold
nothing, and is cut where the next one has something to show — bounded with
`clip-path: inset(0 -Npx 0 0)` over the measured width of the blank run, so it
never paints over that content — and out onto the canvas where nothing follows
it at all. A cell the file *does* wrap keeps its block and clips at the row, so
a wrapped line no longer paints over the row below either.

`max-width:0` on the cell is what keeps such a line from widening its column:
`table-layout: fixed` still sizes the *table* from content, and without it one
long string took a column from 85 px to 3139 px. It is emitted only where the
file states a column width, since a column that states none is exactly its
content's width.

`odr-public/ods/overflow.ods`, before and after — the file that documents this:

| | |
|---|---|
| before | rows 1-5 an unreadable pile of overlapping text |
| after | one line each; row 3 cut at B's edge, row 4 spilling over the empty C and cut before D's content |

## Clicking a cut cell raises it

The block goes out of flow, sized to the string and painted over its neighbours,
so no row moves. A click inside it is for the text — selecting it, and one day
editing it — not for the cell; a click anywhere else, or Escape, puts it back.
A cell that writes its string without a block gets a wrapper from the script for
as long as it is up.

## Numbers

Read-only, the config the Android viewer renders with:

| | before | after |
|---|---|---|
| `Supervised_Business_Register_300425.ods`, 500,000 cells | 121.4 MB | 37.7 MB |
| — inline `style` attributes | 1,547,585 | 0 |
| — elements in the table | 1.5 M | 1.0 M |
| the whole spreadsheet corpus, 314 views | 374 MB | 202 MB |
| render time, register sheet | 4.9 s | 4.9 s |
| peak RSS, register sheet | 475 MB | 493 MB |

## Verification

- `compare-html --driver chrome` over all 314 ods/xlsx/xls/csv/numbers views of
  the public and private corpora: **254 identical, 60 different** — every one of
  the 60 a sheet that used to wrap. An earlier run of the dedup and the run fold
  alone was 298/298 identical, in both the read-only and the editable config.
- Full `odr_test`: 1452 passed, 6 pre-existing skips.
- Buffering the body rather than walking twice moved nothing: 314 of 314
  identical against the two-pass version it replaces.
- Ten tests in `html_test.cpp` off an inline flat-ODS string, and
  `odr-public/ods/file_example_ODS_100.ods` pinned to the `read-only`
  reference-output variant.
- `test/browser/sheet/` — 14 checks for the raise behaviour, in the repo's
  existing idiom for script-only behaviour (`serve` lifts the css and js out of
  `frontend.cpp`, so what runs is what ships). All pass in Chrome.
- clang-tidy on the touched translation units reports nothing new.
- `DeferredBuffer` lives in `util/stream_util` with three unit tests of its own.

## Reference output

Regenerated: 361 files, every one a spreadsheet view, plus
`resources/spreadsheet*.{css,js}` — the last of which also catches up with
pre-existing drift from #817 and #820. Not pushed yet, so `test/data.cmake`
still points at the old revisions.
