### PR TITLE
refactor(api)!: drop the inert config and charset surface

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,14 @@ The release run heads these entries with the version and opens a fresh
 
 ## Unreleased
 
+- **Breaking**: the inert `HtmlConfig` fields `background_image_format`,
+  `background_image_dpi`, `no_drm` and `embed_outline` are gone, with their
+  java, python, objc and wasm mirrors. Drop them; nothing replaces them.
+
+- **Breaking**: `TextFile::charset()` and the `UnknownCharset` exception are
+  gone. Use `TextFile::encoding()`, which returns `TextEncoding::unknown` where
+  `charset()` returned `nullopt`. The bindings' own `charset()` is unchanged.
+
 - **Breaking**: `GlobalParams` is gone, with its java, python and objc mirrors,
   `OdrAndroid.init`, and the `ODR_WITH_LIBMAGIC` / `ODR_BUNDLE_ASSETS` cmake
   options. All of it was inert; delete the calls, nothing replaces them.

--- a/apple/include/OdrCoreObjC/ODRHtml.h
+++ b/apple/include/OdrCoreObjC/ODRHtml.h
@@ -122,11 +122,6 @@ NS_SWIFT_NAME(HtmlConfig)
 @property(nonatomic) uint8_t htmlIndent;
 @property(nonatomic, copy) NSString *htmlIndentString;
 
-/// @deprecated Inert.
-@property(nonatomic, copy) NSString *backgroundImageFormat;
-/// @deprecated Inert.
-@property(nonatomic) double backgroundImageDpi;
-
 /// Render only pages `[begin, end)`, 0-based. `nil` end means to the last page.
 @property(nonatomic) uint32_t pageRangeBegin;
 @property(nonatomic, strong, nullable)
@@ -135,11 +130,6 @@ NS_SWIFT_NAME(HtmlConfig)
 @property(nonatomic) ODRPdfTextMode pdfTextMode;
 @property(nonatomic, copy) NSArray<NSString *> *pdfDualLayerFallbackFonts;
 @property(nonatomic) double pdfDualLayerFallbackFontSizeAdjust;
-
-/// @deprecated Inert.
-@property(nonatomic) BOOL noDrm;
-/// @deprecated Inert.
-@property(nonatomic) BOOL embedOutline;
 
 @property(nonatomic, copy, nullable) NSString *outputPath;
 

