### PR TITLE
feat(html): an editing mode for a sheet, and the locks it refuses on

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,19 @@ The release run heads these entries with the version and opens a fresh
 
 ## Unreleased
 
+- The rendered sheet exposes `odr.editing`: `enable()` / `disable()` turn the
+  mode on, `lockAt()` answers for a cell, and a refusal reaches the host as
+  `odr.onEditRefused` / `odr.onEditModeChange`, whose codes share the space
+  `odr.onError` numbers. Beside it `odr.sheet` addresses the view the way an op
+  does — `cellAt`, `positionOf`, `pinned` and `pin`, by position rather than by
+  where a cell happens to sit after a merge or a sort.
+
+- A sheet states in its markup what the page cannot work out: the sheet an op
+  names (`data-odr-sheet`), whether the document can be edited at all
+  (`data-odr-editable`), and the lock on a cell that cannot be —
+  `data-odr-lock` of `formula`, `rich` or `shapes`, with an `odr-locked` class
+  beside it.
+
 - A sheet rendered with `HtmlConfig::editable` carries no `contenteditable`
   and no `data-odr-path`: its editing is an overlay, so the markup states
   none. A cell's runs fold into the `td` as they do read-only.

--- a/docs/design/spreadsheet-editing.md
+++ b/docs/design/spreadsheet-editing.md
@@ -255,6 +255,44 @@ frequent, it carries a position, and a host wants it on a snackbar while a real
 error goes to a dialog or a log. Sharing the code table keeps one lookup for
 both.
 
+### 8. The sheet script owns the position map, and publishes it as `odr.sheet`
+
+The editor is a second script on the page, and the two things it needs first —
+which cell a position names, and what is pinned — belong to the first, which
+already owns the pin, the raise and the sort:
+
+```js
+odr.sheet.cellAt(column, row); // the `td`, null past the sheet's extent
+odr.sheet.positionOf(cell);    // {column, row}, null for a header
+odr.sheet.pinned();            // {column, row, cell}, null for none
+odr.sheet.pin(position);       // null clears; false where there is no cell
+```
+
+**Why not a copy in the editor:** the map is not a walk over `colspan`. A row
+is named by its `<th>` label, because sorting moves the `<tr>`s away from
+position order; a `rowspan` from an earlier row leaves the positions it covers
+unwritten, so a colspan-only walk misreads every cell after them; and it is
+built once, which means the script that reorders rows is the one that has to
+know. Two copies would also be two owners of the pin classes and the raise
+wrapper — an editor whose overlay is open while the other script lowers the
+cell underneath it.
+
+**Why not one script instead:** the read-only view would carry the editor it
+never runs, and a raw string literal caps at 16380 bytes on msvc
+(`fits_a_literal`), which the two together would reach during step 1.
+
+**The coordinates are the ones an op names** (decision 1), never a DOM index.
+The wash paints through `nth-child`, so the ruler's index stays private to the
+script, and a merged sheet still gets no wash and no sort control. A position a
+merge covers answers with the cell covering it — the one the file states and an
+op names.
+
+**The cost is a public surface**, which a host keeps once it ships. It is a
+small one, and a host gets scroll-to-cell and "what is selected" out of it. What
+step 1.3 needs to reflow a row after a commit (`visibleRight`, `cutOff`) sits in
+the same closure and joins `odr.sheet` when it is written, rather than being
+reached around.
+
 ## Staging
 
 Each step ships on its own. "Both" means `.ods` and `.xlsx`.
@@ -312,11 +350,11 @@ Each step ships on its own. "Both" means `.ods` and `.xlsx`.
 
 1. `odr.editing` mode: enable/disable, lock classes and the document attribute
    from `translate_sheet`, and the three `odr.on*` callbacks with their code
-   table (decision 7).
+   table (decision 7). `spreadsheet_js` publishes `odr.sheet` in the same step
+   (decision 8) — the position map the mode reads a lock through.
 2. Overlay editor: double-click / Enter / typing opens it over the cell; Enter,
-   Tab and blur commit; Escape cancels; arrow keys move the pin. Position
-   comes from the row `<th>` and a per-row colspan/rowspan walk, cached — never
-   `cellIndex`, which merged cells and sorting both break.
+   Tab and blur commit; Escape cancels; arrow keys move the pin, through
+   `odr.sheet.pin` rather than a pin of its own.
 3. Commit: parse per decision 4, record the op with its inverse, patch the
    cell — text, `odr-value-type-float` for alignment, keep any shapes in A1 —
    and **reflow the row**: the spill and clip `translate_sheet` measured for

--- a/src/odr/internal/html/common.hpp
+++ b/src/odr/internal/html/common.hpp
@@ -51,6 +51,13 @@ struct WritingState {
     m_editable_markup = editable;
   }
 
+  /// Whether the document can be edited at all, which a sheet states so its
+  /// editor can refuse before the user clicks anything.
+  [[nodiscard]] bool document_editable() const { return m_document_editable; }
+  void set_document_editable(const bool editable) {
+    m_document_editable = editable;
+  }
+
 private:
   HtmlWriter *m_out;
   const HtmlConfig *m_config;
@@ -59,6 +66,7 @@ private:
   StyleRegistry *m_styles;
   TextDirection m_direction{TextDirection::left_to_right};
   bool m_editable_markup{true};
+  bool m_document_editable{false};
 };
 
 /// Writes the viewport meta tag. Precedence: `config.viewport_content` (raw,

