### PR TITLE
fix(android): name the locale the xref offsets are formatted in

### DIFF
--- a/jni/testfixtures/app/opendocument/core/TestFiles.java
+++ b/jni/testfixtures/app/opendocument/core/TestFiles.java
@@ -8,6 +8,7 @@ import java.nio.file.Path;
 import java.nio.file.StandardCopyOption;
 import java.util.Arrays;
 import java.util.List;
+import java.util.Locale;
 
 /**
  * The suite's input files.
@@ -86,7 +87,7 @@ final class TestFiles {
     int start = out.length();
     out.append("xref\n0 ").append(objects.size() + 1).append("\n0000000000 65535 f \n");
     for (int offset : offsets) {
-      out.append(String.format("%010d 00000 n \n", offset));
+      out.append(String.format(Locale.ROOT, "%010d 00000 n \n", offset));
     }
     out.append("trailer\n<< /Size ").append(objects.size() + 1).append(" /Root 1 0 R >>\n");
     out.append("startxref\n").append(start).append("\n%%EOF\n");


### PR DESCRIPTION
🤖 Generated with [Claude Code](https://claude.com/claude-code)

The `aar` job has failed on main since #850:

```
jni/testfixtures/app/opendocument/core/TestFiles.java:89: Error: Implicitly
using the default locale is a common source of bugs: Use String.format(Locale,
...) instead [DefaultLocale]
> Task :lintDebug FAILED
```

The fixture formats a pdf xref entry, whose offsets are ascii digits in every
locale, so `Locale.ROOT` is both what lint wants and what the format means —
the same call `Color.toString` already makes.

Nothing else in `jni/java`, `jni/testfixtures` or `android/src` uses a
locale-sensitive format.
