### PR TITLE
refactor(html)!: cut translate to its four inputs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,10 @@ The release run heads these entries with the version and opens a fresh
 
 ## Unreleased
 
+- **Breaking**: `html::translate` is four overloads instead of twenty, taking a
+  `DecodedFile`, `Document`, `Filesystem` or `Archive`. The `cache_path` and
+  narrowed-handle ones are gone, in every binding too: drop the cache path.
+
 - **Breaking**: the inert `HtmlConfig` fields `background_image_format`,
   `background_image_dpi`, `no_drm` and `embed_outline` are gone, with their
   java, python, objc and wasm mirrors. Drop them; nothing replaces them.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,12 +16,9 @@ The release run heads these entries with the version and opens a fresh
 
 ## Unreleased
 
-- **Breaking**: `html::translate` is five overloads instead of twenty, taking a
-  `DecodedFile`, `TextFile`, `Document`, `Filesystem` or `Archive`. The
-  `cache_path` and the other narrowed-handle ones are gone, in every binding
-  too: drop the cache path. `TextFile` stays because it is not the same call —
-  it writes the numbered line list, where `translate(DecodedFile)` renders an
-  xml as its source view and a csv as a table.
+- **Breaking**: `html::translate` takes only a `DecodedFile`, `Document`,
+  `Filesystem` or `Archive` now; drop the cache path, in every binding. Open a
+  file as `FileType::text_file` to render it as a numbered line list.
 
 - **Breaking**: the inert `HtmlConfig` fields `background_image_format`,
   `background_image_dpi`, `no_drm` and `embed_outline` are gone, with their

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,9 +16,12 @@ The release run heads these entries with the version and opens a fresh
 
 ## Unreleased
 
-- **Breaking**: `html::translate` is four overloads instead of twenty, taking a
-  `DecodedFile`, `Document`, `Filesystem` or `Archive`. The `cache_path` and
-  narrowed-handle ones are gone, in every binding too: drop the cache path.
+- **Breaking**: `html::translate` is five overloads instead of twenty, taking a
+  `DecodedFile`, `TextFile`, `Document`, `Filesystem` or `Archive`. The
+  `cache_path` and the other narrowed-handle ones are gone, in every binding
+  too: drop the cache path. `TextFile` stays because it is not the same call —
+  it writes the numbered line list, where `translate(DecodedFile)` renders an
+  xml as its source view and a csv as a table.
 
 - **Breaking**: the inert `HtmlConfig` fields `background_image_format`,
   `background_image_dpi`, `no_drm` and `embed_outline` are gone, with their