--- a/src/odr/internal/html/document.cpp
+++ b/src/odr/internal/html/document.cpp
@@ -264,6 +264,7 @@ render(const Document &document, const HtmlConfig &config, const Logger &logger,
   if (document.document_type() != DocumentType::spreadsheet) {
     WritingState state(out, config, resources, logger);
     state.set_direction(document_direction(document));
+    state.set_document_editable(document.is_editable());
     write_head(document, state, name, content_pixels);
     body(state);
     out.write_end();
@@ -275,6 +276,7 @@ render(const Document &document, const HtmlConfig &config, const Logger &logger,
                        StyleRegistry::Digits::base36);
   WritingState head_state(out, config, resources, logger, &styles);
   head_state.set_direction(document_direction(document));
+  head_state.set_document_editable(document.is_editable());
 
   util::stream::DeferredBuffer buffer(
       out.out(), static_cast<std::size_t>(config.spreadsheet_style_buffer),
@@ -287,6 +289,7 @@ render(const Document &document, const HtmlConfig &config, const Logger &logger,
     HtmlWriter body_out(deferred, config);
     WritingState state(body_out, config, resources, logger, &styles);
     state.set_direction(head_state.direction());
+    state.set_document_editable(head_state.document_editable());
     body(state);
   }
   buffer.release();

--- a/src/odr/internal/html/document_element.cpp
+++ b/src/odr/internal/html/document_element.cpp
@@ -288,6 +288,49 @@ bool is_blank(const SheetCell &cell) {
   return true;
 }
 
+/// Empty, or one text run at most - what a write can replace. odf wraps a
+/// cell's text in a `text:p`, ooxml hangs it under the `c` directly, so a
+/// single paragraph is unwrapped once.
+bool holds_one_run(const ElementRange &children, const bool unwrap = true) {
+  ElementIterator child = children.begin();
+  if (child == children.end()) {
+    return true;
+  }
+  const Element only = *child;
+  if (++child != children.end()) {
+    return false;
+  }
+  if (only.type() == ElementType::text) {
+    return true;
+  }
+  return unwrap && only.type() == ElementType::paragraph &&
+         holds_one_run(only.children(), false);
+}
+
+/// Its place among the document's sheets, which is how an op names one.
+std::uint32_t sheet_ordinal(const Sheet &sheet) {
+  std::uint32_t ordinal = 0;
+  for (Element previous = sheet.previous_sibling(); previous;
+       previous = previous.previous_sibling()) {
+    ++ordinal;
+  }
+  return ordinal;
+}
+
+/// Why a cell cannot be edited, or null where it can be. The names the page
+/// reports to its host; `spreadsheet-editing.md` decision 3 lists them.
+const char *cell_lock(const SheetCell &cell, const bool anchors_shapes) {
+  if (cell.value().has_formula()) {
+    return "formula";
+  }
+  // its drawings are what the cell is, and an overlay would cover them
+  if (anchors_shapes) {
+    return "shapes";
+  }
+  // a write replaces the cell's one run, so anything richer would be lost
+  return holds_one_run(cell.children()) ? nullptr : "rich";
+}
+
 /// A shape or picture anchored in a cell reaches past it by design.
 bool holds_only_text(const SheetCell &cell) {
   for (const Element child : cell.children()) {
@@ -429,17 +472,24 @@ void html::translate_sheet(const Sheet &sheet, const WritingState &state) {
   const std::optional<double> print_fit = sheet_print_fit(sheet, end_column);
 
   state.out().write_element_begin(
-      "table", HtmlElementOptions()
-                   .set_class("odr-sheet")
-                   .set_style([&]() -> std::optional<HtmlWritable> {
-                     if (!print_fit.has_value()) {
-                       return std::nullopt;
-                     }
-                     // `Measure` renders no exponent form
-                     return "--odr-print-fit:" +
-                            Measure(*print_fit, DynamicUnit()).to_string() +
-                            ";";
-                   }()));
+      "table",
+      HtmlElementOptions()
+          .set_class("odr-sheet")
+          .set_attributes([&](const HtmlAttributeWriterCallback &clb) {
+            // what the editor asks before the user clicks anything
+            clb("data-odr-editable",
+                state.document_editable() ? "true" : "readOnly");
+            // every op names its sheet, and a view holds only one
+            clb("data-odr-sheet", std::to_string(sheet_ordinal(sheet)));
+          })
+          .set_style([&]() -> std::optional<HtmlWritable> {
+            if (!print_fit.has_value()) {
+              return std::nullopt;
+            }
+            // `Measure` renders no exponent form
+            return "--odr-print-fit:" +
+                   Measure(*print_fit, DynamicUnit()).to_string() + ";";
+          }()));
 
   state.out().write_element_begin("col",
                                   HtmlElementOptions()
@@ -608,6 +658,8 @@ void html::translate_sheet(const Sheet &sheet, const WritingState &state) {
       const std::optional<FoldedCell> folded = fold_cell(
           cell, sheet_state, wraps, anchors_shapes, table_row_style.height);
 
+      const char *lock = cell_lock(cell, anchors_shapes);
+
       state.out().write_element_begin(
           "td",
           HtmlElementOptions()
@@ -619,6 +671,9 @@ void html::translate_sheet(const Sheet &sheet, const WritingState &state) {
                 if (cell_span.rows > 1) {
                   clb("rowspan", std::to_string(cell_span.rows));
                 }
+                if (lock != nullptr) {
+                  clb("data-odr-lock", lock);
+                }
               })
               .set_style(
                   translate_table_cell_style(cell_style) +
@@ -628,10 +683,16 @@ void html::translate_sheet(const Sheet &sheet, const WritingState &state) {
                       (folded.has_value() ? folded->style : std::string()),
                   state.styles())
               .set_class([&]() -> std::optional<HtmlWritable> {
-                if (cell_value_type == ValueType::float_number) {
+                const bool number = cell_value_type == ValueType::float_number;
+                if (number && lock != nullptr) {
+                  return "odr-value-type-float odr-locked";
+                }
+                if (number) {
                   return "odr-value-type-float";
                 }
-                return std::nullopt;
+                return lock != nullptr
+                           ? std::optional<HtmlWritable>("odr-locked")
+                           : std::nullopt;
               }()));
       if (column_index == 0 && row_index == 0) {
         for (const Element shape : sheet.shapes()) {

--- a/src/odr/internal/html/frontend.cpp
+++ b/src/odr/internal/html/frontend.cpp
@@ -1527,6 +1527,8 @@ constexpr std::string_view spreadsheet_js = R"js(
 
   var merged = table.querySelector("td[colspan],td[rowspan]") !== null;
 
+  var odr = (window.odr = window.odr || {});
+
   var style = document.createElement("style");
   document.head.appendChild(style);
 
@@ -1562,8 +1564,98 @@ constexpr std::string_view spreadsheet_js = R"js(
       columnRule(pinnedColumn, "var(--odr-sheet-wash-ruler)", "thead ");
   }
 
-  function columnOf(cell) {
+  // What the wash paints: the cell's place among the ones written beside it,
+  // gutter included, which is what `nth-child` counts. Not a position - a
+  // merge writes nothing for a covered one, and gets no wash either.
+  function rulerColumn(cell) {
     return cell !== null && !merged ? cell.cellIndex : -1;
+  }
+
+  // The gutter's label, which names the row wherever a sort has put it.
+  function rowOf(tr) {
+    return Number(tr.cells[0].textContent) - 1;
+  }
+
+  var index = null;
+
+  // Whether a cell above still reaches into @p row.
+  function holds(above, row) {
+    return above !== undefined && above.last >= row;
+  }
+
+  // A row by its label and, where the sheet merges, its cells by position.
+  // Walked once: a merged sheet is offered no sort control, so the rows are
+  // still in the file's order here and one pass can carry the rowspans down.
+  function build() {
+    var index = { rows: new Map(), positions: new Map() };
+    var covered = [];
+    var body = table.tBodies[0];
+    for (var i = 0; i < body.rows.length; ++i) {
+      var tr = body.rows[i];
+      var row = rowOf(tr);
+      var line = [];
+      index.rows.set(row, { tr: tr, cells: line });
+      if (!merged) {
+        continue;
+      }
+      var column = 0;
+      for (var j = 1; j < tr.cells.length; ++j) {
+        var td = tr.cells[j];
+        while (holds(covered[column], row)) {
+          line[column] = covered[column].cell;
+          ++column;
+        }
+        var columns = Number(td.getAttribute("colspan") || 1);
+        var last = row + Number(td.getAttribute("rowspan") || 1) - 1;
+        for (var k = 0; k < columns; ++k) {
+          line[column + k] = td;
+          covered[column + k] = { last: last, cell: td };
+        }
+        index.positions.set(td, { column: column, row: row });
+        column += columns;
+      }
+      // A rowspan reaching past the row's last cell covers the rest of it.
+      for (; column < covered.length; ++column) {
+        if (holds(covered[column], row)) {
+          line[column] = covered[column].cell;
+        }
+      }
+    }
+    return index;
+  }
+
+  function indexed() {
+    if (index === null) {
+      index = build();
+    }
+    return index;
+  }
+
+  // The `td` at a position, or null past the sheet's extent. A position a
+  // merge covers answers with the cell covering it, which is the one the file
+  // states and an op names.
+  function cellAt(column, row) {
+    var entry = indexed().rows.get(row);
+    if (entry === undefined || column < 0) {
+      return null;
+    }
+    var cell = merged ? entry.cells[column] : entry.tr.cells[column + 1];
+    return cell === undefined ? null : cell;
+  }
+
+  // Where a `td` sits, the way an op names it. Null for anything else - a
+  // header, a cell of another table.
+  function positionOf(cell) {
+    if (cell === null || cell.tagName !== "TD") {
+      return null;
+    }
+    if (merged) {
+      var position = indexed().positions.get(cell);
+      return position === undefined
+        ? null
+        : { column: position.column, row: position.row };
+    }
+    return { column: cell.cellIndex - 1, row: rowOf(cell.parentElement) };
   }
 
   var raisedCell = null;
@@ -1671,8 +1763,51 @@ constexpr std::string_view spreadsheet_js = R"js(
     paint();
   }
 
+  // What is pinned: a cell, or a whole column or row where a header is, the
+  // axis that header does not name being null. Null where nothing is pinned.
+  function pinnedPosition() {
+    if (pinnedCell === null) {
+      return null;
+    }
+    var position = positionOf(pinnedCell);
+    if (position !== null) {
+      return { column: position.column, row: position.row, cell: pinnedCell };
+    }
+    return {
+      column: pinnedCell.classList.contains("odr-sheet-column-header")
+        ? pinnedCell.cellIndex - 1
+        : null,
+      row: pinnedRow === null ? null : rowOf(pinnedRow),
+      cell: pinnedCell,
+    };
+  }
+
+  // Pins the cell at a position, as a click on it does; null clears the pin.
+  // False where the sheet holds no such cell.
+  function pinAt(position) {
+    if (position === null) {
+      pin(-1, null, null);
+      return true;
+    }
+    var cell = cellAt(position.column, position.row);
+    if (cell === null) {
+      return false;
+    }
+    pin(rulerColumn(cell), cell.parentElement, cell);
+    return true;
+  }
+
+  // What the script beside this one, and a host, ask of the sheet: positions
+  // the way an op names them, and the pin. `spreadsheet-editing.md` decision 8.
+  odr.sheet = {
+    cellAt: cellAt,
+    positionOf: positionOf,
+    pinned: pinnedPosition,
+    pin: pinAt,
+  };
+
   table.addEventListener("mouseover", function (event) {
-    var column = columnOf(event.target.closest("td,th"));
+    var column = rulerColumn(event.target.closest("td,th"));
     if (column !== hovered) {
       hovered = column;
       paint();
@@ -1702,13 +1837,13 @@ constexpr std::string_view spreadsheet_js = R"js(
     }
 
     if (cell.classList.contains("odr-sheet-column-header")) {
-      pin(columnOf(cell), null, cell);
+      pin(rulerColumn(cell), null, cell);
     } else if (cell.classList.contains("odr-sheet-row-header")) {
       pin(-1, cell.parentElement, cell);
     } else if (cell.classList.contains("odr-sheet-corner")) {
       pin(-1, null, null);
     } else {
-      pin(columnOf(cell), cell.parentElement, cell);
+      pin(rulerColumn(cell), cell.parentElement, cell);
     }
   });
 
@@ -1851,6 +1986,130 @@ constexpr std::string_view spreadsheet_js = R"js(
       true
     );
   }
+})();
+)js";
+
+/// `odr.editing`: the mode, and the refusals the page reports to its host.
+/// A sheet's editing is an overlay, so the markup states only what the page
+/// cannot work out - the document's editability and a locked cell's reason.
+constexpr std::string_view sheet_editing_js = R"js(
+(function () {
+  "use strict";
+
+  var table = document.querySelector(".odr-sheet");
+  if (table === null) {
+    return;
+  }
+
+  var odr = (window.odr = window.odr || {});
+
+  var sheet = Number(table.getAttribute("data-odr-sheet") || 0);
+  var editable = table.getAttribute("data-odr-editable") === "true";
+  var editing = false;
+  var lastRefusal = null;
+
+  // One space with `odr.onError`'s codes, appended and never renumbered - 1 is
+  // `errorIllegalEditNewLine`. The host maps the code to its own wording; the
+  // message is for a developer who wires nothing.
+  var refusals = {
+    formula: { code: 2, message: "cell holds a formula" },
+    rich: { code: 3, message: "cell holds more than one plain run" },
+    shapes: { code: 4, message: "cell holds a drawing" },
+    readOnly: { code: 5, message: "document cannot be edited" },
+  };
+
+  odr.onEditRefused = function (event) {
+    console.warn("edit refused " + event.code + ": " + event.message);
+  };
+  odr.onEditModeChange = function (event) {
+    console.log("editing " + (event.editing ? "on" : "off"));
+  };
+  odr.onEditChange = function () {};
+
+  function fire(name, event) {
+    if (typeof odr[name] === "function") {
+      odr[name](event);
+    }
+  }
+
+  /// Four taps on a locked cell are one snackbar: the same refusal within two
+  /// seconds of the last is the page's to drop.
+  function refuse(reason, column, row) {
+    var refusal = refusals[reason] || refusals.readOnly;
+    var key = reason + ":" + column + ":" + row;
+    var now = Date.now();
+    if (lastRefusal && lastRefusal.key === key && now - lastRefusal.at < 2000) {
+      return;
+    }
+    lastRefusal = { key: key, at: now };
+    fire("onEditRefused", {
+      sheet: sheet,
+      column: column,
+      row: row,
+      reason: reason,
+      code: refusal.code,
+      message: refusal.message,
+    });
+  }
+
+  function modeChange(reason) {
+    fire("onEditModeChange", {
+      editing: editing,
+      editable: editable,
+      reason: reason || null,
+      code: reason ? refusals[reason].code : 0,
+      message: reason ? refusals[reason].message : "",
+    });
+  }
+
+  odr.editing = {
+    /// Answers whether the mode is on. A document that cannot be edited
+    /// refuses and says why, so a host can grey its button before a click.
+    enable: function () {
+      if (!editable) {
+        modeChange("readOnly");
+        return false;
+      }
+      if (!editing) {
+        editing = true;
+        table.classList.add("odr-editing");
+        modeChange(null);
+      }
+      return true;
+    },
+    disable: function () {
+      if (editing) {
+        editing = false;
+        table.classList.remove("odr-editing");
+        modeChange(null);
+      }
+    },
+    isEnabled: function () {
+      return editing;
+    },
+    /// Whether `enable` would succeed.
+    isEditable: function () {
+      return editable;
+    },
+    /// The lock on the cell at (@p column, @p row), or null where it has none.
+    lockAt: function (column, row) {
+      var cell = odr.sheet.cellAt(column, row);
+      return cell === null ? null : cell.getAttribute("data-odr-lock");
+    },
+  };
+
+  odr.editing.refuseAt = function (column, row) {
+    if (!editable) {
+      refuse("readOnly", column, row);
+      return true;
+    }
+    var lock = odr.editing.lockAt(column, row);
+    if (lock !== null) {
+      refuse(lock, column, row);
+      return true;
+    }
+    return false;
+  };
 })();
 )js";
 
@@ -2266,6 +2525,8 @@ constexpr Asset search_js_asset{HtmlResourceType::js, "text/javascript",
                                 "search.js", search_js};
 constexpr Asset spreadsheet_js_asset{HtmlResourceType::js, "text/javascript",
                                      "spreadsheet.js", spreadsheet_js};
+constexpr Asset sheet_editing_js_asset{HtmlResourceType::js, "text/javascript",
+                                       "sheet-editing.js", sheet_editing_js};
 constexpr Asset text_js_asset{HtmlResourceType::js, "text/javascript",
                               "text.js", text_js};
 constexpr Asset viewport_js_asset{HtmlResourceType::js, "text/javascript",
@@ -2425,6 +2686,7 @@ void html::write_search_script(const WritingState &state) {
 
 void html::write_spreadsheet_script(const WritingState &state) {
   write_script(spreadsheet_js_asset, state);
+  write_script(sheet_editing_js_asset, state);
 }
 
 void html::write_text_script(const WritingState &state) {

--- a/test/browser/sheet/.gitignore
+++ b/test/browser/sheet/.gitignore
@@ -1,3 +1,4 @@
 document.css
 spreadsheet.css
 spreadsheet.js
+sheet-editing.js

--- a/test/browser/sheet/README.md
+++ b/test/browser/sheet/README.md
@@ -1,20 +1,34 @@
 # sheet checks
 
-What the emitted sheet script does with a cell too narrow for its text can only
-be seen in a browser, so these are run by hand rather than by `odr_test`.
+What the emitted sheet scripts do with a cell too narrow for its text, and with
+a position no `td` stands at, can only be seen in a browser, so these are run by
+hand rather than by `odr_test`.
 
 ```bash
-test/browser/sheet/serve         # extracts the css and the script, serves on :8732
+test/browser/sheet/serve         # extracts the css and the scripts, serves on :8732
 open http://localhost:8732/tests.html
+open http://localhost:8732/positions.html
+open http://localhost:8732/sorting.html
 ```
 
-`serve` lifts `document_css`, `spreadsheet_css` and `spreadsheet_js` out of
-`src/odr/internal/html/frontend.cpp`, so what runs is what ships. The markup is
-what `translate_sheet` writes, cut down to the shapes the script has to tell
-apart: a cell that spills over an empty neighbour, one that is cut at its edge,
-one that keeps the block a stated row height needs, and one that writes its
-string straight into the `td`.
+`serve` lifts `document_css`, `spreadsheet_css`, `spreadsheet_js` and
+`sheet_editing_js` out of `src/odr/internal/html/frontend.cpp`, so what runs is
+what ships. Each page prints its own report and heads it with a count; a page
+holds one `.odr-sheet`, because the script binds to the first one it finds.
 
-The point of the checks is that raising a cell shows all of it **without moving
-anything**: the box goes out of flow, so no row changes height, and a click
-inside it is for the text rather than for the cell.
+- **`tests.html`** — raising a cell whose text is cut off. The markup is what
+  `translate_sheet` writes, cut down to the shapes the script has to tell apart:
+  a cell that spills over an empty neighbour, one that is cut at its edge, one
+  that keeps the block a stated row height needs, and one that writes its string
+  straight into the `td`. The point is that raising shows all of a cell
+  **without moving anything**: the box goes out of flow, so no row changes
+  height, and a click inside it is for the text rather than for the cell.
+- **`positions.html`** — `odr.sheet` over a merged sheet. `translate_sheet`
+  writes no `td` for a position a span covers, so the fixture has a `colspan`, a
+  `rowspan`, and a `rowspan` reaching past the last cell of the row below it:
+  the three shapes a walk over `colspan` alone reads wrong. It also checks that
+  `odr.editing` finds a lock through the same map.
+- **`sorting.html`** — the same questions after the sort control has moved every
+  row. Nothing here is merged, because a merged sheet is offered no sort
+  control; a row is found by the label it carries, so where it now sits does not
+  matter.

--- a/test/browser/sheet/checks.js
+++ b/test/browser/sheet/checks.js
@@ -1,0 +1,40 @@
+// The report the check pages print, and the summary line to read at a glance.
+(function () {
+  "use strict";
+
+  var style = document.createElement("style");
+  style.textContent =
+    "#report{font:13px/1.6 monospace;margin:16px}" +
+    "#report .pass::before{content:'PASS ';color:#2a7}" +
+    "#report .fail::before{content:'FAIL ';color:#c33}" +
+    "#summary{font:600 13px/1.6 monospace;margin:16px 16px 0}";
+  document.head.appendChild(style);
+
+  var report = document.getElementById("report");
+  var failed = 0;
+  var total = 0;
+
+  window.check = function (name, condition) {
+    var line = document.createElement("div");
+    line.className = condition ? "pass" : "fail";
+    line.textContent = name;
+    report.appendChild(line);
+    total += 1;
+    if (!condition) {
+      failed += 1;
+    }
+  };
+
+  window.click = function (element) {
+    element.dispatchEvent(new MouseEvent("click", { bubbles: true }));
+    document.body.offsetHeight;
+  };
+
+  window.addEventListener("load", function () {
+    var summary = document.createElement("div");
+    summary.id = "summary";
+    summary.textContent = total + " checks, " + failed + " failed";
+    summary.style.color = failed === 0 ? "#2a7" : "#c33";
+    report.parentNode.insertBefore(summary, report);
+  });
+})();

--- a/test/browser/sheet/positions.html
+++ b/test/browser/sheet/positions.html
@@ -1,0 +1,179 @@
+<!doctype html>
+<html>
+  <head>
+    <meta charset="utf-8" />
+    <title>sheet position checks</title>
+    <link rel="stylesheet" href="document.css" />
+    <link rel="stylesheet" href="spreadsheet.css" />
+  </head>
+  <body class="odr-body odr-gridlines-soft">
+    <!-- A merged sheet as `translate_sheet` writes one: no `td` stands where a
+         span covers a position. B1 spans two columns, A2 two rows, and D4 two
+         rows past the last cell row 5 writes. C2 carries a lock. -->
+    <table class="odr-sheet" data-odr-editable="true" data-odr-sheet="0">
+      <col class="odr-sheet-gutter" />
+      <col />
+      <col />
+      <col />
+      <col />
+      <thead>
+        <tr>
+          <th class="odr-sheet-corner" style="width:calc(1ch + 14px)"></th>
+          <th class="odr-sheet-column-header">A</th>
+          <th class="odr-sheet-column-header">B</th>
+          <th class="odr-sheet-column-header">C</th>
+          <th class="odr-sheet-column-header">D</th>
+        </tr>
+      </thead>
+      <tbody>
+        <tr>
+          <th class="odr-sheet-row-header">1</th>
+          <td>a0</td>
+          <td colspan="2">b0</td>
+          <td>d0</td>
+        </tr>
+        <tr>
+          <th class="odr-sheet-row-header">2</th>
+          <td rowspan="2">a1</td>
+          <td>b1</td>
+          <td class="odr-locked" data-odr-lock="formula">c1</td>
+          <td>d1</td>
+        </tr>
+        <tr>
+          <th class="odr-sheet-row-header">3</th>
+          <td>b2</td>
+          <td>c2</td>
+          <td>d2</td>
+        </tr>
+        <tr>
+          <th class="odr-sheet-row-header">4</th>
+          <td>a3</td>
+          <td>b3</td>
+          <td>c3</td>
+          <td rowspan="2">d3</td>
+        </tr>
+        <tr>
+          <th class="odr-sheet-row-header">5</th>
+          <td>a4</td>
+          <td>b4</td>
+          <td>c4</td>
+        </tr>
+      </tbody>
+    </table>
+
+    <div id="report"></div>
+    <script src="spreadsheet.js"></script>
+    <script src="sheet-editing.js"></script>
+    <script src="checks.js"></script>
+    <script>
+      // What the sheet holds at every position, the covered ones answering
+      // with the cell that covers them.
+      var grid = [
+        ["a0", "b0", "b0", "d0"],
+        ["a1", "b1", "c1", "d1"],
+        ["a1", "b2", "c2", "d2"],
+        ["a3", "b3", "c3", "d3"],
+        ["a4", "b4", "c4", "d3"],
+      ];
+      var wrong = [];
+      for (var row = 0; row < grid.length; ++row) {
+        for (var column = 0; column < 4; ++column) {
+          var cell = odr.sheet.cellAt(column, row);
+          var text = cell === null ? null : cell.textContent;
+          if (text !== grid[row][column]) {
+            wrong.push(column + "," + row + "=" + text);
+          }
+        }
+      }
+      check("every position answers with its cell" + (wrong.length ? ": " + wrong : ""), wrong.length === 0);
+      check(
+        "a colspan-only walk would have missed them",
+        odr.sheet.cellAt(1, 2).textContent === "b2" &&
+          odr.sheet.cellAt(0, 2).textContent === "a1"
+      );
+      check(
+        "nothing stands past the sheet",
+        odr.sheet.cellAt(4, 0) === null &&
+          odr.sheet.cellAt(0, 5) === null &&
+          odr.sheet.cellAt(-1, 0) === null
+      );
+
+      var anchors = [];
+      [].forEach.call(document.querySelectorAll(".odr-sheet tbody td"), function (td) {
+        var at = odr.sheet.positionOf(td);
+        if (odr.sheet.cellAt(at.column, at.row) !== td) {
+          anchors.push(td.textContent);
+        }
+      });
+      check("a cell names the position it was found at" + (anchors.length ? ": " + anchors : ""), anchors.length === 0);
+      check(
+        "a header names none",
+        odr.sheet.positionOf(document.querySelector(".odr-sheet-row-header")) === null &&
+          odr.sheet.positionOf(document.querySelector(".odr-sheet-column-header")) === null
+      );
+
+      var mine = odr.sheet.positionOf(odr.sheet.cellAt(1, 0));
+      mine.column = 99;
+      check(
+        "what it hands out is a copy",
+        odr.sheet.positionOf(odr.sheet.cellAt(1, 0)).column === 1
+      );
+
+      odr.sheet.pin({ column: 2, row: 2 });
+      var pinned = odr.sheet.pinned();
+      check(
+        "a pin by position lands on the cell",
+        pinned !== null && pinned.cell.textContent === "c2" &&
+          pinned.column === 2 && pinned.row === 2
+      );
+      check(
+        "and paints it",
+        pinned.cell.classList.contains("odr-sheet-pinned-cell") &&
+          document.querySelectorAll(".odr-sheet-pinned-cell").length === 1
+      );
+
+      odr.sheet.pin({ column: 0, row: 2 });
+      var covered = odr.sheet.pinned();
+      check(
+        "pinning a covered position pins the cell covering it",
+        covered.cell.textContent === "a1" && covered.row === 1
+      );
+      check("a position the sheet has not is refused", odr.sheet.pin({ column: 9, row: 9 }) === false);
+      check("and leaves the pin where it was", odr.sheet.pinned().cell.textContent === "a1");
+
+      odr.sheet.pin(null);
+      check(
+        "null clears it",
+        odr.sheet.pinned() === null &&
+          document.querySelector(".odr-sheet-pinned-cell") === null
+      );
+
+      click(document.querySelectorAll(".odr-sheet-column-header")[2]);
+      var column = odr.sheet.pinned();
+      check(
+        "a column header names its column and no row",
+        column.column === 2 && column.row === null
+      );
+      click(document.querySelectorAll(".odr-sheet-row-header")[2]);
+      var row = odr.sheet.pinned();
+      check(
+        "a row header names its row and no column",
+        row.column === null && row.row === 2
+      );
+      odr.sheet.pin(null);
+
+      // The editing mode reads the same map.
+      var refusals = [];
+      odr.onEditRefused = function (event) {
+        refusals.push(event.reason + " " + event.code + " at " + event.column + "," + event.row);
+      };
+      check("a locked cell is found through it", odr.editing.lockAt(2, 1) === "formula");
+      check("a plain one carries no lock", odr.editing.lockAt(1, 2) === null);
+      check("editing a locked cell is refused", odr.editing.refuseAt(2, 1) === true);
+      check("a plain cell is not", odr.editing.refuseAt(1, 2) === false);
+      check("the refusal reached the host", refusals.length === 1 && refusals[0] === "formula 2 at 2,1");
+      odr.editing.refuseAt(2, 1);
+      check("and the same one again is dropped", refusals.length === 1);
+    </script>
+  </body>
+</html>

--- a/test/browser/sheet/serve
+++ b/test/browser/sheet/serve
@@ -14,7 +14,10 @@ PARTS = {
     "document.css": 'constexpr std::string_view document_css = R"css(',
     "spreadsheet.css": 'constexpr std::string_view spreadsheet_css = R"css(',
     "spreadsheet.js": 'constexpr std::string_view spreadsheet_js = R"js(',
+    "sheet-editing.js": 'constexpr std::string_view sheet_editing_js = R"js(',
 }
+
+PAGES = ("tests.html", "positions.html", "sorting.html")
 
 
 def extract(source: str, begin: str) -> str:
@@ -34,7 +37,8 @@ def main() -> None:
     )
     socketserver.TCPServer.allow_reuse_address = True
     with socketserver.TCPServer(("127.0.0.1", PORT), handler) as server:
-        print(f"http://localhost:{PORT}/tests.html")
+        for page in PAGES:
+            print(f"http://localhost:{PORT}/{page}")
         server.serve_forever()
 
 

--- a/test/browser/sheet/sorting.html
+++ b/test/browser/sheet/sorting.html
@@ -1,0 +1,118 @@
+<!doctype html>
+<html>
+  <head>
+    <meta charset="utf-8" />
+    <title>sheet position checks under a sort</title>
+    <link rel="stylesheet" href="document.css" />
+    <link rel="stylesheet" href="spreadsheet.css" />
+  </head>
+  <body class="odr-body odr-gridlines-soft">
+    <!-- A sheet with no merge, which is the only kind offered a sort control.
+         Column B is ordered so that sorting it moves every row. -->
+    <table class="odr-sheet" data-odr-editable="true" data-odr-sheet="0">
+      <col class="odr-sheet-gutter" />
+      <col />
+      <col />
+      <col />
+      <thead>
+        <tr>
+          <th class="odr-sheet-corner" style="width:calc(1ch + 14px)"></th>
+          <th class="odr-sheet-column-header">A</th>
+          <th class="odr-sheet-column-header">B</th>
+          <th class="odr-sheet-column-header">C</th>
+        </tr>
+      </thead>
+      <tbody>
+        <tr>
+          <th class="odr-sheet-row-header">1</th>
+          <td>r0</td>
+          <td class="odr-value-type-float">0</td>
+          <td>x0</td>
+        </tr>
+        <tr>
+          <th class="odr-sheet-row-header">2</th>
+          <td>r1</td>
+          <td class="odr-value-type-float">2</td>
+          <td>x1</td>
+        </tr>
+        <tr>
+          <th class="odr-sheet-row-header">3</th>
+          <td>r2</td>
+          <td class="odr-value-type-float">4</td>
+          <td>x2</td>
+        </tr>
+        <tr>
+          <th class="odr-sheet-row-header">4</th>
+          <td>r3</td>
+          <td class="odr-value-type-float">1</td>
+          <td>x3</td>
+        </tr>
+        <tr>
+          <th class="odr-sheet-row-header">5</th>
+          <td>r4</td>
+          <td class="odr-value-type-float">3</td>
+          <td>x4</td>
+        </tr>
+      </tbody>
+    </table>
+
+    <div id="report"></div>
+    <script src="spreadsheet.js"></script>
+    <script src="checks.js"></script>
+    <script>
+      function labels() {
+        return [].map
+          .call(document.querySelectorAll(".odr-sheet tbody th"), function (th) {
+            return th.textContent.trim();
+          })
+          .join("");
+      }
+      function positions() {
+        var wrong = [];
+        for (var row = 0; row < 5; ++row) {
+          var cell = odr.sheet.cellAt(0, row);
+          if (cell === null || cell.textContent !== "r" + row) {
+            wrong.push("0," + row + "=" + (cell && cell.textContent));
+          }
+          var at = odr.sheet.positionOf(odr.sheet.cellAt(2, row));
+          if (at === null || at.column !== 2 || at.row !== row) {
+            wrong.push("round trip at row " + row);
+          }
+        }
+        return wrong;
+      }
+
+      check("the sheet is in position order to begin with", labels() === "12345");
+      var before = positions();
+      check("every position answers with its cell" + (before.length ? ": " + before : ""), before.length === 0);
+
+      click(document.querySelectorAll(".odr-sheet-sort")[1]);
+      check("sorting column B moves every row", labels() === "14253");
+
+      var after = positions();
+      check(
+        "and a position still answers with the same cell" + (after.length ? ": " + after : ""),
+        after.length === 0
+      );
+
+      odr.sheet.pin({ column: 0, row: 3 });
+      var pinned = odr.sheet.pinned();
+      check(
+        "a pin by position follows the row, not the place",
+        pinned.cell.textContent === "r3" && pinned.row === 3
+      );
+      check(
+        "which the sort has moved away from where its position would put it",
+        pinned.cell.parentElement.cells[0].textContent.trim() === "4" &&
+          pinned.cell.parentElement.rowIndex - 1 !== 3
+      );
+      odr.sheet.pin(null);
+
+      click(document.querySelectorAll(".odr-sheet-sort")[1]);
+      click(document.querySelectorAll(".odr-sheet-sort")[1]);
+      check("a third click puts the file's order back", labels() === "12345");
+      var restored = positions();
+      check("with the positions intact" + (restored.length ? ": " + restored : ""), restored.length === 0);
+    </script>
+  </body>
+</html>

--- a/test/browser/sheet/tests.html
+++ b/test/browser/sheet/tests.html
@@ -5,20 +5,6 @@
     <title>sheet checks</title>
     <link rel="stylesheet" href="document.css" />
     <link rel="stylesheet" href="spreadsheet.css" />
-    <style>
-      #report {
-        font: 13px/1.6 monospace;
-        margin: 16px;
-      }
-      .pass::before {
-        content: "PASS ";
-        color: #2a7;
-      }
-      .fail::before {
-        content: "FAIL ";
-        color: #c33;
-      }
-    </style>
   </head>
   <body class="odr-body odr-gridlines-soft">
     <!-- What `translate_sheet` writes, cut down to the shapes the script has to
@@ -69,18 +55,9 @@
 
     <div id="report"></div>
     <script src="spreadsheet.js"></script>
+    <script src="checks.js"></script>
     <script>
       var report = document.getElementById("report");
-      function check(name, condition) {
-        var line = document.createElement("div");
-        line.className = condition ? "pass" : "fail";
-        line.textContent = name;
-        report.appendChild(line);
-      }
-      function click(element) {
-        element.dispatchEvent(new MouseEvent("click", { bubbles: true }));
-        document.body.offsetHeight;
-      }
       function raised(cell) {
         return cell.classList.contains("odr-sheet-raised");
       }

--- a/test/data.cmake
+++ b/test/data.cmake
@@ -17,9 +17,9 @@ odr_test_data(
 odr_test_data(
         PATH "reference-output/odr-public"
         URL "https://github.com/opendocument-app/OpenDocument.test.output.git"
-        REVISION "1f0736902ffc8456f25d224ab282192d23fa8330")
+        REVISION "3a757cf7bf4e06337191562927057e52f37d1a9a")
 
 odr_test_data(
         PATH "reference-output/odr-private"
         URL "https://github.com/opendocument-app/OpenDocument.test-private.output.git"
-        REVISION "af74a7971d3d9c8f1e808126217a9c9beeb603c4")
+        REVISION "c43ef03e9ca239489141a8d91c0187ed9602436a")

--- a/test/data.cmake
+++ b/test/data.cmake
@@ -17,9 +17,9 @@ odr_test_data(
 odr_test_data(
         PATH "reference-output/odr-public"
         URL "https://github.com/opendocument-app/OpenDocument.test.output.git"
-        REVISION "e8dd6b52062fa8efa82a90f3e31b6c5ea7eeb58a")
+        REVISION "1f0736902ffc8456f25d224ab282192d23fa8330")
 
 odr_test_data(
         PATH "reference-output/odr-private"
         URL "https://github.com/opendocument-app/OpenDocument.test-private.output.git"
-        REVISION "ed1be07780b703b5400accbae8ccb124e68ebb71")
+        REVISION "af74a7971d3d9c8f1e808126217a9c9beeb603c4")

--- a/test/src/html_test.cpp
+++ b/test/src/html_test.cpp
@@ -853,6 +853,50 @@ TEST(html, an_editable_sheet_writes_the_markup_a_read_only_one_does) {
   EXPECT_EQ(page, render_sheet(file, HtmlConfig()));
 }
 
+// The page cannot work these out for itself, so the markup states them: which
+// sheet an op names, and whether `enable()` may say yes at all.
+TEST(html, a_sheet_states_its_index_and_whether_it_can_be_edited) {
+  const std::string page =
+      render_sheet(fods_file(fods_row(fods_cell("one"))), HtmlConfig());
+
+  EXPECT_NE(page.find(R"(data-odr-sheet="0")"), std::string::npos);
+  EXPECT_NE(page.find(R"(data-odr-editable="true")"), std::string::npos);
+}
+
+// A formula cell is locked: overwriting it leaves its dependants stale.
+TEST(html, a_formula_cell_is_locked_with_its_reason) {
+  const std::string page = render_sheet(
+      fods_file(fods_row(
+          R"xml(<table:table-cell table:formula="of:=SUM([.B1:.C1])")xml"
+          R"( office:value-type="float" office:value="7">)"
+          R"(<text:p>7</text:p></table:table-cell>)")),
+      HtmlConfig());
+
+  EXPECT_NE(page.find(R"(data-odr-lock="formula")"), std::string::npos);
+  EXPECT_NE(page.find("odr-locked"), std::string::npos);
+}
+
+// A write replaces the cell's one run, so richer markup is locked rather than
+// thrown away.
+TEST(html, a_cell_of_several_paragraphs_is_locked_rich) {
+  const std::string page = render_sheet(
+      fods_file(fods_row(R"(<table:table-cell office:value-type="string">)"
+                         R"(<text:p>a</text:p><text:p>b</text:p>)"
+                         R"(</table:table-cell>)")),
+      HtmlConfig());
+
+  EXPECT_NE(page.find(R"(data-odr-lock="rich")"), std::string::npos);
+}
+
+// The cost is a class on the locked cells only, nothing on the others.
+TEST(html, a_plain_cell_carries_no_lock) {
+  const std::string page =
+      render_sheet(fods_file(fods_row(fods_cell("one"))), HtmlConfig());
+
+  EXPECT_EQ(page.find(R"(data-odr-lock=")"), std::string::npos);
+  EXPECT_EQ(page.find("odr-locked"), std::string::npos);
+}
+
 // A text document still says so in the markup: it has no overlay.
 TEST(html, an_editable_text_document_marks_its_runs) {
   HtmlConfig config;


### PR DESCRIPTION
🤖 Generated with [Claude Code](https://claude.com/claude-code)

Step 1.1 of `docs/design/spreadsheet-editing.md` — stage 0 is done, this opens the browser editor.

## What the markup states

A sheet's editing is an overlay, so the page works out what it can and the markup carries only what it cannot:

| where | what | why |
|---|---|---|
| `<table>` | `data-odr-sheet="0"` | every op names its sheet, and a view holds one |
| `<table>` | `data-odr-editable="true"` | so `enable()` can refuse before the user clicks anything |
| `<td>` | `odr-locked` + `data-odr-lock="…"` | only on a cell an edit would spoil |

Three lock reasons, per decision 3:

- **`formula`** — overwriting it leaves every value computed from it stale.
- **`shapes`** — the cell's drawings *are* the cell, and an overlay would cover them.
- **`rich`** — a write replaces the cell's one run, so anything richer would be thrown away.

`repeated` is **not** among them: #858 made a repeated cell writable, so the lock the plan reserved for it is already gone.

A cell that can be written carries nothing at all — the cost is on the locked cells only, not on the half million others.

## What the scripts do

`sheet-editing.js` holds `odr.editing` (`enable`, `disable`, `isEnabled`, `isEditable`, `lockAt`) and the three flat `odr.on*` callbacks from decision 7.

- **Codes share one space with `odr.onError`'s**, appended and never renumbered — 1 is `errorIllegalEditNewLine`, so these start at 2.
- **The message is for the console, the code is for the host.** Nothing here is localised, so a host maps the code to its own catalogue; the English message is what a developer who wires nothing sees.
- **The page suppresses its own repeats** — an identical refusal within two seconds is dropped, so four taps on a locked cell are one snackbar rather than four.

`spreadsheet.js` publishes **`odr.sheet`** — `cellAt(column, row)`, `positionOf(cell)`, `pinned()`, `pin(position)` — and the editor addresses cells through it (**decision 8**, added to the design in this PR). It is the map, not a walk:

- **a row is named by the label it carries**, never by where it sits: sorting reorders the `<tr>`s, so `body.rows[row]` stops being row `row` the moment a column is sorted;
- **the columns are walked with the rowspans above carried down**: `translate_sheet` writes no `<td>` for a position a merge covers, so a `colspan`-only walk misreads every cell to the right of one;
- **it is built once**, by the script that owns the pin, the raise wrapper and the row order — a second copy would be a second owner of all three, and an overlay open over a cell the other script has just lowered.

Positions are the ones an op names (decision 1); the ruler's `nth-child` index stays private to the script, and a position a merge covers answers with the cell covering it — the one the file states. Merged sheets still get no wash and no sort control, as before.

The first two points were live bugs in the `cellAt` this PR previously carried inside `sheet-editing.js`: it indexed `body.rows` and walked `colspan` only. Neither had shipped.

## One thing worth flagging

My first `rich` classifier assumed a cell wraps its text in a paragraph, which is odf's shape — ooxml hangs the run under the `c` directly. That locked **92,690** xlsx cells that are perfectly plain. Now a single paragraph is unwrapped once, and the corpus reads: 30,906 `formula`, 2,300 `rich`, 36 `shapes`. The remaining public `rich` is `multiline.xlsx`, which genuinely holds several runs.

## Reference output

Regenerated and pinned — 355 output files (83 public, 272 private), plus **`resources/sheet-editing.js`, a new file**, and the `resources/spreadsheet.js` that publishes `odr.sheet`. Every ods page changes, since every `<table>` gains the two attributes and the page gains a script.

Gates: **0 of 355** changed files differ in visible text, and a fresh run against the new reference is **0 diffs in `output/` and `resources/`**.

## Checks

- 1602 tests, 1596 passed, 6 pre-existing skips. 4 new, covering the table attributes, both lock reasons reachable from a fixture, and that a plain cell carries nothing.
- The position map is not reachable from `odr_test`, so `test/browser/sheet` grows two pages beside the raise checks: `positions.html` (a merged sheet — a `colspan`, a `rowspan`, and a `rowspan` past the row's last cell) and `sorting.html` (the same questions once the sort control has moved every row). 42 checks over the three pages, 0 failing. As a negative control the walk this PR replaced was run against the same fixtures: it misses **5 of the merged sheet's 20 positions** and **4 of the 5 sorted rows**, so the fixtures do discriminate.
- clang-tidy clean (the one `deadcode.DeadStores` it reports is pre-existing on main, identical code); gcc-15 `-Wall -Wextra -Werror` over four TUs. No C++ changed since — `odr.sheet` lives in a string literal, and `fits_a_literal` still holds at 14580 of 16380.

## Next in the stack

1.2 the overlay editor, driving `odr.sheet.pin` for the arrow keys, 1.3 commit and row reflow (whose `visibleRight`/`cutOff` join `odr.sheet`), 1.4 undo/redo and `committed()`, 1.5 the browser tests and the wasm example button.