--- a/apple/src/ODRHtml.mm
+++ b/apple/src/ODRHtml.mm
@@ -124,8 +124,6 @@ std::vector<std::string> to_strings(NSArray<NSString *> *strings) {
   _formatHtml = config.format_html ? YES : NO;
   _htmlIndent = config.html_indent;
   _htmlIndentString = to_nsstring(config.html_indent_string);
-  _backgroundImageFormat = to_nsstring(config.background_image_format);
-  _backgroundImageDpi = config.background_image_dpi;
   _pageRangeBegin = config.page_range_begin;
   _pageRangeEnd = config.page_range_end.has_value()
                       ? @(static_cast<unsigned int>(*config.page_range_end))
@@ -134,8 +132,6 @@ std::vector<std::string> to_strings(NSArray<NSString *> *strings) {
   _pdfDualLayerFallbackFonts = to_nsarray(config.pdf_dual_layer_fallback_fonts);
   _pdfDualLayerFallbackFontSizeAdjust =
       config.pdf_dual_layer_fallback_font_size_adjust;
-  _noDrm = config.no_drm ? YES : NO;
-  _embedOutline = config.embed_outline ? YES : NO;
   _outputPath =
       config.output_path.has_value() ? to_nsstring(*config.output_path) : nil;
   return self;
@@ -211,8 +207,6 @@ std::vector<std::string> to_strings(NSArray<NSString *> *strings) {
   config.format_html = _formatHtml == YES;
   config.html_indent = _htmlIndent;
   config.html_indent_string = to_string(_htmlIndentString);
-  config.background_image_format = to_string(_backgroundImageFormat);
-  config.background_image_dpi = _backgroundImageDpi;
   config.page_range_begin = _pageRangeBegin;
   if (_pageRangeEnd != nil) {
     config.page_range_end =
@@ -224,8 +218,6 @@ std::vector<std::string> to_strings(NSArray<NSString *> *strings) {
   config.pdf_dual_layer_fallback_fonts = to_strings(_pdfDualLayerFallbackFonts);
   config.pdf_dual_layer_fallback_font_size_adjust =
       _pdfDualLayerFallbackFontSizeAdjust;
-  config.no_drm = _noDrm == YES;
-  config.embed_outline = _embedOutline == YES;
   if (_outputPath != nil) {
     config.output_path = to_string(_outputPath);
   } else {

--- a/jni/java/app/opendocument/core/HtmlConfig.java
+++ b/jni/java/app/opendocument/core/HtmlConfig.java
@@ -62,12 +62,6 @@ public final class HtmlConfig {
   public int htmlIndent = 1;
   public String htmlIndentString = "\t";
 
-  /** @deprecated Inert. */
-  @Deprecated public String backgroundImageFormat = "png";
-
-  /** @deprecated Inert. */
-  @Deprecated public double backgroundImageDpi = 144.0;
-
   public int pageRangeBegin = 0;
   /** {@code null} renders to the end of the document. */
   public Integer pageRangeEnd;
@@ -77,12 +71,6 @@ public final class HtmlConfig {
     "Arial", "Helvetica", "Liberation Sans", "DejaVu Sans", "Nimbus Sans"
   };
   public double pdfDualLayerFallbackFontSizeAdjust = 0.5;
-
-  /** @deprecated Inert. */
-  @Deprecated public boolean noDrm = false;
-
-  /** @deprecated Inert. */
-  @Deprecated public boolean embedOutline = false;
 
   /** {@code null} keeps output in the cache directory. */
   public String outputPath;

--- a/jni/src/jni_style.cpp
+++ b/jni/src/jni_style.cpp
@@ -489,8 +489,6 @@ jobject html_config_to_java(JNIEnv *env, const odr::HtmlConfig &config) {
   set_boolean("formatHtml", config.format_html);
   set_int("htmlIndent", config.html_indent);
   set_string("htmlIndentString", config.html_indent_string);
-  set_string("backgroundImageFormat", config.background_image_format);
-  set_double("backgroundImageDpi", config.background_image_dpi);
   set_int("pageRangeBegin", static_cast<jint>(config.page_range_begin));
   set_object("pageRangeEnd", "Ljava/lang/Integer;",
              box_integer(env, config.page_range_end));
@@ -514,8 +512,6 @@ jobject html_config_to_java(JNIEnv *env, const odr::HtmlConfig &config) {
   }
   set_double("pdfDualLayerFallbackFontSizeAdjust",
              config.pdf_dual_layer_fallback_font_size_adjust);
-  set_boolean("noDrm", config.no_drm);
-  set_boolean("embedOutline", config.embed_outline);
   set_object("outputPath", "Ljava/lang/String;",
              make_string_opt(env, config.output_path));
 
@@ -678,8 +674,6 @@ odr::HtmlConfig html_config_from_java(JNIEnv *env, jobject config) {
   result.format_html = get_boolean("formatHtml");
   result.html_indent = static_cast<std::uint8_t>(get_int("htmlIndent"));
   result.html_indent_string = get_string("htmlIndentString");
-  result.background_image_format = get_string("backgroundImageFormat");
-  result.background_image_dpi = get_double("backgroundImageDpi");
   result.page_range_begin =
       static_cast<std::uint32_t>(get_int("pageRangeBegin"));
   {
@@ -716,8 +710,6 @@ odr::HtmlConfig html_config_from_java(JNIEnv *env, jobject config) {
   }
   result.pdf_dual_layer_fallback_font_size_adjust =
       get_double("pdfDualLayerFallbackFontSizeAdjust");
-  result.no_drm = get_boolean("noDrm");
-  result.embed_outline = get_boolean("embedOutline");
   result.output_path = get_string_opt("outputPath");
 
   env->DeleteLocalRef(cls);

--- a/python/src/bind_html.cpp
+++ b/python/src/bind_html.cpp
@@ -101,12 +101,6 @@ void odr_python::bind_html(py::module_ &m) {
       .def_readwrite("format_html", &odr::HtmlConfig::format_html)
       .def_readwrite("html_indent", &odr::HtmlConfig::html_indent)
       .def_readwrite("html_indent_string", &odr::HtmlConfig::html_indent_string)
-      .def_readwrite("background_image_format",
-                     &odr::HtmlConfig::background_image_format,
-                     "Deprecated and inert.")
-      .def_readwrite("background_image_dpi",
-                     &odr::HtmlConfig::background_image_dpi,
-                     "Deprecated and inert.")
       .def_readwrite("page_range_begin", &odr::HtmlConfig::page_range_begin)
       .def_readwrite("page_range_end", &odr::HtmlConfig::page_range_end)
       .def_readwrite("pdf_text_mode", &odr::HtmlConfig::pdf_text_mode)
@@ -114,10 +108,6 @@ void odr_python::bind_html(py::module_ &m) {
                      &odr::HtmlConfig::pdf_dual_layer_fallback_fonts)
       .def_readwrite("pdf_dual_layer_fallback_font_size_adjust",
                      &odr::HtmlConfig::pdf_dual_layer_fallback_font_size_adjust)
-      .def_readwrite("no_drm", &odr::HtmlConfig::no_drm,
-                     "Deprecated and inert.")
-      .def_readwrite("embed_outline", &odr::HtmlConfig::embed_outline,
-                     "Deprecated and inert.")
       .def_readwrite("output_path", &odr::HtmlConfig::output_path)
       .def_readwrite("resource_locator", &odr::HtmlConfig::resource_locator);
 

--- a/src/odr/exceptions.cpp
+++ b/src/odr/exceptions.cpp
@@ -49,8 +49,6 @@ NoMarkdownFile::NoMarkdownFile() : Exception("not a markdown file") {}
 
 NoJsonFile::NoJsonFile() : Exception("not a json file") {}
 
-UnknownCharset::UnknownCharset() : Exception("unknown charset") {}
-
 NoImageFile::NoImageFile() : Exception("not an image file") {}
 
 NoArchiveFile::NoArchiveFile() : Exception("not an archive file") {}

--- a/src/odr/exceptions.hpp
+++ b/src/odr/exceptions.hpp
@@ -100,13 +100,6 @@ struct NoJsonFile final : Exception {
   NoJsonFile();
 };
 
-/// @brief Unknown charset exception
-/// @deprecated Nothing throws this any more: a file whose encoding cannot be
-/// named is still text, and reports @ref TextEncoding::unknown.
-struct [[deprecated("nothing throws this")]] UnknownCharset final : Exception {
-  UnknownCharset();
-};
-
 /// @brief No image file exception
 struct NoImageFile final : Exception {
   NoImageFile();

--- a/src/odr/file.cpp
+++ b/src/odr/file.cpp
@@ -301,14 +301,6 @@ TextFile::TextFile(std::shared_ptr<internal::abstract::TextFile> impl)
 
 TextEncoding TextFile::encoding() const { return m_impl->encoding(); }
 
-std::optional<std::string> TextFile::charset() const {
-  const TextEncoding encoding = this->encoding();
-  if (encoding == TextEncoding::unknown) {
-    return {};
-  }
-  return std::string(text_encoding_to_string(encoding));
-}
-
 std::unique_ptr<std::istream> TextFile::stream() const {
   return m_impl->file()->stream();
 }

--- a/src/odr/file.hpp
+++ b/src/odr/file.hpp
@@ -424,11 +424,6 @@ public:
   /// @brief The encoding the file's bytes were detected as, or decoded with.
   [[nodiscard]] TextEncoding encoding() const;
 
-  /// @deprecated See @ref encoding. Returns the encoding's canonical name, and
-  /// `nullopt` for @ref TextEncoding::unknown.
-  [[deprecated("use encoding()")]] [[nodiscard]] std::optional<std::string>
-  charset() const;
-
   /// @brief The file's bytes as they are.
   [[nodiscard]] std::unique_ptr<std::istream> stream() const;
   /// @brief The file's text, decoded to UTF-8 where @ref encoding is

--- a/src/odr/html.hpp
+++ b/src/odr/html.hpp
@@ -175,11 +175,6 @@ struct HtmlConfig {
   std::uint8_t html_indent{1};
   std::string html_indent_string{"\t"};
 
-  /// @deprecated Inert: no view renders a background image to a file.
-  std::string background_image_format{"png"};
-  /// @deprecated See @ref background_image_format.
-  double background_image_dpi{144.0};
-
   /// Renders only the pages with 0-based index in `[page_range_begin,
   /// page_range_end)`; page views and `#pN` anchors keep their document-global
   /// numbers. Honored by the pdf pipeline.
@@ -195,12 +190,6 @@ struct HtmlConfig {
   /// Shrinks the fallback's metrics toward the pdf's (0-1) so css justify can
   /// fill the box. Safe to underestimate: the excess is clipped, not shrunk.
   double pdf_dual_layer_fallback_font_size_adjust{0.5};
-
-  /// @deprecated Inert: no output carries a restriction to lift.
-  bool no_drm{false};
-
-  /// @deprecated Inert: an outline is never written.
-  bool embed_outline{false};
 
   std::optional<std::string> output_path;
   HtmlResourceLocator resource_locator;

--- a/wasm/js/index.d.ts
+++ b/wasm/js/index.d.ts
@@ -86,14 +86,6 @@ export interface HtmlConfig {
   editable?: boolean;
   textDocumentMargin?: boolean;
   formatHtml?: boolean;
-  /** @deprecated Inert. */
-  embedOutline?: boolean;
-  /** @deprecated Inert. */
-  noDrm?: boolean;
-  /** @deprecated Inert. */
-  backgroundImageFormat?: string;
-  /** @deprecated Inert. */
-  backgroundImageDpi?: number;
   pageRangeBegin?: number;
   pageRangeEnd?: number;
   colorScheme?: number;

--- a/wasm/src/wasm_html.cpp
+++ b/wasm/src/wasm_html.cpp
@@ -159,11 +159,6 @@ HtmlConfig to_html_config(const emscripten::val &value) {
   read(value, "editable", config.editable);
   read(value, "textDocumentMargin", config.text_document_margin);
   read(value, "formatHtml", config.format_html);
-  read(value, "embedOutline", config.embed_outline);
-  read(value, "noDrm", config.no_drm);
-
-  read(value, "backgroundImageFormat", config.background_image_format);
-  read(value, "backgroundImageDpi", config.background_image_dpi);
 
   read(value, "pageRangeBegin", config.page_range_begin);
   if (const emscripten::val end = value["pageRangeEnd"];


### PR DESCRIPTION
🤖 Generated with [Claude Code](https://claude.com/claude-code)

PR 3 of the [v7 API plan](https://github.com/opendocument-app/OpenDocument.core/pull/831).
Same premise as #832 — surface that was kept only so existing callers kept
compiling, removed now that a major allows it.

## `HtmlConfig`

Four fields stored a value no view ever read back:

| field | dead since |
|---|---|
| `background_image_format`, `background_image_dpi` | no view renders a background image to a file |
| `no_drm` | no output carries a restriction to lift |
| `embed_outline` | an outline is never written |

Gone with their java, python, objc and wasm mirrors — including the
`@deprecated` entries in `index.d.ts`, so a TypeScript caller finds out at
compile time.

## `TextFile::charset()` and `UnknownCharset`

`charset()` was `text_encoding_to_string(encoding())` with a `nullopt` for
unknown. `encoding()` says the same thing as a `TextEncoding` and reports
`TextEncoding::unknown` instead of an empty optional. `UnknownCharset` goes
too — nothing throws it, because a file whose encoding cannot be named is still
text.

**The bindings keep their own `charset()`.** Worth being explicit, because it
looks like an oversight and is not: those accessors are not mirrors of the
removed overload — JNI, python and objc each build the string from
`encoding()` directly. Removing them would *lose* the accessor rather than
redirect it, because **`TextEncoding` is not mirrored in any binding**. So a
binding-side removal has a prerequisite, which turns out to matter beyond this
PR:

> Mirroring `TextEncoding` (the enum, plus `text_encoding_to_string`,
> `text_encoding_by_name`, `text_encoding_names`, `text_encoding_is_decodable`,
> `all_text_encodings`) is a **non-breaking addition**, and it is also what PR 7
> needs before `CsvOptions` can be folded into the decode options — `CsvOptions`
> carries a `TextEncoding`. It becomes its own PR, before 7.

That reordering is the one thing here that was not in the plan when #831 was
written; I will update the plan doc on that branch.

## Verified

Library, CLI, JNI + jar, python module and `odr_test` build clean; 69 python
tests and the 57 `*Csv*`/`*Text*`/`*Encoding*` gtests pass.

## Migration

- `config.background_image_*`, `config.no_drm`, `config.embed_outline` — delete.
- `text_file.charset()` → `text_file.encoding()`, comparing against
  `TextEncoding::unknown` instead of checking the optional. `text_encoding_to_string`
  gives the old string back if you want it.