### PR TITLE
fix(build): unbreak main — three PageLayout initializers and an msvc raw string

### DIFF
--- a/src/odr/internal/iwork/iwork_document.cpp
+++ b/src/odr/internal/iwork/iwork_document.cpp
@@ -197,6 +197,7 @@ public:
         .print_orientation = {},
         .margin = {},
         .background_color = {},
+        .direction = {},
     };
   }
   [[nodiscard]] ElementIdentifier slide_master_page(

--- a/src/odr/internal/oldms/presentation/ppt_document.cpp
+++ b/src/odr/internal/oldms/presentation/ppt_document.cpp
@@ -147,6 +147,7 @@ public:
           .print_orientation = {},
           .margin = {},
           .background_color = {},
+          .direction = {},
       };
     }
     return {
@@ -155,6 +156,7 @@ public:
         .print_orientation = {},
         .margin = {},
         .background_color = {},
+        .direction = {},
     };
   }
   [[nodiscard]] ElementIdentifier slide_master_page(

--- a/test/src/internal/odf/odf_flat_file_test.cpp
+++ b/test/src/internal/odf/odf_flat_file_test.cpp
@@ -587,10 +587,13 @@ TEST(FlatOpenDocumentFile, a_right_to_left_writing_mode_reads_as_a_direction) {
 /// Neither is a left-to-right claim.
 TEST(FlatOpenDocumentFile, a_writing_mode_without_a_side_names_no_direction) {
   for (const char *mode : {"tb-rl", "tb-lr", "tb", "page"}) {
+    // built outside the macro: msvc's traditional preprocessor does not read
+    // a raw string in a macro argument, and trips over the quotes inside it
+    const std::string properties =
+        R"(style:writing-mode=")" + std::string(mode) + R"(")";
     EXPECT_EQ(std::vector<std::optional<TextDirection>>(
                   {std::nullopt, std::nullopt, std::nullopt}),
-              directions_of(three_paragraphs(
-                  "P1", R"(style:writing-mode=")" + std::string(mode) + "\"")))
+              directions_of(three_paragraphs("P1", properties)))
         << mode;
   }
 }


### PR DESCRIPTION
🤖 Generated with [Claude Code](https://claude.com/claude-code)

`main` is red: its own `build-test` run for #820 fails three of the matrix jobs
(gcc-14, clang-18 `-Werror`, msvc-1940). Two independent causes, both from
already-merged work.

## `PageLayout::direction`

#819 added `direction` to `PageLayout` and left three designated initializers
that name every other field, so `-Wmissing-field-initializers` refuses them:

- `iwork_document.cpp` `slide_page_layout`
- `ppt_document.cpp` `slide_page_layout`, both branches

Only the iwork one appears in the log — gcc stops at the first error, so the two
ppt sites were still hiding behind it. AppleClang does not warn here, which is
why it got through review locally.

## The msvc raw string

`odf_flat_file_test.cpp` builds the writing-mode attribute inside an `EXPECT_EQ`
argument:

```cpp
directions_of(three_paragraphs(
    "P1", R"(style:writing-mode=")" + std::string(mode) + "\""))
```

MSVC's traditional preprocessor does not recognise a raw string literal while
scanning a macro argument, so the `"` inside `R"(…")"` closes a string early and
the later `"\""` lands outside one — `error C2017: illegal escape sequence`. The
attribute is now built into a local before the macro sees it, and the trailing
quote is a raw string too rather than an escape.

`/Zc:preprocessor` would fix the class of problem rather than this instance, but
it changes how every translation unit is preprocessed on msvc, which is not a
thing to slip into a red-main fix.

## Verification

Full suite green (1442 passed, 6 skipped). The three initializer sites now
compile clean under gcc with `-Wall -Wextra -Werror`, checked locally against
libstdc++ — that is the warning surface AppleClang does not reproduce. The msvc
half only CI can confirm.

No `CHANGELOG.md` entry: nothing a consumer notices, and `.direction` was
already defaulting to the same empty value it now names.

#823 is rebased on top of this.
