### PR TITLE
refactor: include what these two files use, and reverse by range

### DIFF
--- a/src/odr/internal/common/random.cpp
+++ b/src/odr/internal/common/random.cpp
@@ -1,6 +1,7 @@
 #include <odr/internal/common/random.hpp>
 
 #include <algorithm>
+#include <iterator>
 #include <random>
 
 namespace odr {

--- a/src/odr/internal/font/type1_charstring.cpp
+++ b/src/odr/internal/font/type1_charstring.cpp
@@ -321,7 +321,7 @@ private:
       m_stack.pop_back();
     }
     // args is reversed (top first); restore call order.
-    std::reverse(args.begin(), args.end());
+    std::ranges::reverse(args);
 
     switch (othersubr) {
     case 1: // flex start

--- a/test/src/internal/odf/odf_table_test.cpp
+++ b/test/src/internal/odf/odf_table_test.cpp
@@ -14,6 +14,7 @@
 
 #include <gtest/gtest.h>
 
+#include <algorithm>
 #include <filesystem>
 #include <fstream>
 #include <memory>


### PR DESCRIPTION
🤖 Generated with [Claude Code](https://claude.com/claude-code)

Broken out of #826 — three changes that are valid C++20 and need nothing from
the bump, so the C++23 PR is left holding only what actually requires C++23.

- `common/random.cpp` calls `std::back_inserter` without `<iterator>`.
- `odf_table_test.cpp` calls `std::ranges::find` without `<algorithm>`.

Both compile today only because libc++ hands those out transitively through
`<algorithm>` and `<random>`. It stops doing so under C++23, which is why these
two lines were the *entire* source cost of that bump — they are correct on their
own terms either way.

- `type1_charstring.cpp`'s `std::reverse(args.begin(), args.end())` becomes
  `std::ranges::reverse(args)`, per the ranges convention in AGENTS.md. C++20,
  unrelated to the includes; here because it is the same size.

Builds clean at C++20 (`-Wall -Wextra`), no behaviour change.