### PR TITLE
test(data): advance the reference-output pins onto the run #824 pushed

### DIFF
--- a/test/data.cmake
+++ b/test/data.cmake
@@ -17,9 +17,9 @@ odr_test_data(
 odr_test_data(
         PATH "reference-output/odr-public"
         URL "https://github.com/opendocument-app/OpenDocument.test.output.git"
-        REVISION "8d9a5459118e25eb44db8b86564b7848cb5a4b66")
+        REVISION "a89a503618ee75f597d64d5dc2990d973a8e6e3d")
 
 odr_test_data(
         PATH "reference-output/odr-private"
         URL "https://github.com/opendocument-app/OpenDocument.test-private.output.git"
-        REVISION "a83bd65792fba59ad2555c9e56a54bcb8f4605f0")
+        REVISION "27f66375b17729a3df858daf756bcceb803e7879")


### PR DESCRIPTION
🤖 Generated with [Claude Code](https://claude.com/claude-code)

`main` is red, and so is every open pull request: the `test` leg's
`compare-html` step dies before it compares anything.

```
ValueError: 'build/test/output/odr-public/output/ods/file_example_ODS_100.ods-read-only'
  is not in the subpath of 'test/data/reference-output/odr-public/output'
```

#824 regenerated and pushed reference output but left `test/data.cmake` pinned
at #819's revisions, so CI clones a tree two commits behind what the suite now
writes. The first directory with no reference is
`ods/file_example_ODS_100.ods-read-only`, one of the second-config outputs #699
added — and htmlcmp reports it by building the failure's path with
`relative_to(a)` for a path that lives under `b`, so it raises instead. The
crash is what you see; the pin lag is what caused it.

Two lines, onto the commits that match `main` today:

| | from | to |
|---|---|---|
| `reference-output/odr-public` | `8d9a545` (#819) | `a89a503` (#824) |
| `reference-output/odr-private` | `a83bd65` (#819) | `27f6637` (#824) |

Not the tips of those repositories — the commit above each is in-flight work
that has not landed here.

## Verified

A full RelWithDebInfo run of the suite, diffed against both output repositories
checked out at exactly these two commits:

```
diff -rq  public:  0 lines
diff -rq  private: 0 lines
```