### PR TITLE
feat(pdf): write markup and ink annotations

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -225,6 +225,7 @@ set(ODR_SOURCE_FILES
 
         "src/odr/internal/pdf/pdf_afm.cpp"
         "src/odr/internal/pdf/pdf_afm_data.cpp"
+        "src/odr/internal/pdf/pdf_annotation.cpp"
         "src/odr/internal/pdf/pdf_cid.cpp"
         "src/odr/internal/pdf/pdf_cid_data.cpp"
         "src/odr/internal/pdf/pdf_cmap.cpp"

--- a/docs/design/pdf-annotation.md
+++ b/docs/design/pdf-annotation.md
@@ -3,8 +3,8 @@
 Status: **underway.** This records the architecture for adding markup
 annotations — text highlight and freehand drawing first — to an existing PDF,
 the alternatives weighed, and the effort it costs. The format model is
-validated against four viewers, and Phases 0 through 1 have landed: the
-incremental writer works, the annotations it will carry are not written yet.
+validated against four viewers, and Phases 0 through 3 have landed: the writer
+appends, and the markup and ink annotations it carries are written.
 
 Scope is **markup only**: draw on top of a page, highlight/underline/strike
 text. Editing or removing the *existing* text of a PDF is explicitly out — that
@@ -166,10 +166,8 @@ Notes on the shape:
 - **`quads` order is upper-left, upper-right, lower-left, lower-right.** The
   spec's stated order (12.5.6.10) is counterclockwise; every implementation
   writes the Z-order above, and `pdfAnnotate`'s documentation says as much
-  outright. Follow the implementations, and say so in a comment at the one place
-  that emits it. Still **unverified** — see *Validated against real viewers*:
-  an annotation carrying an `/AP` never has its `/QuadPoints` read, so a test
-  has to reach for a viewer that regenerates the appearance.
+  outright, as does Phase 2's appearance-less experiment. Follow the
+  implementations, and say so in a comment at the one place that emits it.
 - **`delete` only names an annotation we wrote**, identified by the `/NM` we
   minted. Deleting a foreign annotation is out of scope: we would have to prove
   nothing else references it.
@@ -225,9 +223,8 @@ correctly (user-space y 700/688 arrived at page-box y 92/104).
 Three things the spike did **not** settle, and Phase 1 and 2 owe tests for each:
 
 - **QuadPoints ordering.** With an `/AP` present, the appearance is what every
-  one of those engines painted — the `/QuadPoints` were never consulted. The
-  ordering matters only to a viewer that regenerates the appearance, and to
-  text-selection semantics. The note below stands as a note.
+  one of those engines painted — the `/QuadPoints` were never consulted.
+  Settled in Phase 2 with an appearance-less annotation instead.
 - **A page dictionary inside an object stream**, and **appending to a file
   whose newest section is an xref stream.** The spike's fixture had neither;
   Phase 1's tests cover both.
@@ -279,17 +276,21 @@ ghostscript, CoreGraphics and our own renderer all honour the new rotation
 A page dictionary living inside an object stream is rewritten uncompressed in
 the new section, the newer type-1 entry winning over the older type-2 one.
 
-### Phase 2 — highlight (2 d, ~200 lines)
+### Phases 2 and 3 — text markup and ink — **done** (#847)
 
-Annotation dictionary + appearance builder + `/Annots` append. The test is the
-round trip: write, re-open with `DocumentParser`, assert the appearance resolves
-and the rendered page carries a `mix-blend-mode:multiply` rect at the expected
-position.
+`pdf/pdf_annotation.{hpp,cpp}`: `write_text_markup` covers `/Highlight`,
+`/Underline`, `/StrikeOut` and `/Squiggly`; `write_ink` covers `/Ink`, its
+strokes smoothed Catmull-Rom → cubic bezier. `append_page_annotations` puts
+them on the page, rewriting the `/Annots` array itself where it is indirect.
 
-### Phase 3 — ink (1–2 d, ~150 lines)
+Only the highlight multiplies (11.6.4.1) — it is a wash over the text, where
+the others are marks drawn on top of it.
 
-Stroke smoothing (Catmull-Rom → cubic bezier) into the appearance stream.
-`/BS /W`, round caps/joins.
+**`/QuadPoints` ordering is settled.** Two files carrying the same visual
+rectangle, one in Z-order and one in the spec's counterclockwise order, each
+with no `/AP` so a viewer has to synthesize the appearance: ghostscript draws
+the Z-order as a clean rectangle and the spec's order as a twisted, smeared
+blob. CoreGraphics synthesizes nothing at all, so it is no oracle here.
 
 ### Phase 4 — public API (1 d, ~130 lines)
 
@@ -368,8 +369,3 @@ Medium:
   the `Decryptor` key accessor need to land in v1 after all?
 - **Where does the pending-annotation state live across a reload** in the mobile
   WebView — the browser only, or does the host persist the payload?
-- **How do we test `/QuadPoints` ordering at all?** Every engine we have as an
-  oracle paints the `/AP` and ignores them. Options: write one annotation
-  *without* an appearance and see where a viewer puts it, or check what Acrobat
-  does with our file. Cheap either way, but it needs deciding before Phase 2
-  claims the ordering is right.

--- a/docs/design/pdf-annotation.md
+++ b/docs/design/pdf-annotation.md
@@ -284,13 +284,14 @@ strokes smoothed Catmull-Rom → cubic bezier. `append_page_annotations` puts
 them on the page, rewriting the `/Annots` array itself where it is indirect.
 
 Only the highlight multiplies (11.6.4.1) — it is a wash over the text, where
-the others are marks drawn on top of it.
+the others are marks drawn on top of it. Opacity rides on the annotation's
+`/CA` alone, which a viewer applies to the whole appearance; setting `ca` in
+the appearance's own state as well would square it.
 
-**`/QuadPoints` ordering is settled.** Two files carrying the same visual
-rectangle, one in Z-order and one in the spec's counterclockwise order, each
-with no `/AP` so a viewer has to synthesize the appearance: ghostscript draws
-the Z-order as a clean rectangle and the spec's order as a twisted, smeared
-blob. CoreGraphics synthesizes nothing at all, so it is no oracle here.
+**`/QuadPoints` ordering is settled** against two appearance-less files that
+force a viewer to synthesize one: ghostscript draws the Z-order as a clean
+rectangle and 12.5.6.10's counterclockwise order as a twisted blob.
+CoreGraphics synthesizes nothing at all, so it is no oracle here.
 
 ### Phase 4 — public API (1 d, ~130 lines)
 

--- a/src/odr/internal/pdf/pdf_annotation.cpp
+++ b/src/odr/internal/pdf/pdf_annotation.cpp
@@ -1,0 +1,379 @@
+#include <odr/internal/pdf/pdf_annotation.hpp>
+
+#include <odr/internal/pdf/pdf_document_element.hpp>
+#include <odr/internal/pdf/pdf_document_parser.hpp>
+#include <odr/internal/pdf/pdf_writer.hpp>
+#include <odr/internal/util/number_util.hpp>
+
+#include <algorithm>
+#include <cmath>
+#include <sstream>
+#include <stdexcept>
+
+#include <fmt/format.h>
+
+namespace odr::internal::pdf {
+
+namespace {
+
+/// A rectangle in user space, as `/Rect` and `/BBox` state it.
+struct Box {
+  double x0{0};
+  double y0{0};
+  double x1{0};
+  double y1{0};
+
+  void include(const double x, const double y) {
+    x0 = std::min(x0, x);
+    y0 = std::min(y0, y);
+    x1 = std::max(x1, x);
+    y1 = std::max(y1, y);
+  }
+  [[nodiscard]] Box grown(const double margin) const {
+    return {x0 - margin, y0 - margin, x1 + margin, y1 + margin};
+  }
+};
+
+Box box_of(const std::vector<Quad> &quads) {
+  Box result{quads.front()[0], quads.front()[1], quads.front()[0],
+             quads.front()[1]};
+  for (const Quad &quad : quads) {
+    for (std::size_t i = 0; i < quad.size(); i += 2) {
+      result.include(quad[i], quad[i + 1]);
+    }
+  }
+  return result;
+}
+
+Box box_of(const std::vector<InkStroke> &strokes) {
+  Box result{strokes.front()[0], strokes.front()[1], strokes.front()[0],
+             strokes.front()[1]};
+  for (const InkStroke &stroke : strokes) {
+    for (std::size_t i = 0; i < stroke.size(); i += 2) {
+      result.include(stroke[i], stroke[i + 1]);
+    }
+  }
+  return result;
+}
+
+Object rectangle(const Box &box) {
+  Array result;
+  for (const double v : {box.x0, box.y0, box.x1, box.y1}) {
+    result.holder().emplace_back(Real{v});
+  }
+  return Object(std::move(result));
+}
+
+std::string number(const double value) {
+  return util::number::to_string_significant(value, 6);
+}
+
+/// The `/ExtGState` an appearance needs, and the `gs` name to invoke it with.
+/// `blend` is empty for the default Normal.
+Dictionary graphics_state_resources(const double alpha,
+                                    const std::string_view blend) {
+  Dictionary state;
+  state["ca"] = Object(Real{alpha});
+  state["CA"] = Object(Real{alpha});
+  if (!blend.empty()) {
+    state["BM"] = Object(Name{std::string(blend)});
+  }
+  Dictionary states;
+  states["G0"] = Object(std::move(state));
+  Dictionary result;
+  result["ExtGState"] = Object(std::move(states));
+  return result;
+}
+
+/// The form XObject an annotation's `/AP /N` points at. A transparency group
+/// is what lets `/BM /Multiply` composite against the page rather than against
+/// the form's own backdrop.
+Dictionary appearance_dictionary(const Box &box, Dictionary resources,
+                                 const bool transparency_group) {
+  Dictionary result;
+  result["Type"] = Object(Name{"XObject"});
+  result["Subtype"] = Object(Name{"Form"});
+  result["BBox"] = rectangle(box);
+  result["Resources"] = Object(std::move(resources));
+  if (transparency_group) {
+    Dictionary group;
+    group["Type"] = Object(Name{"Group"});
+    group["S"] = Object(Name{"Transparency"});
+    group["CS"] = Object(Name{"DeviceRGB"});
+    result["Group"] = Object(std::move(group));
+  }
+  return result;
+}
+
+void write_common(Dictionary &dictionary, const AnnotationCommon &common,
+                  const ObjectReference &self) {
+  Array color;
+  for (const double c : common.color) {
+    color.holder().emplace_back(Real{c});
+  }
+  dictionary["C"] = Object(std::move(color));
+  dictionary["CA"] = Object(Real{common.opacity});
+  // 12.5.3: bit 3, Print. Without it a viewer may show but never print it.
+  dictionary["F"] = Object(Integer{4});
+  // unique within the file, and stable for a given file and annotation
+  dictionary["NM"] = Object(StandardString{fmt::format("odr-{}", self.id)});
+  if (!common.author.empty()) {
+    dictionary["T"] = Object(StandardString{common.author});
+  }
+  if (!common.contents.empty()) {
+    dictionary["Contents"] = Object(StandardString{common.contents});
+  }
+}
+
+std::string_view subtype_of(const TextMarkupKind kind) {
+  switch (kind) {
+  case TextMarkupKind::highlight:
+    return "Highlight";
+  case TextMarkupKind::underline:
+    return "Underline";
+  case TextMarkupKind::strike_out:
+    return "StrikeOut";
+  case TextMarkupKind::squiggly:
+    return "Squiggly";
+  }
+  throw std::invalid_argument("unknown text markup kind");
+}
+
+/// A quad's corners, named. The order is the one `Quad` documents.
+struct QuadCorners {
+  double left{0};
+  double right{0};
+  double top{0};
+  double bottom{0};
+};
+
+QuadCorners corners_of(const Quad &quad) {
+  return {std::min({quad[0], quad[2], quad[4], quad[6]}),
+          std::max({quad[0], quad[2], quad[4], quad[6]}),
+          std::max({quad[1], quad[3], quad[5], quad[7]}),
+          std::min({quad[1], quad[3], quad[5], quad[7]})};
+}
+
+/// A filled bar across `quad`, `height` tall, its bottom at `bottom`.
+void bar(std::ostringstream &out, const QuadCorners &quad, const double bottom,
+         const double height) {
+  out << number(quad.left) << ' ' << number(bottom) << ' '
+      << number(quad.right - quad.left) << ' ' << number(height) << " re\n";
+}
+
+/// A wave along the bottom of `quad`, as a stroked zigzag of `amplitude`.
+void wave(std::ostringstream &out, const QuadCorners &quad,
+          const double amplitude) {
+  const double base = quad.bottom + amplitude;
+  out << number(quad.left) << ' ' << number(base) << " m\n";
+  const auto steps = static_cast<std::size_t>(
+      std::max(1.0, std::floor((quad.right - quad.left) / amplitude)));
+  for (std::size_t i = 1; i <= steps; ++i) {
+    out << number(quad.left + static_cast<double>(i) * amplitude) << ' '
+        << number(i % 2 == 1 ? base + amplitude : base) << " l\n";
+  }
+  out << "S\n";
+}
+
+std::string text_markup_appearance(const TextMarkup &markup) {
+  std::ostringstream out;
+  out << "/G0 gs\n";
+  const auto &[r, g, b] = markup.common.color;
+  out << number(r) << ' ' << number(g) << ' ' << number(b);
+
+  if (markup.kind == TextMarkupKind::squiggly) {
+    out << " RG\n";
+  } else {
+    out << " rg\n";
+  }
+
+  for (const Quad &quad : markup.quads) {
+    const QuadCorners c = corners_of(quad);
+    const double height = c.top - c.bottom;
+    switch (markup.kind) {
+    case TextMarkupKind::highlight:
+      bar(out, c, c.bottom, height);
+      break;
+    case TextMarkupKind::underline:
+      bar(out, c, c.bottom + height / 16, std::max(height / 16, 0.5));
+      break;
+    case TextMarkupKind::strike_out:
+      bar(out, c, c.bottom + height / 2, std::max(height / 16, 0.5));
+      break;
+    case TextMarkupKind::squiggly:
+      out << number(std::max(height / 16, 0.5)) << " w\n";
+      wave(out, c, std::max(height / 8, 1.0));
+      break;
+    }
+  }
+
+  if (markup.kind != TextMarkupKind::squiggly) {
+    out << "f\n";
+  }
+  return std::move(out).str();
+}
+
+/// Catmull-Rom through `points`, emitted as the cubic beziers PDF has. The
+/// tangent at each point is half the vector between its neighbours.
+void smooth_path(std::ostringstream &out, const InkStroke &stroke) {
+  const std::size_t count = stroke.size() / 2;
+  const auto x = [&](const std::size_t i) {
+    return stroke[2 * std::clamp<std::size_t>(i, 0, count - 1)];
+  };
+  const auto y = [&](const std::size_t i) {
+    return stroke[2 * std::clamp<std::size_t>(i, 0, count - 1) + 1];
+  };
+
+  out << number(x(0)) << ' ' << number(y(0)) << " m\n";
+  if (count == 1) {
+    // a dot: a zero-length segment, which round caps render as a disc
+    out << number(x(0)) << ' ' << number(y(0)) << " l\n";
+    return;
+  }
+  for (std::size_t i = 0; i + 1 < count; ++i) {
+    const double c1x = x(i) + (x(i + 1) - x(i == 0 ? 0 : i - 1)) / 6;
+    const double c1y = y(i) + (y(i + 1) - y(i == 0 ? 0 : i - 1)) / 6;
+    const double c2x = x(i + 1) - (x(i + 2) - x(i)) / 6;
+    const double c2y = y(i + 1) - (y(i + 2) - y(i)) / 6;
+    out << number(c1x) << ' ' << number(c1y) << ' ' << number(c2x) << ' '
+        << number(c2y) << ' ' << number(x(i + 1)) << ' ' << number(y(i + 1))
+        << " c\n";
+  }
+}
+
+std::string ink_appearance(const Ink &ink) {
+  std::ostringstream out;
+  out << "/G0 gs\n";
+  const auto &[r, g, b] = ink.common.color;
+  out << number(r) << ' ' << number(g) << ' ' << number(b) << " RG\n";
+  out << number(ink.width) << " w 1 J 1 j\n";
+  for (const InkStroke &stroke : ink.strokes) {
+    smooth_path(out, stroke);
+    out << "S\n";
+  }
+  return std::move(out).str();
+}
+
+} // namespace
+
+ObjectReference write_text_markup(IncrementalWriter &writer,
+                                  const TextMarkup &markup) {
+  if (markup.quads.empty()) {
+    throw std::invalid_argument("text markup has no quads");
+  }
+
+  const Box box = box_of(markup.quads);
+  const ObjectReference appearance = writer.mint_object();
+  const ObjectReference annotation = writer.mint_object();
+
+  // 11.6.4.1: only a highlight is a wash over the text; the others are marks
+  // drawn on top and blend normally.
+  const bool multiply = markup.kind == TextMarkupKind::highlight;
+  writer.set_stream_object(
+      appearance,
+      appearance_dictionary(
+          box,
+          graphics_state_resources(markup.common.opacity,
+                                   multiply ? "Multiply" : ""),
+          multiply),
+      text_markup_appearance(markup));
+
+  Dictionary dictionary;
+  dictionary["Type"] = Object(Name{"Annot"});
+  dictionary["Subtype"] = Object(Name{std::string(subtype_of(markup.kind))});
+  dictionary["Rect"] = rectangle(box);
+  Array quad_points;
+  for (const Quad &quad : markup.quads) {
+    for (const double v : quad) {
+      quad_points.holder().emplace_back(Real{v});
+    }
+  }
+  dictionary["QuadPoints"] = Object(std::move(quad_points));
+  write_common(dictionary, markup.common, annotation);
+  Dictionary appearances;
+  appearances["N"] = Object(appearance);
+  dictionary["AP"] = Object(std::move(appearances));
+
+  writer.set_object(annotation, Object(std::move(dictionary)));
+  return annotation;
+}
+
+ObjectReference write_ink(IncrementalWriter &writer, const Ink &ink) {
+  if (ink.strokes.empty()) {
+    throw std::invalid_argument("ink has no strokes");
+  }
+  for (const InkStroke &stroke : ink.strokes) {
+    if (stroke.empty() || stroke.size() % 2 != 0) {
+      throw std::invalid_argument("ink stroke is not a sequence of x y pairs");
+    }
+  }
+
+  // the stroke straddles the path, and a round join can reach half a width out
+  const Box box = box_of(ink.strokes).grown(ink.width);
+  const ObjectReference appearance = writer.mint_object();
+  const ObjectReference annotation = writer.mint_object();
+
+  writer.set_stream_object(
+      appearance,
+      appearance_dictionary(
+          box, graphics_state_resources(ink.common.opacity, ""), false),
+      ink_appearance(ink));
+
+  Dictionary dictionary;
+  dictionary["Type"] = Object(Name{"Annot"});
+  dictionary["Subtype"] = Object(Name{"Ink"});
+  dictionary["Rect"] = rectangle(box);
+  Array ink_list;
+  for (const InkStroke &stroke : ink.strokes) {
+    Array points;
+    for (const double v : stroke) {
+      points.holder().emplace_back(Real{v});
+    }
+    ink_list.holder().emplace_back(std::move(points));
+  }
+  dictionary["InkList"] = Object(std::move(ink_list));
+  Dictionary border;
+  border["W"] = Object(Real{ink.width});
+  dictionary["BS"] = Object(std::move(border));
+  write_common(dictionary, ink.common, annotation);
+  Dictionary appearances;
+  appearances["N"] = Object(appearance);
+  dictionary["AP"] = Object(std::move(appearances));
+
+  writer.set_object(annotation, Object(std::move(dictionary)));
+  return annotation;
+}
+
+void append_page_annotations(IncrementalWriter &writer, const Page &page,
+                             const std::vector<ObjectReference> &annotations) {
+  if (annotations.empty()) {
+    return;
+  }
+
+  Dictionary dictionary = page.object.as_dictionary();
+  const Object &existing = dictionary.get("Annots");
+
+  const auto extend = [&annotations](Array array) {
+    for (const ObjectReference &annotation : annotations) {
+      array.holder().emplace_back(annotation);
+    }
+    return array;
+  };
+
+  // `/Annots` may be an indirect array shared with nothing else; rewriting it
+  // in place leaves the page dictionary untouched.
+  if (existing.is_reference()) {
+    const ObjectReference reference = existing.as_reference();
+    const Object &array = writer.parser().read_object(reference).object;
+    writer.set_object(
+        reference,
+        Object(extend(array.is_array() ? array.as_array() : Array{})));
+    return;
+  }
+
+  dictionary["Annots"] =
+      Object(extend(existing.is_array() ? existing.as_array() : Array{}));
+  writer.set_object(page.object_reference, Object(std::move(dictionary)));
+}
+
+} // namespace odr::internal::pdf

--- a/src/odr/internal/pdf/pdf_annotation.cpp
+++ b/src/odr/internal/pdf/pdf_annotation.cpp
@@ -34,23 +34,13 @@ struct Box {
   }
 };
 