--- a/android/src/androidTest/java/app/opendocument/core/DocumentTest.kt
+++ b/android/src/androidTest/java/app/opendocument/core/DocumentTest.kt
@@ -85,11 +85,10 @@ class DocumentTest {
 
     @Test
     fun translateToHtml() {
-        val cache = Files.createDirectories(tempDir.resolve("cache"))
         val output = Files.createDirectories(tempDir.resolve("output"))
 
         val file = Odr.open(TestFiles.odtFile(tempDir).toString())
-        val service = Html.translate(file, cache.toString(), HtmlConfig())
+        val service = Html.translate(file, HtmlConfig())
         val html = service.bringOffline(output.toString())
 
         val pages = html.pages()
@@ -112,9 +111,8 @@ class DocumentTest {
 
     @Test
     fun translateCsv() {
-        val cache = Files.createDirectories(tempDir.resolve("csv-cache"))
         val file = Odr.open(TestFiles.csvFile(tempDir).toString())
-        val service = Html.translate(file, cache.toString(), HtmlConfig())
+        val service = Html.translate(file, HtmlConfig())
 
         // a spreadsheet: a document view plus one per sheet
         val views = service.listViews()

--- a/android/src/androidTest/java/app/opendocument/core/HttpServerTest.kt
+++ b/android/src/androidTest/java/app/opendocument/core/HttpServerTest.kt
@@ -4,7 +4,6 @@ import androidx.test.ext.junit.runners.AndroidJUnit4
 import java.io.IOException
 import java.net.HttpURLConnection
 import java.net.URL
-import java.nio.file.Files
 import java.nio.file.Path
 import java.util.concurrent.atomic.AtomicReference
 import org.junit.Assert.assertEquals
@@ -60,12 +59,11 @@ class HttpServerTest {
 
         val server = HttpServer()
 
-        val cachePath = Files.createDirectories(tempDir.resolve("doc-cache")).toString()
         val file = Odr.open(TestFiles.odtFile(tempDir).toString())
         val htmlConfig = HtmlConfig()
         htmlConfig.embedImages = false
         htmlConfig.relativeResourcePaths = false
-        val service = Html.translate(file, cachePath, htmlConfig)
+        val service = Html.translate(file, htmlConfig)
         server.connectService(service, "doc")
         val views = service.listViews()
         assertEquals(1, views.size)

--- a/apple/README.md
+++ b/apple/README.md
@@ -24,7 +24,7 @@ Requires iOS 15 or macOS 12.
 let file = try DecodedFile.decode(path: path)
 let config = HtmlConfig()
 let service = try HtmlTranslator.translate(
-  file: file, cachePath: cacheDirectory, config: config)
+  file: file, config: config)
 
 for view in service.views {
   var resources: NSArray?
@@ -50,7 +50,7 @@ it beats writing every page to disk up front.
 
 ```swift
 let service = try HtmlTranslator.translate(
-  file: file, cachePath: cacheDirectory, config: HtmlConfig())
+  file: file, config: HtmlConfig())
 
 let server = HttpServer()
 try server.connect(service, prefix: "doc")

--- a/apple/include/OdrCoreObjC/ODRHtml.h
+++ b/apple/include/OdrCoreObjC/ODRHtml.h
@@ -257,39 +257,34 @@ NS_SWIFT_NAME(HtmlService)
 NS_SWIFT_NAME(HtmlTranslator)
 @interface ODRHtmlTranslator : NSObject
 
-/// Translates a decoded file. `cachePath` is a directory for temporary output.
+/// Translates a decoded file, dispatching on what it decoded to.
 + (nullable ODRHtmlService *)translateFile:(ODRDecodedFile *)file
-                                 cachePath:(NSString *)cachePath
                                     config:(ODRHtmlConfig *)config
                                      error:(NSError **)error
-    NS_SWIFT_NAME(translate(file:cachePath:config:));
+    NS_SWIFT_NAME(translate(file:config:));
 + (nullable ODRHtmlService *)translateFile:(ODRDecodedFile *)file
-                                 cachePath:(NSString *)cachePath
                                     config:(ODRHtmlConfig *)config
                                     logger:(ODRLogger *)logger
                                      error:(NSError **)error
-    NS_SWIFT_NAME(translate(file:cachePath:config:logger:));
+    NS_SWIFT_NAME(translate(file:config:logger:));
 
 /// Translates an already-decoded document.
 + (nullable ODRHtmlService *)translateDocument:(ODRDocument *)document
-                                     cachePath:(NSString *)cachePath
                                         config:(ODRHtmlConfig *)config
                                          error:(NSError **)error
-    NS_SWIFT_NAME(translate(document:cachePath:config:));
+    NS_SWIFT_NAME(translate(document:config:));
 
 /// Translates a filesystem — a document's parts, or an archive's contents.
 + (nullable ODRHtmlService *)translateFilesystem:(ODRFilesystem *)filesystem
-                                       cachePath:(NSString *)cachePath
                                           config:(ODRHtmlConfig *)config
                                            error:(NSError **)error
-    NS_SWIFT_NAME(translate(filesystem:cachePath:config:));
+    NS_SWIFT_NAME(translate(filesystem:config:));
 
 /// Translates an archive.
 + (nullable ODRHtmlService *)translateArchive:(ODRArchive *)archive
-                                    cachePath:(NSString *)cachePath
                                        config:(ODRHtmlConfig *)config
                                         error:(NSError **)error
-    NS_SWIFT_NAME(translate(archive:cachePath:config:));
+    NS_SWIFT_NAME(translate(archive:config:));
 
 /// Applies a diff produced by the browser-side JavaScript back to `document`.
 + (BOOL)editDocument:(ODRDocument *)document

--- a/apple/src/ODRHtml.mm
+++ b/apple/src/ODRHtml.mm
@@ -504,61 +504,51 @@ NSArray<ODRHtmlResource *> *to_nsarray(const odr::HtmlResources &resources) {
 @implementation ODRHtmlTranslator
 
 + (nullable ODRHtmlService *)translateFile:(ODRDecodedFile *)file
-                                 cachePath:(NSString *)cachePath
                                     config:(ODRHtmlConfig *)config
                                      error:(NSError **)error {
   return [ODRHtmlTranslator translateFile:file
-                                cachePath:cachePath
                                    config:config
                                    logger:ODRLogger.null
                                     error:error];
 }
 
 + (nullable ODRHtmlService *)translateFile:(ODRDecodedFile *)file
-                                 cachePath:(NSString *)cachePath
                                     config:(ODRHtmlConfig *)config
                                     logger:(ODRLogger *)logger
                                      error:(NSError **)error {
   return guarded(error, [&]() -> ODRHtmlService * {
     return [ODRHtmlService
-        serviceWithHandle:odr::html::translate(
-                              file.handle, to_string(cachePath),
-                              config.nativeConfig, logger.handle)];
+        serviceWithHandle:odr::html::translate(file.handle, config.nativeConfig,
+                                               logger.handle)];
   });
 }
 
 + (nullable ODRHtmlService *)translateDocument:(ODRDocument *)document
-                                     cachePath:(NSString *)cachePath
                                         config:(ODRHtmlConfig *)config
                                          error:(NSError **)error {
   return guarded(error, [&]() -> ODRHtmlService * {
     return [ODRHtmlService
         serviceWithHandle:odr::html::translate(document.handle,
-                                               to_string(cachePath),
                                                config.nativeConfig)];
   });
 }
 
 + (nullable ODRHtmlService *)translateFilesystem:(ODRFilesystem *)filesystem
-                                       cachePath:(NSString *)cachePath
                                           config:(ODRHtmlConfig *)config
                                            error:(NSError **)error {
   return guarded(error, [&]() -> ODRHtmlService * {
     return [ODRHtmlService
         serviceWithHandle:odr::html::translate(filesystem.handle,
-                                               to_string(cachePath),
                                                config.nativeConfig)];
   });
 }
 
 + (nullable ODRHtmlService *)translateArchive:(ODRArchive *)archive
-                                    cachePath:(NSString *)cachePath
                                        config:(ODRHtmlConfig *)config
                                         error:(NSError **)error {
   return guarded(error, [&]() -> ODRHtmlService * {
     return [ODRHtmlService
         serviceWithHandle:odr::html::translate(archive.handle,
-                                               to_string(cachePath),
                                                config.nativeConfig)];
   });
 }

--- a/apple/tests/OdrCoreTests.swift
+++ b/apple/tests/OdrCoreTests.swift
@@ -121,7 +121,7 @@ final class HtmlTests: XCTestCase {
   private func service() throws -> HtmlService {
     let file = try DecodedFile.decode(path: try Fixture.odt())
     return try HtmlTranslator.translate(
-      file: file, cachePath: try temporaryDirectory(), config: HtmlConfig())
+      file: file, config: HtmlConfig())
   }
 
   func testRendersHtml() throws {
@@ -152,7 +152,7 @@ final class HtmlTests: XCTestCase {
 
     let file = try DecodedFile.decode(path: try Fixture.odt())
     let service = try HtmlTranslator.translate(
-      file: file, cachePath: try temporaryDirectory(), config: config)
+      file: file, config: config)
     var resources: NSArray?
     let html = try XCTUnwrap(service.views.first).writeHtml(resources: &resources)
 
@@ -188,7 +188,7 @@ final class HtmlTests: XCTestCase {
       "alpha,beta\ngamma,delta\nepsilon,zeta\n", as: "table.csv")
     let file = try DecodedFile.decode(path: path)
     let service = try HtmlTranslator.translate(
-      file: file, cachePath: try temporaryDirectory(), config: config)
+      file: file, config: config)
     var resources: NSArray?
     let html = try XCTUnwrap(service.views.first).writeHtml(resources: &resources)
 
@@ -242,8 +242,7 @@ final class HttpServerTests: XCTestCase {
     let config = HtmlConfig()
     config.relativeResourcePaths = false
     let service = try HtmlTranslator.translate(
-      file: try DecodedFile.decode(path: try Fixture.odt()),
-      cachePath: try temporaryDirectory(), config: config)
+      file: try DecodedFile.decode(path: try Fixture.odt()), config: config)
 
     let server = HttpServer()
     try server.connect(service, prefix: "doc")

--- a/cli/src/server.cpp
+++ b/cli/src/server.cpp
@@ -6,7 +6,6 @@
 #include <odr/http_server.hpp>
 
 #include <cstdint>
-#include <filesystem>
 #include <iostream>
 #include <string>
 
@@ -48,12 +47,6 @@ int main(const int argc, char **argv) {
 
     const HttpServer server{{}, logger};
 
-    // the server does not own a cache any more, so the translation goes
-    // somewhere of our choosing
-    const std::filesystem::path cache_path =
-        std::filesystem::temp_directory_path() / "odr-server";
-    std::filesystem::remove_all(cache_path);
-
     // bind before anything is printed: the port is only known once the socket
     // is, and it is not necessarily the one that was asked for
     const std::uint32_t port = server.bind("localhost", 8080);
@@ -66,11 +59,9 @@ int main(const int argc, char **argv) {
 
     {
       const std::string prefix = "file";
-      const std::string prefix_cache_path = (cache_path / prefix).string();
-      std::filesystem::create_directories(prefix_cache_path);
 
       const HtmlService service =
-          html::translate(decoded_file, prefix_cache_path, html_config, logger);
+          html::translate(decoded_file, html_config, logger);
       server.connect_service(service, prefix);
       const HtmlViews views = service.list_views();
       ODR_INFO(logger, "hosted decoded file with id: " << prefix);
@@ -86,11 +77,9 @@ int main(const int argc, char **argv) {
               : decoded_file.as_archive_file().archive().as_filesystem();
 
       const std::string prefix = "filesystem";
-      const std::string prefix_cache_path = (cache_path / prefix).string();
-      std::filesystem::create_directories(prefix_cache_path);
 
       const HtmlService filesystem_service =
-          html::translate(filesystem, prefix_cache_path, html_config, logger);
+          html::translate(filesystem, html_config, logger);
       server.connect_service(filesystem_service, prefix);
       ODR_INFO(logger, "hosted filesystem with id: " << prefix);
       for (const auto &view : filesystem_service.list_views()) {

--- a/cli/src/translate.cpp
+++ b/cli/src/translate.cpp
@@ -46,7 +46,7 @@ int main(const int argc, char **argv) {
     config.format_html = true;
 
     std::filesystem::create_directories(output);
-    const HtmlService service = html::translate(decoded_file, output, config);
+    const HtmlService service = html::translate(decoded_file, config);
     const Html html = service.bring_offline(output);
 
     return 0;

--- a/jni/README.md
+++ b/jni/README.md
@@ -11,7 +11,7 @@ import app.opendocument.core.HtmlService;
 import app.opendocument.core.Odr;
 
 DecodedFile file = Odr.open("document.odt");
-HtmlService service = Html.translate(file, "cache-dir", new HtmlConfig());
+HtmlService service = Html.translate(file, new HtmlConfig());
 app.opendocument.core.Html html = service.bringOffline("output-dir");
 for (var page : html.pages()) {
     System.out.println(page.name + " " + page.path);

--- a/jni/java/app/opendocument/core/Html.java
+++ b/jni/java/app/opendocument/core/Html.java
@@ -55,28 +55,27 @@ public final class Html {
   // the wrapper for the duration - keepAlive() does.
 
   /** Translates a decoded file to HTML. */
-  public static HtmlService translate(DecodedFile file, String cachePath, HtmlConfig config) {
+  public static HtmlService translate(DecodedFile file, HtmlConfig config) {
     try {
-      return new HtmlService(translateFile(file.handle(), cachePath, config), file);
+      return new HtmlService(translateFile(file.handle(), config), file);
     } finally {
       file.keepAlive();
     }
   }
 
   /** Translates a document to HTML. */
-  public static HtmlService translate(Document document, String cachePath, HtmlConfig config) {
+  public static HtmlService translate(Document document, HtmlConfig config) {
     try {
-      return new HtmlService(translateDocument(document.handle(), cachePath, config), document);
+      return new HtmlService(translateDocument(document.handle(), config), document);
     } finally {
       document.keepAlive();
     }
   }
 
   /** Translates a filesystem to HTML. */
-  public static HtmlService translate(Filesystem filesystem, String cachePath, HtmlConfig config) {
+  public static HtmlService translate(Filesystem filesystem, HtmlConfig config) {
     try {
-      return new HtmlService(
-          translateFilesystem(filesystem.handle(), cachePath, config), filesystem);
+      return new HtmlService(translateFilesystem(filesystem.handle(), config), filesystem);
     } finally {
       filesystem.keepAlive();
     }
@@ -87,11 +86,9 @@ public final class Html {
     document.edit(diff);
   }
 
-  private static native long translateFile(long fileHandle, String cachePath, HtmlConfig config);
+  private static native long translateFile(long fileHandle, HtmlConfig config);
 
-  private static native long translateDocument(
-      long documentHandle, String cachePath, HtmlConfig config);
+  private static native long translateDocument(long documentHandle, HtmlConfig config);
 
-  private static native long translateFilesystem(
-      long filesystemHandle, String cachePath, HtmlConfig config);
+  private static native long translateFilesystem(long filesystemHandle, HtmlConfig config);
 }

--- a/jni/src/jni_html.cpp
+++ b/jni/src/jni_html.cpp
@@ -177,24 +177,21 @@ odr::HtmlResource &resource(jlong handle) {
 extern "C" JNIEXPORT jlong JNICALL
 Java_app_opendocument_core_Html_translateFile(JNIEnv *env, jclass,
                                               jlong file_handle,
-                                              jstring cache_path,
                                               jobject config) {
   return guarded(env, [&] {
-    return make_handle(odr::html::translate(
-        *from_handle<odr::DecodedFile>(file_handle), to_string(env, cache_path),
-        odr_jni::html_config_from_java(env, config)));
+    return make_handle(
+        odr::html::translate(*from_handle<odr::DecodedFile>(file_handle),
+                             odr_jni::html_config_from_java(env, config)));
   });
 }
 
 extern "C" JNIEXPORT jlong JNICALL
 Java_app_opendocument_core_Html_translateDocument(JNIEnv *env, jclass,
                                                   jlong document_handle,
-                                                  jstring cache_path,
                                                   jobject config) {
   return guarded(env, [&] {
     return make_handle(
         odr::html::translate(*from_handle<odr::Document>(document_handle),
-                             to_string(env, cache_path),
                              odr_jni::html_config_from_java(env, config)));
   });
 }
@@ -202,12 +199,10 @@ Java_app_opendocument_core_Html_translateDocument(JNIEnv *env, jclass,
 extern "C" JNIEXPORT jlong JNICALL
 Java_app_opendocument_core_Html_translateFilesystem(JNIEnv *env, jclass,
                                                     jlong filesystem_handle,
-                                                    jstring cache_path,
                                                     jobject config) {
   return guarded(env, [&] {
     return make_handle(
         odr::html::translate(*from_handle<odr::Filesystem>(filesystem_handle),
-                             to_string(env, cache_path),
                              odr_jni::html_config_from_java(env, config)));
   });
 }

--- a/jni/tests/app/opendocument/core/HtmlTest.java
+++ b/jni/tests/app/opendocument/core/HtmlTest.java
@@ -16,17 +16,15 @@ class HtmlTest {
   @TempDir Path tempDir;
 
   private Html translateOffline(Path input) throws IOException {
-    Path cache = Files.createDirectories(tempDir.resolve("cache"));
     Path output = Files.createDirectories(tempDir.resolve("output"));
     DecodedFile file = Odr.open(input.toString());
-    HtmlService service = Html.translate(file, cache.toString(), new HtmlConfig());
+    HtmlService service = Html.translate(file, new HtmlConfig());
     return service.bringOffline(output.toString());
   }
 
   private String renderOdt(HtmlConfig config) throws IOException {
-    Path cache = Files.createTempDirectory(tempDir, "render");
     DecodedFile file = Odr.open(TestFiles.odtFile(tempDir).toString());
-    HtmlService service = Html.translate(file, cache.toString(), config);
+    HtmlService service = Html.translate(file, config);
     return service.listViews().get(0).writeHtml().html;
   }
 
@@ -52,9 +50,8 @@ class HtmlTest {
     config.viewportWidth = 420;
     config.initialZoom = 1.5;
 
-    Path cache = Files.createDirectories(tempDir.resolve("cache"));
     DecodedFile file = Odr.open(TestFiles.odtFile(tempDir).toString());
-    HtmlConfig readBack = Html.translate(file, cache.toString(), config).config();
+    HtmlConfig readBack = Html.translate(file, config).config();
 
     assertEquals(HtmlViewportMode.FIT_WIDTH, readBack.viewportMode);
     assertEquals(HtmlViewportMode.ACTUAL_SIZE, readBack.spreadsheetViewportMode);
@@ -80,9 +77,8 @@ class HtmlTest {
     assertTrue(
         renderOdt(config).contains(":root{--odr-min-margin-top:12px;--odr-min-margin-left:1cm;}"));
 
-    Path cache = Files.createDirectories(tempDir.resolve("margin"));
     DecodedFile file = Odr.open(TestFiles.odtFile(tempDir).toString());
-    HtmlConfig readBack = Html.translate(file, cache.toString(), config).config();
+    HtmlConfig readBack = Html.translate(file, config).config();
     assertEquals(new Measure(12, "px"), readBack.minContentMargin.top);
     assertEquals(new Measure(1, "cm"), readBack.minContentMargin.left);
     assertNull(readBack.minContentMargin.right);
@@ -128,9 +124,8 @@ class HtmlTest {
     system.colorScheme = HtmlColorScheme.SYSTEM;
     assertTrue(renderOdt(system).contains("media=\"(prefers-color-scheme: dark)\""));
 
-    Path cache = Files.createDirectories(tempDir.resolve("scheme"));
     DecodedFile file = Odr.open(TestFiles.odtFile(tempDir).toString());
-    HtmlConfig readBack = Html.translate(file, cache.toString(), system).config();
+    HtmlConfig readBack = Html.translate(file, system).config();
     assertEquals(HtmlColorScheme.SYSTEM, readBack.colorScheme);
   }
 
@@ -166,18 +161,17 @@ class HtmlTest {
   void spreadsheetCutReachesTheView() throws IOException {
     assertEquals(Long.valueOf(500000L), new HtmlConfig().spreadsheetCellLimit);
 
-    Path cache = Files.createDirectories(tempDir.resolve("cache"));
     DecodedFile file = Odr.open(TestFiles.csvFile(tempDir).toString());
 
     HtmlConfig full = new HtmlConfig();
-    for (HtmlView view : Html.translate(file, cache.toString(), full).listViews()) {
+    for (HtmlView view : Html.translate(file, full).listViews()) {
       assertNull(view.sheetCut());
     }
 
     HtmlConfig cut = new HtmlConfig();
     cut.spreadsheetLimit = new TableDimensions(2, 1);
     cut.spreadsheetCellLimit = null;
-    HtmlService service = Html.translate(file, cache.toString(), cut);
+    HtmlService service = Html.translate(file, cut);
 
     assertNull(service.config().spreadsheetCellLimit);
     HtmlSheetCut sheetCut = service.listViews().get(1).sheetCut();
@@ -190,9 +184,8 @@ class HtmlTest {
 
   @Test
   void htmlServiceViews() throws IOException {
-    Path cache = Files.createDirectories(tempDir.resolve("cache"));
     DecodedFile file = Odr.open(TestFiles.odtFile(tempDir).toString());
-    HtmlService service = Html.translate(file, cache.toString(), new HtmlConfig());
+    HtmlService service = Html.translate(file, new HtmlConfig());
 
     List<HtmlView> views = service.listViews();
     assertEquals(1, views.size());

--- a/jni/tests/app/opendocument/core/HttpServerTest.java
+++ b/jni/tests/app/opendocument/core/HttpServerTest.java
@@ -61,11 +61,10 @@ class HttpServerTest {
     HttpServer server = new HttpServer();
 
     // the server hosts what it is given; translating is the caller's business
-    String cachePath = Files.createDirectories(tempDir.resolve("doc-cache")).toString();
     DecodedFile file = Odr.open(TestFiles.odtFile(tempDir).toString());
     HtmlConfig htmlConfig = new HtmlConfig();
     htmlConfig.embedImages = false;
-    HtmlService service = Html.translate(file, cachePath, htmlConfig);
+    HtmlService service = Html.translate(file, htmlConfig);
     server.connectService(service, "doc");
     List<HtmlView> views = service.listViews();
     assertEquals(1, views.size());

--- a/python/pyodr/__init__.py
+++ b/python/pyodr/__init__.py
@@ -6,7 +6,7 @@ render them to HTML.
 Example:
     >>> import pyodr
     >>> file = pyodr.open("document.odt")
-    >>> service = pyodr.html.translate(file, cache_path, pyodr.HtmlConfig())
+    >>> service = pyodr.html.translate(file, pyodr.HtmlConfig())
     >>> html = service.bring_offline(output_path)
     >>> [page.path for page in html.pages()]
 """

--- a/python/pyodr/cli.py
+++ b/python/pyodr/cli.py
@@ -42,9 +42,8 @@ def _translate(args, file) -> int:
         output.mkdir(parents=True, exist_ok=True)
     else:
         output = Path(tempfile.mkdtemp(prefix="pyodr-"))
-    cache = tempfile.mkdtemp(prefix="pyodr-cache-")
 
-    service = pyodr.html.translate(file, cache, pyodr.HtmlConfig())
+    service = pyodr.html.translate(file, pyodr.HtmlConfig())
     html = service.bring_offline(str(output))
 
     for page in html.pages():
@@ -62,8 +61,7 @@ def _serve(args, file) -> int:
 
     html_config = pyodr.HtmlConfig()
     html_config.embed_images = False
-    cache = tempfile.mkdtemp(prefix="pyodr-server-")
-    service = pyodr.html.translate(file, cache, html_config)
+    service = pyodr.html.translate(file, html_config)
 
     prefix = "file"
     server = pyodr.HttpServer()

--- a/python/src/bind_html.cpp
+++ b/python/src/bind_html.cpp
@@ -211,31 +211,31 @@ void odr_python::bind_html(py::module_ &m) {
   // GIL themselves.
   html.def(
       "translate",
-      [](const odr::DecodedFile &file, const std::string &cache_path,
-         const odr::HtmlConfig &config, const odr::Logger &logger) {
-        return odr::html::translate(file, cache_path, config, logger);
+      [](const odr::DecodedFile &file, const odr::HtmlConfig &config,
+         const odr::Logger &logger) {
+        return odr::html::translate(file, config, logger);
       },
-      py::arg("file"), py::arg("cache_path"), py::arg("config"),
+      py::arg("file"), py::arg("config"),
       py::arg("logger") = odr::Logger::null(),
       py::call_guard<py::gil_scoped_release>(),
       "Translate a decoded file to HTML.");
   html.def(
       "translate",
-      [](const odr::Document &document, const std::string &cache_path,
-         const odr::HtmlConfig &config, const odr::Logger &logger) {
-        return odr::html::translate(document, cache_path, config, logger);
+      [](const odr::Document &document, const odr::HtmlConfig &config,
+         const odr::Logger &logger) {
+        return odr::html::translate(document, config, logger);
       },
-      py::arg("document"), py::arg("cache_path"), py::arg("config"),
+      py::arg("document"), py::arg("config"),
       py::arg("logger") = odr::Logger::null(),
       py::call_guard<py::gil_scoped_release>(),
       "Translate a document to HTML.");
   html.def(
       "translate",
-      [](const odr::Filesystem &filesystem, const std::string &cache_path,
-         const odr::HtmlConfig &config, const odr::Logger &logger) {
-        return odr::html::translate(filesystem, cache_path, config, logger);
+      [](const odr::Filesystem &filesystem, const odr::HtmlConfig &config,
+         const odr::Logger &logger) {
+        return odr::html::translate(filesystem, config, logger);
       },
-      py::arg("filesystem"), py::arg("cache_path"), py::arg("config"),
+      py::arg("filesystem"), py::arg("config"),
       py::arg("logger") = odr::Logger::null(),
       py::call_guard<py::gil_scoped_release>(),
       "Translate a filesystem to HTML.");

--- a/python/tests/test_html.py
+++ b/python/tests/test_html.py
@@ -5,11 +5,9 @@ import pyodr
 
 def translate_offline(path, tmp_path):
     file = pyodr.open(str(path))
-    cache = tmp_path / "cache"
     output = tmp_path / "output"
-    cache.mkdir()
     output.mkdir()
-    service = pyodr.html.translate(file, str(cache), pyodr.HtmlConfig())
+    service = pyodr.html.translate(file, pyodr.HtmlConfig())
     return service.bring_offline(str(output))
 
 
@@ -30,17 +28,16 @@ def test_html_config_defaults():
     assert config.spreadsheet_cell_limit is None
 
 
-def test_html_view_sheet_cut(csv_path, tmp_path):
-    cache = tmp_path / "cache"
+def test_html_view_sheet_cut(csv_path):
     file = pyodr.open(str(csv_path))
 
     config = pyodr.HtmlConfig()
-    service = pyodr.html.translate(file, str(cache), config)
+    service = pyodr.html.translate(file, config)
     assert all(view.sheet_cut() is None for view in service.list_views())
 
     config.spreadsheet_limit = pyodr.TableDimensions(2, 1)
     config.spreadsheet_cell_limit = None
-    service = pyodr.html.translate(file, str(cache), config)
+    service = pyodr.html.translate(file, config)
 
     cut = service.list_views()[1].sheet_cut()
     assert cut is not None
@@ -76,61 +73,57 @@ def test_html_config_viewport_defaults():
     assert config.initial_zoom == 1.5
 
 
-def test_viewport_mode_reaches_the_html(odt_path, tmp_path):
+def test_viewport_mode_reaches_the_html(odt_path):
     # The C++ suite covers the mode matrix; this only proves the config crosses
     # the binding. A text document without margins is reflowing content, so
     # `automatic` resolves to `actual_size`.
-    def render(name, config):
-        cache = tmp_path / name
-        cache.mkdir()
+    def render(config):
         file = pyodr.open(str(odt_path))
-        service = pyodr.html.translate(file, str(cache), config)
+        service = pyodr.html.translate(file, config)
         content, _ = service.list_views()[0].write_html()
         return content
 
     assert (
         '<meta name="viewport" '
         'content="width=device-width,initial-scale=1.0,user-scalable=yes"/>'
-        in render("automatic", pyodr.HtmlConfig())
+        in render(pyodr.HtmlConfig())
     )
 
     fit_width = pyodr.HtmlConfig()
     fit_width.viewport_mode = pyodr.HtmlViewportMode.fit_width
     assert (
         '<meta name="viewport" content="width=device-width,user-scalable=yes"/>'
-        in render("fit_width", fit_width)
+        in render(fit_width)
     )
 
     # only paged content has a width to fit, hence the margins
     by_view = pyodr.HtmlConfig()
     by_view.viewport_mode = pyodr.HtmlViewportMode.fit_width_by_view
     by_view.text_document_margin = True
-    assert "--odr-fit:view" in render("by_view", by_view)
+    assert "--odr-fit:view" in render(by_view)
 
     raw = pyodr.HtmlConfig()
     raw.viewport_content = "width=420"
-    assert '<meta name="viewport" content="width=420"/>' in render("raw", raw)
+    assert '<meta name="viewport" content="width=420"/>' in render(raw)
 
 
-def test_min_content_margin_reaches_the_html(odt_path, tmp_path):
+def test_min_content_margin_reaches_the_html(odt_path):
     # The C++ suite covers where the floor lands; this only proves it crosses
     # the binding, unset sides and all.
-    def render(name, config):
-        cache = tmp_path / name
-        cache.mkdir()
+    def render(config):
         file = pyodr.open(str(odt_path))
-        service = pyodr.html.translate(file, str(cache), config)
+        service = pyodr.html.translate(file, config)
         content, _ = service.list_views()[0].write_html()
         return content
 
     default = pyodr.HtmlConfig()
     assert default.min_content_margin.top is None
-    assert ":root{--odr-min-margin" not in render("default", default)
+    assert ":root{--odr-min-margin" not in render(default)
 
     config = pyodr.HtmlConfig()
     config.min_content_margin.top = pyodr.Measure("12px")
     config.min_content_margin.left = pyodr.Measure("1cm")
-    html = render("margin", config)
+    html = render(config)
     assert ":root{--odr-min-margin-top:12px;--odr-min-margin-left:1cm;}" in html
     assert "--odr-min-margin-right:" not in html
 
@@ -161,11 +154,9 @@ def test_translate_document(odt_path, tmp_path):
     assert "Hello from pyodr!" in content
 
 
-def test_html_service_views(odt_path, tmp_path):
+def test_html_service_views(odt_path):
     file = pyodr.open(str(odt_path))
-    cache = tmp_path / "cache"
-    cache.mkdir()
-    service = pyodr.html.translate(file, str(cache), pyodr.HtmlConfig())
+    service = pyodr.html.translate(file, pyodr.HtmlConfig())
 
     views = service.list_views()
     assert len(views) == 1
@@ -175,14 +166,12 @@ def test_html_service_views(odt_path, tmp_path):
     assert isinstance(resources, list)
 
 
-def test_html_view_outlives_service(odt_path, tmp_path):
+def test_html_view_outlives_service(odt_path):
     file = pyodr.open(str(odt_path))
-    cache = tmp_path / "cache"
-    cache.mkdir()
 
     # The service temporary is dropped immediately; the view must keep it
     # alive.
-    view = pyodr.html.translate(file, str(cache), pyodr.HtmlConfig()).list_views()[0]
+    view = pyodr.html.translate(file, pyodr.HtmlConfig()).list_views()[0]
 
     content, _ = view.write_html()
     assert "Hello from pyodr!" in content

--- a/python/tests/test_http_server.py
+++ b/python/tests/test_http_server.py
@@ -20,16 +20,14 @@ def fetch(url, timeout=5.0):
 
 
 @pytest.mark.skipif(not pyodr.has_http_server, reason="built without the HTTP server")
-def test_serve_file(odt_path, tmp_path):
+def test_serve_file(odt_path):
     server = pyodr.HttpServer()
 
     # the server hosts what it is given; translating is the caller's business
-    cache_path = tmp_path / "doc-cache"
-    cache_path.mkdir()
     file = pyodr.open(str(odt_path))
     html_config = pyodr.HtmlConfig()
     html_config.embed_images = False
-    service = pyodr.html.translate(file, str(cache_path), html_config)
+    service = pyodr.html.translate(file, html_config)
     server.connect_service(service, "doc")
     views = service.list_views()
     assert len(views) == 1

--- a/src/odr/html.cpp
+++ b/src/odr/html.cpp
@@ -214,6 +214,49 @@ void HtmlResource::write_resource(std::ostream &os) const {
   m_impl->write_resource(os);
 }
 
+namespace {
+
+HtmlService translate_text_file(const TextFile &text_file,
+                                const HtmlConfig &config,
+                                const Logger &logger) {
+  return internal::html::create_text_service(text_file, config, logger);
+}
+
+HtmlService translate_image_file(const ImageFile &image_file,
+                                 const HtmlConfig &config,
+                                 const Logger &logger) {
+  // refusing says what a blank `<img>` cannot
+  if (!capabilities_by_file_type(image_file.file_type()).translate_html) {
+    throw UnsupportedFileType(image_file.file_type());
+  }
+  return internal::html::create_image_service(image_file, config, logger);
+}
+
+HtmlService translate_archive_file(const ArchiveFile &archive_file,
+                                   const HtmlConfig &config,
+                                   const Logger &logger) {
+  return html::translate(archive_file.archive(), config, logger);
+}
+
+HtmlService translate_document_file(const DocumentFile &document_file,
+                                    const HtmlConfig &config,
+                                    const Logger &logger) {
+  return html::translate(document_file.document(), config, logger);
+}
+
+HtmlService translate_pdf_file(const PdfFile &pdf_file,
+                               const HtmlConfig &config, const Logger &logger) {
+  return internal::html::create_pdf_service(pdf_file, config, logger);
+}
+
+HtmlService translate_font_file(const FontFile &font_file,
+                                const HtmlConfig &config,
+                                const Logger &logger) {
+  return internal::html::create_font_service(font_file, config, logger);
+}
+
+} // namespace
+
 HtmlService html::translate(const DecodedFile &file, const HtmlConfig &config,
                             const Logger &logger) {
   // before the text branch: a csv is a text file, and rendering one as a line
@@ -225,29 +268,29 @@ HtmlService html::translate(const DecodedFile &file, const HtmlConfig &config,
   if (file.is_markdown_file()) {
     return translate(file.as_markdown_file().document(), config, logger);
   }
-  // and before it for the same reason. Translating it as a text file by hand
-  // still writes the line list.
+  // and before it for the same reason. Opening the bytes as `text_file` is how
+  // to ask for the line list.
   if (file.file_type() == FileType::xml) {
     return internal::html::create_xml_service(file.as_text_file(), config,
                                               logger);
   }
   if (file.is_text_file()) {
-    return translate(file.as_text_file(), config, logger);
+    return translate_text_file(file.as_text_file(), config, logger);
   }
   if (file.is_image_file()) {
-    return translate(file.as_image_file(), config, logger);
+    return translate_image_file(file.as_image_file(), config, logger);
   }
   if (file.is_archive_file()) {
-    return translate(file.as_archive_file(), config, logger);
+    return translate_archive_file(file.as_archive_file(), config, logger);
   }
   if (file.is_document_file()) {
-    return translate(file.as_document_file(), config, logger);
+    return translate_document_file(file.as_document_file(), config, logger);
   }
   if (file.is_pdf_file()) {
-    return translate(file.as_pdf_file(), config, logger);
+    return translate_pdf_file(file.as_pdf_file(), config, logger);
   }
   if (file.is_font_file()) {
-    return translate(file.as_font_file(), config, logger);
+    return translate_font_file(file.as_font_file(), config, logger);
   }
   // No wrapper type to go through: nothing is decoded, so the plain
   // `DecodedFile` already carries the bytes and the type that names them.
@@ -288,40 +331,6 @@ HtmlResourceLocator html::standard_resource_locator() {
   };
 }
 
-HtmlService html::translate(const TextFile &text_file, const HtmlConfig &config,
-                            const Logger &logger) {
-  return internal::html::create_text_service(text_file, config, logger);
-}
-
-HtmlService html::translate(const ImageFile &image_file,
-                            const HtmlConfig &config, const Logger &logger) {
-  // refusing says what a blank `<img>` cannot
-  if (!capabilities_by_file_type(image_file.file_type()).translate_html) {
-    throw UnsupportedFileType(image_file.file_type());
-  }
-  return internal::html::create_image_service(image_file, config, logger);
-}
-
-HtmlService html::translate(const ArchiveFile &archive_file,
-                            const HtmlConfig &config, const Logger &logger) {
-  return translate(archive_file.archive(), config, logger);
-}
-
-HtmlService html::translate(const DocumentFile &document_file,
-                            const HtmlConfig &config, const Logger &logger) {
-  return translate(document_file.document(), config, logger);
-}
-
-HtmlService html::translate(const PdfFile &pdf_file, const HtmlConfig &config,
-                            const Logger &logger) {
-  return internal::html::create_pdf_service(pdf_file, config, logger);
-}
-
-HtmlService html::translate(const FontFile &font_file, const HtmlConfig &config,
-                            const Logger &logger) {
-  return internal::html::create_font_service(font_file, config, logger);
-}
-
 HtmlService html::translate(const Filesystem &filesystem,
                             const HtmlConfig &config, const Logger &logger) {
   return internal::html::create_filesystem_service(filesystem, config, logger);
@@ -335,70 +344,6 @@ HtmlService html::translate(const Archive &archive, const HtmlConfig &config,
 HtmlService html::translate(const Document &document, const HtmlConfig &config,
                             const Logger &logger) {
   return internal::html::create_document_service(document, config, logger);
-}
-
-// The `cache_path` overloads. Nothing reads the path: no renderer has since the
-// output became a set of streams, and the `create_directories` that used to sit
-// here made a directory nobody wrote into.
-
-HtmlService html::translate(const DecodedFile &file,
-                            const std::string & /*cache_path*/,
-                            const HtmlConfig &config, const Logger &logger) {
-  return translate(file, config, logger);
-}
-
-HtmlService html::translate(const TextFile &text_file,
-                            const std::string & /*cache_path*/,
-                            const HtmlConfig &config, const Logger &logger) {
-  return translate(text_file, config, logger);
-}
-
-HtmlService html::translate(const ImageFile &image_file,
-                            const std::string & /*cache_path*/,
-                            const HtmlConfig &config, const Logger &logger) {
-  return translate(image_file, config, logger);
-}
-
-HtmlService html::translate(const ArchiveFile &archive_file,
-                            const std::string & /*cache_path*/,
-                            const HtmlConfig &config, const Logger &logger) {
-  return translate(archive_file, config, logger);
-}
-
-HtmlService html::translate(const DocumentFile &document_file,
-                            const std::string & /*cache_path*/,
-                            const HtmlConfig &config, const Logger &logger) {
-  return translate(document_file, config, logger);
-}
-
-HtmlService html::translate(const PdfFile &pdf_file,
-                            const std::string & /*cache_path*/,
-                            const HtmlConfig &config, const Logger &logger) {
-  return translate(pdf_file, config, logger);
-}
-
-HtmlService html::translate(const FontFile &font_file,
-                            const std::string & /*cache_path*/,
-                            const HtmlConfig &config, const Logger &logger) {
-  return translate(font_file, config, logger);
-}
-
-HtmlService html::translate(const Filesystem &filesystem,
-                            const std::string & /*cache_path*/,
-                            const HtmlConfig &config, const Logger &logger) {
-  return translate(filesystem, config, logger);
-}
-
-HtmlService html::translate(const Archive &archive,
-                            const std::string & /*cache_path*/,
-                            const HtmlConfig &config, const Logger &logger) {
-  return translate(archive, config, logger);
-}
-
-HtmlService html::translate(const Document &document,
-                            const std::string & /*cache_path*/,
-                            const HtmlConfig &config, const Logger &logger) {
-  return translate(document, config, logger);
 }
 
 void html::edit(const Document &document, const std::string_view diff,

--- a/src/odr/html.cpp
+++ b/src/odr/html.cpp
@@ -216,12 +216,6 @@ void HtmlResource::write_resource(std::ostream &os) const {
 
 namespace {
 
-HtmlService translate_text_file(const TextFile &text_file,
-                                const HtmlConfig &config,
-                                const Logger &logger) {
-  return internal::html::create_text_service(text_file, config, logger);
-}
-
 HtmlService translate_image_file(const ImageFile &image_file,
                                  const HtmlConfig &config,
                                  const Logger &logger) {
@@ -275,7 +269,7 @@ HtmlService html::translate(const DecodedFile &file, const HtmlConfig &config,
                                               logger);
   }
   if (file.is_text_file()) {
-    return translate_text_file(file.as_text_file(), config, logger);
+    return translate(file.as_text_file(), config, logger);
   }
   if (file.is_image_file()) {
     return translate_image_file(file.as_image_file(), config, logger);
@@ -339,6 +333,11 @@ HtmlService html::translate(const Filesystem &filesystem,
 HtmlService html::translate(const Archive &archive, const HtmlConfig &config,
                             const Logger &logger) {
   return translate(archive.as_filesystem(), config, logger);
+}
+
+HtmlService html::translate(const TextFile &text_file, const HtmlConfig &config,
+                            const Logger &logger) {
+  return internal::html::create_text_service(text_file, config, logger);
 }
 
 HtmlService html::translate(const Document &document, const HtmlConfig &config,

--- a/src/odr/html.cpp
+++ b/src/odr/html.cpp
@@ -216,6 +216,12 @@ void HtmlResource::write_resource(std::ostream &os) const {
 
 namespace {
 
+HtmlService translate_text_file(const TextFile &text_file,
+                                const HtmlConfig &config,
+                                const Logger &logger) {
+  return internal::html::create_text_service(text_file, config, logger);
+}
+
 HtmlService translate_image_file(const ImageFile &image_file,
                                  const HtmlConfig &config,
                                  const Logger &logger) {
@@ -262,14 +268,13 @@ HtmlService html::translate(const DecodedFile &file, const HtmlConfig &config,
   if (file.is_markdown_file()) {
     return translate(file.as_markdown_file().document(), config, logger);
   }
-  // and before it for the same reason. Opening the bytes as `text_file` is how
-  // to ask for the line list.
+  // and before it for the same reason; open as `text_file` for the line list
   if (file.file_type() == FileType::xml) {
     return internal::html::create_xml_service(file.as_text_file(), config,
                                               logger);
   }
   if (file.is_text_file()) {
-    return translate(file.as_text_file(), config, logger);
+    return translate_text_file(file.as_text_file(), config, logger);
   }
   if (file.is_image_file()) {
     return translate_image_file(file.as_image_file(), config, logger);
@@ -333,11 +338,6 @@ HtmlService html::translate(const Filesystem &filesystem,
 HtmlService html::translate(const Archive &archive, const HtmlConfig &config,
                             const Logger &logger) {
   return translate(archive.as_filesystem(), config, logger);
-}
-
-HtmlService html::translate(const TextFile &text_file, const HtmlConfig &config,
-                            const Logger &logger) {
-  return internal::html::create_text_service(text_file, config, logger);
 }
 
 HtmlService html::translate(const Document &document, const HtmlConfig &config,

--- a/src/odr/html.hpp
+++ b/src/odr/html.hpp
@@ -293,20 +293,8 @@ namespace html {
 
 HtmlResourceLocator standard_resource_locator();
 
-/// @brief Translates a decoded file to HTML.
-///
-/// The one entry point for a file: it dispatches on the decoded type, so a
-/// caller that already narrowed to a @ref DocumentFile or a @ref PdfFile
-/// passes it here too.
+/// @brief Translates a decoded file to HTML, dispatching on the decoded type.
 HtmlService translate(const DecodedFile &file, const HtmlConfig &config,
-                      const Logger &logger = Logger::null());
-
-/// @brief Translates a text file to HTML, as a numbered line list.
-///
-/// Not what @ref translate(const DecodedFile &, const HtmlConfig &, const
-/// Logger &) does with one: it renders an xml as its source view and a csv as
-/// a table. Narrowing by hand is how a caller asks for the lines instead.
-HtmlService translate(const TextFile &text_file, const HtmlConfig &config,
                       const Logger &logger = Logger::null());
 
 /// @brief Translates a document to HTML.

--- a/src/odr/html.hpp
+++ b/src/odr/html.hpp
@@ -301,6 +301,14 @@ HtmlResourceLocator standard_resource_locator();
 HtmlService translate(const DecodedFile &file, const HtmlConfig &config,
                       const Logger &logger = Logger::null());
 
+/// @brief Translates a text file to HTML, as a numbered line list.
+///
+/// Not what @ref translate(const DecodedFile &, const HtmlConfig &, const
+/// Logger &) does with one: it renders an xml as its source view and a csv as
+/// a table. Narrowing by hand is how a caller asks for the lines instead.
+HtmlService translate(const TextFile &text_file, const HtmlConfig &config,
+                      const Logger &logger = Logger::null());
+
 /// @brief Translates a document to HTML.
 HtmlService translate(const Document &document, const HtmlConfig &config,
                       const Logger &logger = Logger::null());

--- a/src/odr/html.hpp
+++ b/src/odr/html.hpp
@@ -294,77 +294,22 @@ namespace html {
 HtmlResourceLocator standard_resource_locator();
 
 /// @brief Translates a decoded file to HTML.
+///
+/// The one entry point for a file: it dispatches on the decoded type, so a
+/// caller that already narrowed to a @ref DocumentFile or a @ref PdfFile
+/// passes it here too.
 HtmlService translate(const DecodedFile &file, const HtmlConfig &config,
                       const Logger &logger = Logger::null());
 
-/// @brief Translates a text file to HTML.
-HtmlService translate(const TextFile &text_file, const HtmlConfig &config,
+/// @brief Translates a document to HTML.
+HtmlService translate(const Document &document, const HtmlConfig &config,
                       const Logger &logger = Logger::null());
-/// @brief Translates an image file to HTML.
-HtmlService translate(const ImageFile &image_file, const HtmlConfig &config,
-                      const Logger &logger = Logger::null());
-/// @brief Translates an archive file to HTML.
-HtmlService translate(const ArchiveFile &archive_file, const HtmlConfig &config,
-                      const Logger &logger = Logger::null());
-/// @brief Translates a document file to HTML.
-HtmlService translate(const DocumentFile &document_file,
-                      const HtmlConfig &config,
-                      const Logger &logger = Logger::null());
-/// @brief Translates a PDF file to HTML.
-HtmlService translate(const PdfFile &pdf_file, const HtmlConfig &config,
-                      const Logger &logger = Logger::null());
-
-/// @brief Translates a font file to HTML (a specimen page).
-HtmlService translate(const FontFile &font_file, const HtmlConfig &config,
-                      const Logger &logger = Logger::null());
-
 /// @brief Translates a filesystem to HTML.
 HtmlService translate(const Filesystem &filesystem, const HtmlConfig &config,
                       const Logger &logger = Logger::null());
 /// @brief Translates an archive to HTML.
 HtmlService translate(const Archive &archive, const HtmlConfig &config,
                       const Logger &logger = Logger::null());
-/// @brief Translates a document to HTML.
-HtmlService translate(const Document &document, const HtmlConfig &config,
-                      const Logger &logger = Logger::null());
-
-/// @name Translation with a cache path
-///
-/// `cache_path` is ignored — nothing on the render path writes to disk, and no
-/// renderer has read it since the output became a set of streams. Kept so
-/// existing callers keep compiling; prefer the overloads above.
-/// @{
-HtmlService translate(const DecodedFile &file, const std::string &cache_path,
-                      const HtmlConfig &config,
-                      const Logger &logger = Logger::null());
-HtmlService translate(const TextFile &text_file, const std::string &cache_path,
-                      const HtmlConfig &config,
-                      const Logger &logger = Logger::null());
-HtmlService translate(const ImageFile &image_file,
-                      const std::string &cache_path, const HtmlConfig &config,
-                      const Logger &logger = Logger::null());
-HtmlService translate(const ArchiveFile &archive_file,
-                      const std::string &cache_path, const HtmlConfig &config,
-                      const Logger &logger = Logger::null());
-HtmlService translate(const DocumentFile &document_file,
-                      const std::string &cache_path, const HtmlConfig &config,
-                      const Logger &logger = Logger::null());
-HtmlService translate(const PdfFile &pdf_file, const std::string &cache_path,
-                      const HtmlConfig &config,
-                      const Logger &logger = Logger::null());
-HtmlService translate(const FontFile &font_file, const std::string &cache_path,
-                      const HtmlConfig &config,
-                      const Logger &logger = Logger::null());
-HtmlService translate(const Filesystem &filesystem,
-                      const std::string &cache_path, const HtmlConfig &config,
-                      const Logger &logger = Logger::null());
-HtmlService translate(const Archive &archive, const std::string &cache_path,
-                      const HtmlConfig &config,
-                      const Logger &logger = Logger::null());
-HtmlService translate(const Document &document, const std::string &cache_path,
-                      const HtmlConfig &config,
-                      const Logger &logger = Logger::null());
-/// @}
 
 /// @brief Applies a diff to a document. The diff is what our JavaScript
 /// produces in the browser.

--- a/test/src/html_output_test.cpp
+++ b/test/src/html_output_test.cpp
@@ -198,8 +198,7 @@ TEST_P(HtmlOutputTests, html_meta) {
   // and would bury the corpus log.
   const Logger render_logger =
       Logger::create_stdio("odr-test", LogLevel::warning);
-  HtmlService service =
-      html::translate(file, output_path_tmp, config, render_logger);
+  HtmlService service = html::translate(file, config, render_logger);
   Html html = service.bring_offline(output_path);
   fs::remove_all(output_path_tmp);
 

--- a/test/src/html_test.cpp
+++ b/test/src/html_test.cpp
@@ -31,14 +31,11 @@ using namespace odr::test;
 TEST(html, linked_resources_are_served) {
   const auto logger = Logger::create_stdio("odr-test", LogLevel::verbose);
 
-  const std::string cache_path =
-      (std::filesystem::current_path() / "cache").string();
-
   const auto check = [&](const DecodedFile &file, const std::string &view) {
     HtmlConfig config;
     config.embed_shipped_resources = false;
 
-    const HtmlService service = html::translate(file, cache_path, config);
+    const HtmlService service = html::translate(file, config);
 
     std::ostringstream out;
     const HtmlResources resources = service.list_views().at(0).write_html(out);
@@ -79,16 +76,13 @@ TEST(html, linked_resources_are_served) {
 TEST(html, linked_images_are_served) {
   const auto logger = Logger::create_stdio("odr-test", LogLevel::verbose);
 
-  const std::string cache_path =
-      (std::filesystem::current_path() / "images").string();
-
   const auto check = [&](const std::string &path) {
     const DecodedFile file(TestData::test_file_path(path), logger);
 
     HtmlConfig config;
     config.embed_images = false;
 
-    const HtmlService service = html::translate(file, cache_path, config);
+    const HtmlService service = html::translate(file, config);
 
     std::ostringstream out;
     const HtmlResources resources = service.list_views().at(0).write_html(out);
@@ -398,10 +392,8 @@ TEST(html, views) {
 
   const Document document = document_file.document();
 
-  const std::string cache_path =
-      (std::filesystem::current_path() / "cache").string();
   const HtmlConfig config;
-  const HtmlService service = html::translate(document, cache_path, config);
+  const HtmlService service = html::translate(document, config);
 
   const HtmlViews &views = service.list_views();
 
@@ -423,7 +415,7 @@ TEST(html, paged_output_fits_the_viewport) {
     const std::string cache =
         (std::filesystem::current_path() / "fit").string();
     std::ostringstream out;
-    html::translate(file, cache, config).list_views().at(0).write_html(out);
+    html::translate(file, config).list_views().at(0).write_html(out);
     return std::move(out).str();
   };
 
@@ -504,8 +496,7 @@ TEST(html, each_view_fits_the_page_it_renders) {
   config.viewport_width = 400;
 
   const DecodedFile file{path};
-  const HtmlService service = html::translate(
-      file, (std::filesystem::current_path() / "rotate").string(), config);
+  const HtmlService service = html::translate(file, config);
 
   const auto factor_of = [&](const std::size_t view) {
     std::ostringstream out;
@@ -542,7 +533,7 @@ TEST(html, an_image_fits_the_viewport) {
     const std::string cache =
         (std::filesystem::current_path() / "image_fit").string();
     std::ostringstream out;
-    html::translate(file, cache, config).list_views().at(0).write_html(out);
+    html::translate(file, config).list_views().at(0).write_html(out);
     return std::move(out).str();
   };
 

--- a/test/src/internal/csv/csv_file_test.cpp
+++ b/test/src/internal/csv/csv_file_test.cpp
@@ -342,8 +342,7 @@ TEST(CsvDocument, renders_as_a_table) {
   const CsvFile file =
       CsvFile::from_file(File::from_memory("a,b\n1,2\n"), CsvOptions{});
 
-  const HtmlService service =
-      html::translate(file.document(), "", HtmlConfig());
+  const HtmlService service = html::translate(file.document(), HtmlConfig());
   std::ostringstream out;
   service.list_views().back().write_html(out);
 

--- a/test/src/internal/font/font_file.cpp
+++ b/test/src/internal/font/font_file.cpp
@@ -145,10 +145,8 @@ TEST(FontFileTest, specimen_page_embeds_font_and_glyph_grid) {
   const odr::FontFile font_file(std::make_shared<font::FontFile>(
       std::make_shared<MemoryFile>(sample_ttf()), FileType::truetype_font));
 
-  const std::string cache_path =
-      (std::filesystem::temp_directory_path() / "odr_font_test").string();
   const HtmlConfig config;
-  const HtmlService service = html::translate(font_file, cache_path, config);
+  const HtmlService service = html::translate(font_file, config);
 
   const HtmlViews &views = service.list_views();
   ASSERT_EQ(views.size(), 1);

--- a/test/src/internal/html/image_file_test.cpp
+++ b/test/src/internal/html/image_file_test.cpp
@@ -36,10 +36,6 @@ File png_file() {
   return image_file(std::string("\x89PNG\r\n\x1a\n", 8) + "payload");
 }
 
-std::string cache_path(const std::string &name) {
-  return (std::filesystem::current_path() / name).string();
-}
-
 std::string write_path(const HtmlService &service, const std::string &path) {
   std::ostringstream out;
   service.write(path, out);
@@ -113,8 +109,7 @@ TEST(image_file, svg_is_detected_and_opens_as_an_image) {
 
 TEST(image_file, svg_translates_to_an_image_page) {
   const DecodedFile file{svg_file()};
-  const HtmlService service =
-      html::translate(file, cache_path("image_svg"), HtmlConfig());
+  const HtmlService service = html::translate(file, HtmlConfig());
 
   ASSERT_EQ(service.list_views().size(), 1);
   EXPECT_EQ(service.list_views().front().name(), "image");
@@ -130,8 +125,7 @@ TEST(image_file, ico_is_named_by_its_own_mime_type) {
   EXPECT_EQ(file.file_type(), FileType::windows_icon);
   EXPECT_TRUE(file.is_image_file());
 
-  const HtmlService service =
-      html::translate(file, cache_path("image_ico"), HtmlConfig());
+  const HtmlService service = html::translate(file, HtmlConfig());
   const std::string html = write_path(service, "image.html");
   EXPECT_NE(html.find("data:image/vnd.microsoft.icon;base64,"),
             std::string::npos);

--- a/test/src/internal/html/media_file_test.cpp
+++ b/test/src/internal/html/media_file_test.cpp
@@ -31,7 +31,7 @@ const std::string mp4_signature =
 
 File mp4_file() { return media_file(mp4_signature); }
 
-std::string cache_path(const std::string &name) {
+std::string temp_path(const std::string &name) {
   return (std::filesystem::current_path() / name).string();
 }
 
@@ -59,8 +59,7 @@ TEST(media_file, audio_is_decoded_without_a_wrapper_type) {
 
 TEST(media_file, audio_translates_to_a_player) {
   const DecodedFile file{mp3_file()};
-  const HtmlService service =
-      html::translate(file, cache_path("media_audio"), HtmlConfig());
+  const HtmlService service = html::translate(file, HtmlConfig());
 
   ASSERT_EQ(service.list_views().size(), 1);
   EXPECT_EQ(service.list_views().front().name(), "audio");
@@ -74,8 +73,7 @@ TEST(media_file, audio_translates_to_a_player) {
 
 TEST(media_file, video_translates_to_a_player) {
   const DecodedFile file{mp4_file()};
-  const HtmlService service =
-      html::translate(file, cache_path("media_video"), HtmlConfig());
+  const HtmlService service = html::translate(file, HtmlConfig());
 
   ASSERT_EQ(service.list_views().size(), 1);
   EXPECT_EQ(service.list_views().front().name(), "video");
@@ -90,8 +88,7 @@ TEST(media_file, video_translates_to_a_player) {
 /// base64'd into the markup the way an image is.
 TEST(media_file, the_media_is_served_as_a_resource) {
   const DecodedFile file{mp4_file()};
-  const HtmlService service =
-      html::translate(file, cache_path("media_resource"), HtmlConfig());
+  const HtmlService service = html::translate(file, HtmlConfig());
 
   EXPECT_TRUE(service.exists("video.mp4"));
   EXPECT_EQ(service.mimetype("video.mp4"), "video/mp4");
@@ -104,12 +101,11 @@ TEST(media_file, the_media_is_served_as_a_resource) {
 }
 
 TEST(media_file, bring_offline_writes_the_media_next_to_the_page) {
-  const std::string output_path = cache_path("media_offline");
+  const std::string output_path = temp_path("media_offline");
   std::filesystem::remove_all(output_path);
 
   const DecodedFile file{mp4_file()};
-  const HtmlService service =
-      html::translate(file, cache_path("media_offline_cache"), HtmlConfig());
+  const HtmlService service = html::translate(file, HtmlConfig());
   const Html html = service.bring_offline(output_path);
 
   ASSERT_EQ(html.pages().size(), 1);
@@ -128,7 +124,7 @@ TEST(media_file, bring_offline_writes_the_media_next_to_the_page) {
 /// webm as `video/x-matroska` and no browser would play it. The name it came
 /// in under wins whenever the same type claims it.
 TEST(media_file, a_webm_keeps_its_own_name_and_mime) {
-  const std::filesystem::path directory = cache_path("media_webm");
+  const std::filesystem::path directory = temp_path("media_webm");
   std::filesystem::create_directories(directory);
 
   for (const auto &[name, path, mime_type] :
@@ -142,8 +138,7 @@ TEST(media_file, a_webm_keeps_its_own_name_and_mime) {
     const DecodedFile file{File(file_path.string())};
     ASSERT_EQ(file.file_type(), FileType::matroska_video) << path;
 
-    const HtmlService service =
-        html::translate(file, cache_path("media_webm_cache"), HtmlConfig());
+    const HtmlService service = html::translate(file, HtmlConfig());
 
     EXPECT_TRUE(service.exists(name)) << path;
     EXPECT_EQ(service.mimetype(name), mime_type) << path;
@@ -164,8 +159,7 @@ TEST(media_file, webp_opens_as_an_image) {
   EXPECT_EQ(decoded.file_type(), FileType::webp);
   EXPECT_TRUE(decoded.is_image_file());
 
-  const HtmlService service =
-      html::translate(decoded, cache_path("media_webp"), HtmlConfig());
+  const HtmlService service = html::translate(decoded, HtmlConfig());
   ASSERT_EQ(service.list_views().size(), 1);
 
   // named, not guessed: a browser that honours the data URL's type has to be

--- a/test/src/internal/xml/xml_file_test.cpp
+++ b/test/src/internal/xml/xml_file_test.cpp
@@ -110,11 +110,12 @@ TEST(XmlDeclaration, the_encoding_pseudo_attribute_is_read_off_the_bytes) {
   EXPECT_EQ(declared_encoding(R"(<?xml encoding="UTF-8")"), "");
 }
 
-/// Asking for the text rendering by hand gets the text rendering — the source
-/// view is what an xml file translates to, not what a text file translates to.
-TEST(XmlHtml, translating_it_as_a_text_file_still_writes_the_line_list) {
+/// The source view is what an xml file translates to. Opening the same bytes as
+/// a text file is how you ask for the line list instead.
+TEST(XmlHtml, opening_it_as_a_text_file_writes_the_line_list) {
   const HtmlService service = html::translate(
-      odr::TextFile(xml_file("<a><b/></a>")), HtmlConfig(), Logger::null());
+      DecodedFile(File::from_memory("<a><b/></a>"), FileType::text_file),
+      HtmlConfig(), Logger::null());
 
   std::ostringstream out;
   service.write("text.html", out);

--- a/test/src/internal/xml/xml_file_test.cpp
+++ b/test/src/internal/xml/xml_file_test.cpp
@@ -110,8 +110,7 @@ TEST(XmlDeclaration, the_encoding_pseudo_attribute_is_read_off_the_bytes) {
   EXPECT_EQ(declared_encoding(R"(<?xml encoding="UTF-8")"), "");
 }
 
-/// The source view is what an xml file translates to. Opening the same bytes as
-/// a text file is how you ask for the line list instead.
+/// Opening the same bytes as a text file is how to ask for the line list.
 TEST(XmlHtml, opening_it_as_a_text_file_writes_the_line_list) {
   const HtmlService service = html::translate(
       DecodedFile(File::from_memory("<a><b/></a>"), FileType::text_file),


### PR DESCRIPTION
🤖 Generated with [Claude Code](https://claude.com/claude-code)

PR 4 of the [v7 API plan](https://github.com/opendocument-app/OpenDocument.core/pull/831).

`html::translate` had **twenty overloads** answering four questions.

## The ten `cache_path` ones

Removed. The header already documented the parameter as ignored, and the
implementation was ten one-line forwards under a comment saying so. Nothing on
the render path writes to disk.

The interesting part is what the callers were doing with it. `cli/server.cpp`
built a directory per prefix and `remove_all`'d a cache root on startup;
`test/html_test.cpp` and the media/image tests each built a path to hand over.
All of it fed a parameter that was discarded — so this PR deletes a fair amount
of `create_directories` that made directories nobody wrote into.

## The six narrowed-handle ones

`translate(TextFile)`, `(ImageFile)`, `(ArchiveFile)`, `(DocumentFile)`,
`(PdfFile)`, `(FontFile)` are gone from the header. They are not lost work —
`translate(DecodedFile)` dispatches to every one of them, so they stay exactly
where they were, as file-local helpers behind the dispatcher:

```cpp
namespace {
HtmlService translate_text_file(const TextFile &, const HtmlConfig &, const Logger &);
HtmlService translate_image_file(const ImageFile &, ...);
...
}  // namespace
```

Two of them delegate back out to `html::translate` and now say so with a
qualified name — an anonymous namespace in `odr` does not see `odr::html`, which
the previous `html::translate(...)` definition context did.

## What remains

Four, for the four inputs that genuinely differ:

```cpp
HtmlService translate(const DecodedFile &, const HtmlConfig &, const Logger & = …);
HtmlService translate(const Document &,   const HtmlConfig &, const Logger & = …);
HtmlService translate(const Filesystem &, const HtmlConfig &, const Logger & = …);
HtmlService translate(const Archive &,    const HtmlConfig &, const Logger & = …);
```

## Bindings

The cache argument goes from all of them, so this is breaking for every
consumer:

| | before | after |
|---|---|---|
| Java | `Html.translate(file, cachePath, config)` | `Html.translate(file, config)` |
| Python | `pyodr.html.translate(file, cache_path, config)` | `pyodr.html.translate(file, config)` |
| Swift | `HtmlTranslator.translate(file:cachePath:config:)` | `HtmlTranslator.translate(file:config:)` |

wasm already called the cache-free overloads and is unchanged.

Net −344/+162, most of it deletion.

## Verified

Full build (library, CLI, JNI + jar, python module, tests) clean. 195
`html*`/`Html*`/`*Image*`/`*Media*`/`*Font*`/`*Csv*`/`*Markdown*` gtests, 69
python tests, and the JNI junit suite via `ctest --test-dir jni` all pass.
Apple and its Swift tests are signature edits with no behaviour change.

## Migration

Drop the cache path argument. If you built a directory to pass to it, drop the
directory too — nothing was ever written there.