-Box box_of(const std::vector<Quad> &quads) {
-  Box result{quads.front()[0], quads.front()[1], quads.front()[0],
-             quads.front()[1]};
-  for (const Quad &quad : quads) {
-    for (std::size_t i = 0; i < quad.size(); i += 2) {
-      result.include(quad[i], quad[i + 1]);
-    }
-  }
-  return result;
-}
-
-Box box_of(const std::vector<InkStroke> &strokes) {
-  Box result{strokes.front()[0], strokes.front()[1], strokes.front()[0],
-             strokes.front()[1]};
-  for (const InkStroke &stroke : strokes) {
-    for (std::size_t i = 0; i < stroke.size(); i += 2) {
-      result.include(stroke[i], stroke[i + 1]);
+/// The bounding box of a non-empty range of `x y` pair sequences.
+template <typename Points> Box box_of(const std::vector<Points> &groups) {
+  Box result{groups.front()[0], groups.front()[1], groups.front()[0],
+             groups.front()[1]};
+  for (const Points &points : groups) {
+    for (std::size_t i = 0; i < points.size(); i += 2) {
+      result.include(points[i], points[i + 1]);
     }
   }
   return result;
@@ -68,16 +58,12 @@ std::string number(const double value) {
   return util::number::to_string_significant(value, 6);
 }
 
-/// The `/ExtGState` an appearance needs, and the `gs` name to invoke it with.
-/// `blend` is empty for the default Normal.
-Dictionary graphics_state_resources(const double alpha,
-                                    const std::string_view blend) {
+/// The `/ExtGState` a multiplied appearance invokes as `/G0 gs`. Opacity is not
+/// in it: `/CA` already applies to the appearance as a whole (12.5.2), so
+/// repeating it here would square it.
+Dictionary multiply_resources() {
   Dictionary state;
-  state["ca"] = Object(Real{alpha});
-  state["CA"] = Object(Real{alpha});
-  if (!blend.empty()) {
-    state["BM"] = Object(Name{std::string(blend)});
-  }
+  state["BM"] = Object(Name{"Multiply"});
   Dictionary states;
   states["G0"] = Object(std::move(state));
   Dictionary result;
@@ -85,9 +71,9 @@ Dictionary graphics_state_resources(const double alpha,
   return result;
 }
 
-/// The form XObject an annotation's `/AP /N` points at. A transparency group
-/// is what lets `/BM /Multiply` composite against the page rather than against
-/// the form's own backdrop.
+/// The form XObject an annotation's `/AP /N` points at. A transparency group is
+/// what lets `/BM /Multiply` composite against the page rather than against the
+/// form's own backdrop.
 Dictionary appearance_dictionary(const Box &box, Dictionary resources,
                                  const bool transparency_group) {
   Dictionary result;
@@ -115,7 +101,6 @@ void write_common(Dictionary &dictionary, const AnnotationCommon &common,
   dictionary["CA"] = Object(Real{common.opacity});
   // 12.5.3: bit 3, Print. Without it a viewer may show but never print it.
   dictionary["F"] = Object(Integer{4});
-  // unique within the file, and stable for a given file and annotation
   dictionary["NM"] = Object(StandardString{fmt::format("odr-{}", self.id)});
   if (!common.author.empty()) {
     dictionary["T"] = Object(StandardString{common.author});
@@ -139,7 +124,7 @@ std::string_view subtype_of(const TextMarkupKind kind) {
   throw std::invalid_argument("unknown text markup kind");
 }
 
-/// A quad's corners, named. The order is the one `Quad` documents.
+/// A quad's extent, whichever corners it states.
 struct QuadCorners {
   double left{0};
   double right{0};
@@ -154,7 +139,6 @@ QuadCorners corners_of(const Quad &quad) {
           std::min({quad[1], quad[3], quad[5], quad[7]})};
 }
 
-/// A filled bar across `quad`, `height` tall, its bottom at `bottom`.
 void bar(std::ostringstream &out, const QuadCorners &quad, const double bottom,
          const double height) {
   out << number(quad.left) << ' ' << number(bottom) << ' '
@@ -177,15 +161,12 @@ void wave(std::ostringstream &out, const QuadCorners &quad,
 
 std::string text_markup_appearance(const TextMarkup &markup) {
   std::ostringstream out;
-  out << "/G0 gs\n";
+  if (markup.kind == TextMarkupKind::highlight) {
+    out << "/G0 gs\n";
+  }
   const auto &[r, g, b] = markup.common.color;
   out << number(r) << ' ' << number(g) << ' ' << number(b);
-
-  if (markup.kind == TextMarkupKind::squiggly) {
-    out << " RG\n";
-  } else {
-    out << " rg\n";
-  }
+  out << (markup.kind == TextMarkupKind::squiggly ? " RG\n" : " rg\n");
 
   for (const Quad &quad : markup.quads) {
     const QuadCorners c = corners_of(quad);
@@ -213,8 +194,9 @@ std::string text_markup_appearance(const TextMarkup &markup) {
   return std::move(out).str();
 }
 
-/// Catmull-Rom through `points`, emitted as the cubic beziers PDF has. The
-/// tangent at each point is half the vector between its neighbours.
+/// Catmull-Rom through `stroke`, emitted as the cubic beziers PDF has: the
+/// tangent at a point is half the vector between its neighbours, and a control
+/// point sits a third of that away.
 void smooth_path(std::ostringstream &out, const InkStroke &stroke) {
   const std::size_t count = stroke.size() / 2;
   const auto x = [&](const std::size_t i) {
@@ -243,7 +225,6 @@ void smooth_path(std::ostringstream &out, const InkStroke &stroke) {
 
 std::string ink_appearance(const Ink &ink) {
   std::ostringstream out;
-  out << "/G0 gs\n";
   const auto &[r, g, b] = ink.common.color;
   out << number(r) << ' ' << number(g) << ' ' << number(b) << " RG\n";
   out << number(ink.width) << " w 1 J 1 j\n";
@@ -254,10 +235,20 @@ std::string ink_appearance(const Ink &ink) {
   return std::move(out).str();
 }
 
+Object annotation_appearance(const ObjectReference &appearance) {
+  Dictionary result;
+  result["N"] = Object(appearance);
+  return Object(std::move(result));
+}
+
 } // namespace
 
-ObjectReference write_text_markup(IncrementalWriter &writer,
-                                  const TextMarkup &markup) {
+} // namespace odr::internal::pdf
+
+namespace odr::internal {
+
+pdf::ObjectReference pdf::write_text_markup(IncrementalWriter &writer,
+                                            const TextMarkup &markup) {
   if (markup.quads.empty()) {
     throw std::invalid_argument("text markup has no quads");
   }
@@ -271,11 +262,8 @@ ObjectReference write_text_markup(IncrementalWriter &writer,
   const bool multiply = markup.kind == TextMarkupKind::highlight;
   writer.set_stream_object(
       appearance,
-      appearance_dictionary(
-          box,
-          graphics_state_resources(markup.common.opacity,
-                                   multiply ? "Multiply" : ""),
-          multiply),
+      appearance_dictionary(box, multiply ? multiply_resources() : Dictionary{},
+                            multiply),
       text_markup_appearance(markup));
 
   Dictionary dictionary;
@@ -290,15 +278,13 @@ ObjectReference write_text_markup(IncrementalWriter &writer,
   }
   dictionary["QuadPoints"] = Object(std::move(quad_points));
   write_common(dictionary, markup.common, annotation);
-  Dictionary appearances;
-  appearances["N"] = Object(appearance);
-  dictionary["AP"] = Object(std::move(appearances));
+  dictionary["AP"] = annotation_appearance(appearance);
 
   writer.set_object(annotation, Object(std::move(dictionary)));
   return annotation;
 }
 
-ObjectReference write_ink(IncrementalWriter &writer, const Ink &ink) {
+pdf::ObjectReference pdf::write_ink(IncrementalWriter &writer, const Ink &ink) {
   if (ink.strokes.empty()) {
     throw std::invalid_argument("ink has no strokes");
   }
@@ -313,11 +299,9 @@ ObjectReference write_ink(IncrementalWriter &writer, const Ink &ink) {
   const ObjectReference appearance = writer.mint_object();
   const ObjectReference annotation = writer.mint_object();
 
-  writer.set_stream_object(
-      appearance,
-      appearance_dictionary(
-          box, graphics_state_resources(ink.common.opacity, ""), false),
-      ink_appearance(ink));
+  writer.set_stream_object(appearance,
+                           appearance_dictionary(box, Dictionary{}, false),
+                           ink_appearance(ink));
 
   Dictionary dictionary;
   dictionary["Type"] = Object(Name{"Annot"});
@@ -336,16 +320,15 @@ ObjectReference write_ink(IncrementalWriter &writer, const Ink &ink) {
   border["W"] = Object(Real{ink.width});
   dictionary["BS"] = Object(std::move(border));
   write_common(dictionary, ink.common, annotation);
-  Dictionary appearances;
-  appearances["N"] = Object(appearance);
-  dictionary["AP"] = Object(std::move(appearances));
+  dictionary["AP"] = annotation_appearance(appearance);
 
   writer.set_object(annotation, Object(std::move(dictionary)));
   return annotation;
 }
 
-void append_page_annotations(IncrementalWriter &writer, const Page &page,
-                             const std::vector<ObjectReference> &annotations) {
+void pdf::append_page_annotations(
+    IncrementalWriter &writer, const Page &page,
+    const std::vector<ObjectReference> &annotations) {
   if (annotations.empty()) {
     return;
   }
@@ -360,8 +343,8 @@ void append_page_annotations(IncrementalWriter &writer, const Page &page,
     return array;
   };
 
-  // `/Annots` may be an indirect array shared with nothing else; rewriting it
-  // in place leaves the page dictionary untouched.
+  // where `/Annots` is indirect, rewriting the array leaves the page dictionary
+  // untouched
   if (existing.is_reference()) {
     const ObjectReference reference = existing.as_reference();
     const Object &array = writer.parser().read_object(reference).object;
@@ -376,4 +359,4 @@ void append_page_annotations(IncrementalWriter &writer, const Page &page,
   writer.set_object(page.object_reference, Object(std::move(dictionary)));
 }
 
-} // namespace odr::internal::pdf
+} // namespace odr::internal

--- a/src/odr/internal/pdf/pdf_annotation.hpp
+++ b/src/odr/internal/pdf/pdf_annotation.hpp
@@ -12,9 +12,8 @@ class IncrementalWriter;
 struct Page;
 
 /// A text markup quadrilateral in user space: upper-left, upper-right,
-/// lower-left, lower-right. 12.5.6.10 states a different order, which no
-/// producer writes and which viewers synthesizing an appearance draw as a
-/// twisted quad.
+/// lower-left, lower-right — the order producers write, not the
+/// counterclockwise one 12.5.6.10 states.
 using Quad = std::array<double, 8>;
 
 /// One pen-down to pen-up stroke as flat `x y` pairs in user space.
@@ -47,16 +46,17 @@ struct Ink {
   AnnotationCommon common;
 };
 
-/// Write the annotation and the appearance stream it paints through
-/// (decision 3: we never leave a viewer to synthesize one).
+/// Write the annotation together with the appearance stream it paints through,
+/// so no viewer has to synthesize one.
 /// @throws std::invalid_argument on empty or malformed geometry.
 ObjectReference write_text_markup(IncrementalWriter &writer,
                                   const TextMarkup &markup);
 ObjectReference write_ink(IncrementalWriter &writer, const Ink &ink);
 
-/// Append `annotations` to `page`'s `/Annots`, rewriting whichever object
-/// holds it — the page dictionary, or the array itself where `/Annots` is
-/// indirect.
+/// Append `annotations` to `page`'s `/Annots`, rewriting whichever object holds
+/// it — the page dictionary, or the array itself where `/Annots` is indirect.
+/// Reads the page as the source file has it, so call it once per page with
+/// everything that page gains.
 void append_page_annotations(IncrementalWriter &writer, const Page &page,
                              const std::vector<ObjectReference> &annotations);
 

--- a/src/odr/internal/pdf/pdf_annotation.hpp
+++ b/src/odr/internal/pdf/pdf_annotation.hpp
@@ -1,0 +1,63 @@
+#pragma once
+
+#include <odr/internal/pdf/pdf_object.hpp>
+
+#include <array>
+#include <string>
+#include <vector>
+
+namespace odr::internal::pdf {
+
+class IncrementalWriter;
+struct Page;
+
+/// A text markup quadrilateral in user space: upper-left, upper-right,
+/// lower-left, lower-right. 12.5.6.10 states a different order, which no
+/// producer writes and which viewers synthesizing an appearance draw as a
+/// twisted quad.
+using Quad = std::array<double, 8>;
+
+/// One pen-down to pen-up stroke as flat `x y` pairs in user space.
+using InkStroke = std::vector<double>;
+
+enum class TextMarkupKind {
+  highlight,  ///< 12.5.6.10, multiplied over the text it covers
+  underline,  ///< a bar along the bottom of each quad
+  strike_out, ///< a bar across the middle of each quad
+  squiggly,   ///< a wave along the bottom of each quad
+};
+
+/// Fields every markup annotation carries (12.5.2).
+struct AnnotationCommon {
+  std::array<double, 3> color{0, 0, 0}; ///< `/C`, DeviceRGB in [0, 1]
+  double opacity{1};                    ///< `/CA`
+  std::string author;                   ///< `/T`, omitted when empty
+  std::string contents;                 ///< `/Contents`, omitted when empty
+};
+
+struct TextMarkup {
+  TextMarkupKind kind{TextMarkupKind::highlight};
+  std::vector<Quad> quads;
+  AnnotationCommon common;
+};
+
+struct Ink {
+  std::vector<InkStroke> strokes;
+  double width{1}; ///< `/BS /W`, in points
+  AnnotationCommon common;
+};
+
+/// Write the annotation and the appearance stream it paints through
+/// (decision 3: we never leave a viewer to synthesize one).
+/// @throws std::invalid_argument on empty or malformed geometry.
+ObjectReference write_text_markup(IncrementalWriter &writer,
+                                  const TextMarkup &markup);
+ObjectReference write_ink(IncrementalWriter &writer, const Ink &ink);
+
+/// Append `annotations` to `page`'s `/Annots`, rewriting whichever object
+/// holds it — the page dictionary, or the array itself where `/Annots` is
+/// indirect.
+void append_page_annotations(IncrementalWriter &writer, const Page &page,
+                             const std::vector<ObjectReference> &annotations);
+
+} // namespace odr::internal::pdf

--- a/src/odr/internal/pdf/pdf_writer.hpp
+++ b/src/odr/internal/pdf/pdf_writer.hpp
@@ -19,6 +19,9 @@ public:
   ///         cross-reference table, or encrypted.
   explicit IncrementalWriter(DocumentParser &parser);
 
+  /// The parser the update is being written against.
+  [[nodiscard]] DocumentParser &parser() const noexcept { return *m_parser; }
+
   /// An id past every one the file uses.
   [[nodiscard]] ObjectReference mint_object();
 

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -93,6 +93,7 @@ add_executable(odr_test
         "src/internal/ooxml/ooxml_util_test.cpp"
         "src/internal/ooxml/ooxml_presentation_style_test.cpp"
 
+        "src/internal/pdf/pdf_annotation.cpp"
         "src/internal/pdf/pdf_cid.cpp"
         "src/internal/pdf/pdf_cmap.cpp"
         "src/internal/pdf/pdf_color.cpp"

--- a/test/src/internal/pdf/pdf_annotation.cpp
+++ b/test/src/internal/pdf/pdf_annotation.cpp
@@ -56,6 +56,20 @@ std::string annotated(const std::string &pdf, Annotate &&annotate) {
   return std::move(out).str();
 }
 
+std::string with_markup(const TextMarkup &markup) {
+  return annotated(mini_pdf(), [&markup](IncrementalWriter &w) {
+    return std::vector{write_text_markup(w, markup)};
+  });
+}
+
+/// The dictionary of the one annotation `markup` produces.
+Dictionary markup_annotation(const TextMarkup &markup) {
+  DocumentParser parser(
+      std::make_unique<std::istringstream>(with_markup(markup)));
+  const std::unique_ptr<Document> document = parser.parse_document();
+  return first_page(*document)->annotations.front()->object.as_dictionary();
+}
+
 TextMarkup one_line_highlight() {
   TextMarkup markup;
   markup.kind = TextMarkupKind::highlight;
@@ -68,11 +82,8 @@ TextMarkup one_line_highlight() {
 
 // The annotation and its appearance both land, and the page reaches them.
 TEST(PdfAnnotation, highlight_round_trips) {
-  const std::string result = annotated(mini_pdf(), [](IncrementalWriter &w) {
-    return std::vector{write_text_markup(w, one_line_highlight())};
-  });
-
-  DocumentParser parser(std::make_unique<std::istringstream>(result));
+  DocumentParser parser(
+      std::make_unique<std::istringstream>(with_markup(one_line_highlight())));
   const std::unique_ptr<Document> document = parser.parse_document();
   const Page *page = first_page(*document);
   ASSERT_NE(page, nullptr);
@@ -97,57 +108,49 @@ TEST(PdfAnnotation, highlight_round_trips) {
 }
 
 // 11.6.4.1: the highlight is a wash, so its appearance multiplies; the marks
-// drawn on top of the text do not.
+// drawn on top of the text do not. Opacity stays out of the state — `/CA`
+// already applies to the whole appearance, so a second `ca` would square it.
 TEST(PdfAnnotation, only_highlight_multiplies) {
-  const auto blend_mode = [](const TextMarkupKind kind) {
+  const auto resources = [](const TextMarkupKind kind) {
     TextMarkup markup = one_line_highlight();
     markup.kind = kind;
+    markup.common.opacity = 0.5;
 
-    const std::string result =
-        annotated(mini_pdf(), [&markup](IncrementalWriter &w) {
-          return std::vector{write_text_markup(w, markup)};
-        });
-
-    DocumentParser parser(std::make_unique<std::istringstream>(result));
+    DocumentParser parser(
+        std::make_unique<std::istringstream>(with_markup(markup)));
     const std::unique_ptr<Document> document = parser.parse_document();
-    const Annotation &annotation = *first_page(*document)->annotations.front();
-    const ObjectReference appearance = annotation.object.as_dictionary()
-                                           .get("AP")
-                                           .as_dictionary()
-                                           .get("N")
-                                           .as_reference();
-    const Dictionary &state = parser.read_object(appearance)
-                                  .object.as_dictionary()
-                                  .get("Resources")
-                                  .as_dictionary()
-                                  .get("ExtGState")
-                                  .as_dictionary()
-                                  .get("G0")
-                                  .as_dictionary();
-    return state.has_key("BM") ? state.get("BM").as_string() : std::string();
+    const Dictionary &dictionary =
+        first_page(*document)->annotations.front()->object.as_dictionary();
+    EXPECT_DOUBLE_EQ(dictionary.get("CA").as_real(), 0.5);
+    return parser
+        .read_object(
+            dictionary.get("AP").as_dictionary().get("N").as_reference())
+        .object.as_dictionary()
+        .get("Resources")
+        .as_dictionary();
   };
 
-  EXPECT_EQ(blend_mode(TextMarkupKind::highlight), "Multiply");
-  EXPECT_EQ(blend_mode(TextMarkupKind::underline), "");
-  EXPECT_EQ(blend_mode(TextMarkupKind::strike_out), "");
-  EXPECT_EQ(blend_mode(TextMarkupKind::squiggly), "");
+  const Dictionary state = resources(TextMarkupKind::highlight)
+                               .get("ExtGState")
+                               .as_dictionary()
+                               .get("G0")
+                               .as_dictionary();
+  EXPECT_EQ(state.get("BM").as_string(), "Multiply");
+  EXPECT_FALSE(state.has_key("ca"));
+  EXPECT_FALSE(state.has_key("CA"));
+
+  for (const TextMarkupKind kind :
+       {TextMarkupKind::underline, TextMarkupKind::strike_out,
+        TextMarkupKind::squiggly}) {
+    EXPECT_FALSE(resources(kind).has_key("ExtGState"));
+  }
 }
 
 TEST(PdfAnnotation, text_markup_subtypes) {
   const auto subtype = [](const TextMarkupKind kind) {
     TextMarkup markup = one_line_highlight();
     markup.kind = kind;
-    const std::string result =
-        annotated(mini_pdf(), [&markup](IncrementalWriter &w) {
-          return std::vector{write_text_markup(w, markup)};
-        });
-    DocumentParser parser(std::make_unique<std::istringstream>(result));
-    const std::unique_ptr<Document> document = parser.parse_document();
-    return first_page(*document)
-        ->annotations.front()
-        ->object.as_dictionary()
-        .get("Subtype")
-        .as_string();
+    return markup_annotation(markup).get("Subtype").as_string();
   };
 
   EXPECT_EQ(subtype(TextMarkupKind::highlight), "Highlight");
@@ -203,19 +206,9 @@ TEST(PdfAnnotation, empty_geometry_throws) {
 }
 
 TEST(PdfAnnotation, optional_fields_are_omitted_when_empty) {
-  const auto annotation_of = [](const TextMarkup &markup, DocumentParser &out) {
-    return first_page(*out.parse_document())
-        ->annotations.front()
-        ->object.as_dictionary();
-  };
-
   TextMarkup markup = one_line_highlight();
   {
-    DocumentParser parser(std::make_unique<std::istringstream>(
-        annotated(mini_pdf(), [&markup](IncrementalWriter &w) {
-          return std::vector{write_text_markup(w, markup)};
-        })));
-    const Dictionary dictionary = annotation_of(markup, parser);
+    const Dictionary dictionary = markup_annotation(markup);
     EXPECT_FALSE(dictionary.has_key("T"));
     EXPECT_FALSE(dictionary.has_key("Contents"));
   }
@@ -223,11 +216,7 @@ TEST(PdfAnnotation, optional_fields_are_omitted_when_empty) {
   markup.common.author = "a reviewer";
   markup.common.contents = "why (this) matters";
   {
-    DocumentParser parser(std::make_unique<std::istringstream>(
-        annotated(mini_pdf(), [&markup](IncrementalWriter &w) {
-          return std::vector{write_text_markup(w, markup)};
-        })));
-    const Dictionary dictionary = annotation_of(markup, parser);
+    const Dictionary dictionary = markup_annotation(markup);
     EXPECT_EQ(dictionary.get("T").as_string(), "a reviewer");
     // the parenthesis survives the escaping the writer applies
     EXPECT_EQ(dictionary.get("Contents").as_string(), "why (this) matters");

--- a/test/src/internal/pdf/pdf_annotation.cpp
+++ b/test/src/internal/pdf/pdf_annotation.cpp
@@ -1,0 +1,282 @@
+#include <odr/internal/pdf/pdf_annotation.hpp>
+
+#include <odr/internal/common/file.hpp>
+#include <odr/internal/pdf/pdf_document.hpp>
+#include <odr/internal/pdf/pdf_document_element.hpp>
+#include <odr/internal/pdf/pdf_document_parser.hpp>
+#include <odr/internal/pdf/pdf_writer.hpp>
+
+#include <test_util.hpp>
+
+#include <internal/pdf/pdf_test_file_builder.hpp>
+
+#include <memory>
+#include <sstream>
+#include <string>
+#include <vector>
+
+#include <gtest/gtest.h>
+
+using namespace odr::internal;
+using namespace odr::internal::pdf;
+using namespace odr::test;
+using PdfFileBuilder = odr::test::pdf::PdfFileBuilder;
+
+namespace {
+
+std::string mini_pdf() {
+  PdfFileBuilder builder;
+  builder.object("<< /Type /Catalog /Pages 2 0 R >>")
+      .object("<< /Type /Pages /Kids [3 0 R] /Count 1 >>")
+      .object("<< /Type /Page /Parent 2 0 R /MediaBox [0 0 612 792] "
+              "/Resources << >> /Contents 4 0 R >>")
+      .stream_object("", "BT ET")
+      .trailer("/Root 1 0 R /ID [<0102> <0304>]");
+  return builder.build_classic();
+}
+
+const Page *first_page(const Document &document) {
+  const auto &kids = document.catalog->pages->kids;
+  return kids.empty() ? nullptr : dynamic_cast<Page *>(kids.front());
+}
+
+/// Writes `annotate`'s annotations onto the first page of `pdf` and returns the
+/// resulting file.
+template <typename Annotate>
+std::string annotated(const std::string &pdf, Annotate &&annotate) {
+  DocumentParser parser(std::make_unique<std::istringstream>(pdf));
+  const std::unique_ptr<Document> document = parser.parse_document();
+  const Page *page = first_page(*document);
+  EXPECT_NE(page, nullptr);
+
+  IncrementalWriter writer(parser);
+  append_page_annotations(writer, *page, annotate(writer));
+  std::ostringstream out;
+  writer.write(out);
+  return std::move(out).str();
+}
+
+TextMarkup one_line_highlight() {
+  TextMarkup markup;
+  markup.kind = TextMarkupKind::highlight;
+  markup.quads.push_back({72, 700, 300, 700, 72, 688, 300, 688});
+  markup.common.color = {1, 0.9, 0.2};
+  return markup;
+}
+
+} // namespace
+
+// The annotation and its appearance both land, and the page reaches them.
+TEST(PdfAnnotation, highlight_round_trips) {
+  const std::string result = annotated(mini_pdf(), [](IncrementalWriter &w) {
+    return std::vector{write_text_markup(w, one_line_highlight())};
+  });
+
+  DocumentParser parser(std::make_unique<std::istringstream>(result));
+  const std::unique_ptr<Document> document = parser.parse_document();
+  const Page *page = first_page(*document);
+  ASSERT_NE(page, nullptr);
+  ASSERT_EQ(page->annotations.size(), 1);
+
+  const Annotation &annotation = *page->annotations.front();
+  const Dictionary &dictionary = annotation.object.as_dictionary();
+  EXPECT_EQ(dictionary.get("Subtype").as_string(), "Highlight");
+  EXPECT_EQ(dictionary.get("QuadPoints").as_array().size(), 8);
+  EXPECT_EQ(dictionary.get("F").as_integer(), 4);
+  EXPECT_EQ(dictionary.get("NM").as_string(), "odr-6");
+
+  // `/Rect` is the union of the quads
+  const std::vector<double> rect = dictionary.get("Rect").as_reals();
+  EXPECT_DOUBLE_EQ(rect[0], 72);
+  EXPECT_DOUBLE_EQ(rect[1], 688);
+  EXPECT_DOUBLE_EQ(rect[2], 300);
+  EXPECT_DOUBLE_EQ(rect[3], 700);
+
+  // the parser resolved `/AP /N` into a form, which is what makes it paint
+  ASSERT_NE(annotation.appearance, nullptr);
+}
+
+// 11.6.4.1: the highlight is a wash, so its appearance multiplies; the marks
+// drawn on top of the text do not.
+TEST(PdfAnnotation, only_highlight_multiplies) {
+  const auto blend_mode = [](const TextMarkupKind kind) {
+    TextMarkup markup = one_line_highlight();
+    markup.kind = kind;
+
+    const std::string result =
+        annotated(mini_pdf(), [&markup](IncrementalWriter &w) {
+          return std::vector{write_text_markup(w, markup)};
+        });
+
+    DocumentParser parser(std::make_unique<std::istringstream>(result));
+    const std::unique_ptr<Document> document = parser.parse_document();
+    const Annotation &annotation = *first_page(*document)->annotations.front();
+    const ObjectReference appearance = annotation.object.as_dictionary()
+                                           .get("AP")
+                                           .as_dictionary()
+                                           .get("N")
+                                           .as_reference();
+    const Dictionary &state = parser.read_object(appearance)
+                                  .object.as_dictionary()
+                                  .get("Resources")
+                                  .as_dictionary()
+                                  .get("ExtGState")
+                                  .as_dictionary()
+                                  .get("G0")
+                                  .as_dictionary();
+    return state.has_key("BM") ? state.get("BM").as_string() : std::string();
+  };
+
+  EXPECT_EQ(blend_mode(TextMarkupKind::highlight), "Multiply");
+  EXPECT_EQ(blend_mode(TextMarkupKind::underline), "");
+  EXPECT_EQ(blend_mode(TextMarkupKind::strike_out), "");
+  EXPECT_EQ(blend_mode(TextMarkupKind::squiggly), "");
+}
+
+TEST(PdfAnnotation, text_markup_subtypes) {
+  const auto subtype = [](const TextMarkupKind kind) {
+    TextMarkup markup = one_line_highlight();
+    markup.kind = kind;
+    const std::string result =
+        annotated(mini_pdf(), [&markup](IncrementalWriter &w) {
+          return std::vector{write_text_markup(w, markup)};
+        });
+    DocumentParser parser(std::make_unique<std::istringstream>(result));
+    const std::unique_ptr<Document> document = parser.parse_document();
+    return first_page(*document)
+        ->annotations.front()
+        ->object.as_dictionary()
+        .get("Subtype")
+        .as_string();
+  };
+
+  EXPECT_EQ(subtype(TextMarkupKind::highlight), "Highlight");
+  EXPECT_EQ(subtype(TextMarkupKind::underline), "Underline");
+  EXPECT_EQ(subtype(TextMarkupKind::strike_out), "StrikeOut");
+  EXPECT_EQ(subtype(TextMarkupKind::squiggly), "Squiggly");
+}
+
+TEST(PdfAnnotation, ink_round_trips) {
+  Ink ink;
+  ink.strokes.push_back({100, 500, 130, 540, 160, 490});
+  ink.width = 2;
+  ink.common.color = {0.9, 0.1, 0.1};
+
+  const std::string result =
+      annotated(mini_pdf(), [&ink](IncrementalWriter &w) {
+        return std::vector{write_ink(w, ink)};
+      });
+
+  DocumentParser parser(std::make_unique<std::istringstream>(result));
+  const std::unique_ptr<Document> document = parser.parse_document();
+  const Page *page = first_page(*document);
+  ASSERT_NE(page, nullptr);
+  ASSERT_EQ(page->annotations.size(), 1);
+
+  const Annotation &annotation = *page->annotations.front();
+  const Dictionary &dictionary = annotation.object.as_dictionary();
+  EXPECT_EQ(dictionary.get("Subtype").as_string(), "Ink");
+  ASSERT_EQ(dictionary.get("InkList").as_array().size(), 1);
+  EXPECT_EQ(dictionary.get("InkList").as_array()[0].as_array().size(), 6);
+  EXPECT_DOUBLE_EQ(dictionary.get("BS").as_dictionary().get("W").as_real(), 2);
+  ASSERT_NE(annotation.appearance, nullptr);
+
+  // the box is grown by the stroke width, which straddles the path
+  const std::vector<double> rect = dictionary.get("Rect").as_reals();
+  EXPECT_DOUBLE_EQ(rect[0], 98);
+  EXPECT_DOUBLE_EQ(rect[1], 488);
+  EXPECT_DOUBLE_EQ(rect[2], 162);
+  EXPECT_DOUBLE_EQ(rect[3], 542);
+}
+
+TEST(PdfAnnotation, empty_geometry_throws) {
+  DocumentParser parser(std::make_unique<std::istringstream>(mini_pdf()));
+  IncrementalWriter writer(parser);
+
+  EXPECT_THROW(std::ignore = write_text_markup(writer, TextMarkup{}),
+               std::invalid_argument);
+  EXPECT_THROW(std::ignore = write_ink(writer, Ink{}), std::invalid_argument);
+
+  Ink odd;
+  odd.strokes.push_back({1, 2, 3});
+  EXPECT_THROW(std::ignore = write_ink(writer, odd), std::invalid_argument);
+}
+
+TEST(PdfAnnotation, optional_fields_are_omitted_when_empty) {
+  const auto annotation_of = [](const TextMarkup &markup, DocumentParser &out) {
+    return first_page(*out.parse_document())
+        ->annotations.front()
+        ->object.as_dictionary();
+  };
+
+  TextMarkup markup = one_line_highlight();
+  {
+    DocumentParser parser(std::make_unique<std::istringstream>(
+        annotated(mini_pdf(), [&markup](IncrementalWriter &w) {
+          return std::vector{write_text_markup(w, markup)};
+        })));
+    const Dictionary dictionary = annotation_of(markup, parser);
+    EXPECT_FALSE(dictionary.has_key("T"));
+    EXPECT_FALSE(dictionary.has_key("Contents"));
+  }
+
+  markup.common.author = "a reviewer";
+  markup.common.contents = "why (this) matters";
+  {
+    DocumentParser parser(std::make_unique<std::istringstream>(
+        annotated(mini_pdf(), [&markup](IncrementalWriter &w) {
+          return std::vector{write_text_markup(w, markup)};
+        })));
+    const Dictionary dictionary = annotation_of(markup, parser);
+    EXPECT_EQ(dictionary.get("T").as_string(), "a reviewer");
+    // the parenthesis survives the escaping the writer applies
+    EXPECT_EQ(dictionary.get("Contents").as_string(), "why (this) matters");
+  }
+}
+
+// Several annotations on one page share a single page rewrite.
+TEST(PdfAnnotation, appends_several_annotations) {
+  Ink ink;
+  ink.strokes.push_back({10, 10, 20, 20});
+
+  const std::string result =
+      annotated(mini_pdf(), [&ink](IncrementalWriter &w) {
+        return std::vector{write_text_markup(w, one_line_highlight()),
+                           write_ink(w, ink)};
+      });
+
+  DocumentParser parser(std::make_unique<std::istringstream>(result));
+  const std::unique_ptr<Document> document = parser.parse_document();
+  EXPECT_EQ(first_page(*document)->annotations.size(), 2);
+}
+
+// A real file whose pages already carry link annotations: ours are appended,
+// the existing ones stay.
+TEST(PdfAnnotation, appends_to_an_existing_annots_array) {
+  const auto file = std::make_shared<DiskFile>(
+      TestData::test_file_path("odr-public/pdf/style-various-1.pdf"));
+
+  std::size_t before = 0;
+  std::ostringstream out;
+  {
+    DocumentParser parser(file->stream());
+    const std::unique_ptr<Document> document = parser.parse_document();
+    const Page *page = first_page(*document);
+    ASSERT_NE(page, nullptr);
+    before = page->annotations.size();
+    ASSERT_GT(before, 0);
+
+    IncrementalWriter writer(parser);
+    append_page_annotations(writer, *page,
+                            {write_text_markup(writer, one_line_highlight())});
+    writer.write(out);
+  }
+
+  DocumentParser parser(
+      std::make_unique<std::istringstream>(std::move(out).str()));
+  const std::unique_ptr<Document> document = parser.parse_document();
+  const Page *page = first_page(*document);
+  ASSERT_NE(page, nullptr);
+  EXPECT_EQ(page->annotations.size(), before + 1);
+  EXPECT_NE(page->annotations.back()->appearance, nullptr);
+}


### PR DESCRIPTION
🤖 Generated with [Claude Code](https://claude.com/claude-code)

**Phases 2 and 3** of `docs/design/pdf-annotation.md`, on top of the writer from #845. First PR of four; the public API, browser layer and bindings follow.

`pdf/pdf_annotation.{hpp,cpp}`:

- `write_text_markup` — `/Highlight`, `/Underline`, `/StrikeOut`, `/Squiggly`
- `write_ink` — `/Ink`, strokes smoothed Catmull-Rom → the cubic beziers PDF has
- `append_page_annotations` — puts them on a page, rewriting the **`/Annots` array itself** where the page holds it indirectly rather than rewriting the page

Every annotation carries its own appearance stream (decision 3): our renderer draws annotations only from `/AP /N`, and viewers disagree about the ones they synthesize. Only the highlight blends `Multiply` — it is a wash over the text, where the others are marks drawn on top of it (11.6.4.1).

## `/QuadPoints` ordering — settled

The doc has carried this as unverified since the spike, because an annotation with an `/AP` never has its quad points read, so no oracle we had could test the ordering.

Resolved by writing two files with the **same visual rectangle** and **no appearance**, forcing the viewer to synthesize one:

| order | ghostscript renders |
|---|---|
| upper-left, upper-right, lower-left, lower-right | a clean rectangle ✅ |
| the spec's counterclockwise order (12.5.6.10) | a twisted, smeared blob ❌ |

So the Z-order every implementation writes is right and the spec's literal order is wrong, and the comment in the code now says so with evidence behind it. Worth knowing for anyone repeating this: **CoreGraphics synthesizes no appearance at all**, so it is no oracle for this question.

## Verified

Eight assertion tests: round trips for highlight and ink, all four markup subtypes, the blend-mode split, `/Rect` as the union of quads, the ink box grown by the stroke width, `/T` and `/Contents` omitted when empty (and a `(` in `/Contents` surviving escaping), several annotations sharing one page rewrite, and appending to `style-various-1.pdf`'s existing `/Annots`.

End to end on a real file with all five kinds at once: `qpdf --check` clean, CoreGraphics paints every one with the text showing through the highlight, and **odr's own renderer** emits the highlight as `<path fill="rgb(255,230,51)" style="mix-blend-mode:multiply">` and the ink as `C` beziers — the self-verifying round trip the design predicted.

18 annotation/writer tests pass; `-Werror` clean; clang-tidy clean.

No consumer-visible change yet — the public API is the next PR — so no changelog entry.