### PR TITLE
feat(html): a text editor that owns the edit

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,17 @@ The release run heads these entries with the version and opens a fresh
 
 ## Unreleased
 
+- A text document is edited the way a reader expects: typing, replacing and
+  deleting across runs and paragraphs, Enter, Backspace at a paragraph start,
+  and a plain-text paste that opens a paragraph per line.
+
+- **Undo and redo are the editor's.** `odr.editing.undo()` / `redo()` answer
+  for a text document, `odr.onEditChange` reports `canUndo` / `canRedo`
+  truthfully, and ctrl/cmd+Z is taken.
+
+- Enter is no longer refused. Reason `newLine` (code 1) now marks only a soft
+  line break, which no operation carries.
+
 - A paragraph splits, merges and is inserted — `splitParagraph`,
   `mergeParagraph`, `insertParagraph`, and the matching `Document` methods in
   C++. Enter, Backspace at a paragraph start and a delete across paragraphs.

--- a/docs/design/document-editing.md
+++ b/docs/design/document-editing.md
@@ -138,7 +138,27 @@ be what we would have to replay.
 every edit it was going to apply. So this work has to carry undo/redo, which
 until now was honestly refused (`canUndo` answered false and a host's button
 stayed grey). That is phase 3 item 2 of [`editing.md`](editing.md), and it
-arrives here because it is no longer optional.
+arrives here because it is no longer optional. One `beforeinput` is one undo
+step; a browser coalesces a word, and matching that is a later refinement.
+
+### 6b. The page is the model, because the editor is the only one writing it
+
+Decision 8 of [`editing.md`](editing.md) called for a structured model beside
+the page, with the DOM as its projection. The editor keeps no such second
+structure: the runs and paragraphs are addressed in the page by
+`data-odr-id`, and **that is the model**.
+
+**Why the second structure bought nothing:** what decision 8 was protecting
+against is contenteditable inventing markup we cannot map back. Owning the
+mutation removes that at the source — nothing but this editor writes the page,
+so the page cannot drift into a shape the element tree has no name for. A
+parallel model would have to be kept in step with the page anyway, and the
+place the two could disagree is exactly the bug it was meant to catch.
+
+**Where it earns its keep:** a composition cannot be cancelled, so the browser
+*does* write inside a run. With the page as the model there is nothing to
+reconcile — `compositionend` reads the run's text and that is the operation.
+With a parallel model that same case would be a merge.
 
 ### 7. Read-only engines say nothing
 
@@ -272,8 +292,8 @@ Each step is a pull request that builds and tests on its own.
    **Landed.**
 3. **Paragraphs split and merge.** `splitParagraph`, `mergeParagraph`,
    `insertParagraph`. **Landed.**
-4. **The browser editor.** Model-first, owns the DOM mutation, records the ops,
-   and carries undo/redo (decision 6).
+4. **The browser editor.** Owns the DOM mutation, records the ops, and carries
+   undo/redo (decisions 6 and 6b). **Landed.**
 5. **pptx writes.** `save`, `is_editable`, `is_savable`, the capability row and
    the new hooks over `a:p` / `a:r`.
 
@@ -301,6 +321,30 @@ A split exactly at the end of a span leaves an **empty copy of that span**
 behind. It is valid in both formats — the corpus is full of `<w:r><w:rPr/></w:r>`
 that producers wrote themselves — and pruning it would cost a branch to save
 nothing a reader sees.
+
+## What the editor does with a keystroke
+
+Every edit is one of two shapes, and both come out of one function:
+
+- **A range replaced by some text.** Typing, replacing a selection, every
+  delete, and each line of a paste. Inside one run it is a `setText`; across
+  runs it is a `setText` on each end and a `removeElement` between; across
+  paragraphs it is that plus a `mergeParagraph`.
+- **A split where the caret sits.** Enter, and every line break in a paste.
+  The run is cut in two first (decision 3) unless the caret is already at a
+  run boundary.
+
+Two details the checks pin down:
+
+- **A delete whose range the browser did not state is one character**, in the
+  direction the key names — or, at the start of a paragraph, the boundary
+  itself, which merges and takes no character. A browser normally states the
+  range; an Android WebView is reported not to. The *word* and *line* deletes
+  are not extended this way: guessing where a word ends would take away text
+  the reader did not name, so nothing happens.
+- **The line box is kept the way a fresh render writes it** — `<br>` where a
+  paragraph holds nothing, `<wbr>` where it holds something. An edited page
+  then looks like a re-rendered one, which is what makes the two comparable.
 
 ## Open questions
 

--- a/docs/design/editing.md
+++ b/docs/design/editing.md
@@ -342,15 +342,18 @@ attribute.
 ### 13. One editable view, and every edit it cannot replay is refused
 
 `enable()` puts `contenteditable` on the **body**, not on each run. The editor
-then intercepts `beforeinput` and refuses everything that is not the text of one
-addressed run:
+then intercepts `beforeinput` and takes the edits it can express as operations:
 
 | The edit | What happens |
 |---|---|
-| text typed, replaced, pasted plain, deleted, composed — inside one run | allowed, and the run joins the log |
-| a new line (`insertParagraph`, `insertLineBreak`) | refused, reason `newLine` |
+| text typed, replaced, deleted — inside one run, across runs, across paragraphs | taken |
+| Enter | taken: the paragraph splits where the caret sits |
+| Backspace at the start of a paragraph | taken: the paragraph merges into the one before it |
+| a paste of plain text, over as many lines as it holds | taken: each line after the first opens a paragraph |
+| a composition (CJK, autocorrect, dictation) | let through and reconciled on `compositionend` |
+| a soft line break (`insertLineBreak`) | refused, reason `newLine` - no operation carries one |
 | anything else the browser offers (a mark, a list, a drop) | refused, reason `unsupportedEdit` |
-| an edit spanning two runs, or landing outside every run | refused, reason `range` |
+| an edit reaching over a picture or a table, or landing outside every run | refused, reason `range` |
 
 **Why the whole view rather than a run at a time:** `contenteditable` per run
 makes every run its own editing host, and a host is a wall. The caret cannot
@@ -365,52 +368,36 @@ over every run.
 it says *what* the edit is (`inputType`), it says *where* (`getTargetRanges()`),
 and it is cancelable. `text.js` already edits the plain-text view this way.
 
-**The whitelist is closed, not open.** Only the input types that change the text
-of one run are allowed; anything unrecognised is refused. An open list would let
-a browser-specific `inputType` through to a `MutationObserver` that only watches
-`characterData`, and a structural change would then be invisible to the log and
-saved wrong. Refusing something we could have allowed costs a reader one
-gesture; allowing something we cannot replay costs them their document.
+**The whitelist is closed, not open.** Only the input types the editor can
+express are taken; anything unrecognised is refused. Refusing something we could
+have allowed costs a reader one gesture; allowing something we cannot replay
+costs them their document.
 
 **The address is the whole guard.** No element is marked non-editable: an edit is
-allowed because it lands inside a `x-s[data-odr-id]` run, so a picture, a table's
-furniture, the gap between two paragraphs and the page box are all refused
-without a single attribute of their own. That is decision 10's rule — mark the
-exceptions, not the rest — applied to the caret instead of to a cell.
+allowed because it lands inside a `x-s[data-odr-id]` run and reaches over
+nothing but runs, so a picture, a table's furniture and the page box are all
+refused without a single attribute of their own. That is decision 10's rule —
+mark the exceptions, not the rest — applied to the caret instead of to a cell.
 
-**`input` is what the log collects on, not a `MutationObserver`.** The browser
-raises `input` when *it* applied an edit; a script rewriting the page raises
-none. That is the whole difference: `search.js` wraps every match in a `<mark>`,
-which an observer watching `characterData` reads as nine edits — measured, and
-it lit the host's save button and put nine no-op `setText` ops in the log. The
-run is the one `beforeinput` named, or the one the caret sits in where no
-`beforeinput` arrived; a run the editor cannot name at all raises code 9 rather
-than being dropped.
+**The editor owns the edit.** It cancels the `beforeinput` and splices the page
+itself, rather than letting the browser apply the change and reading the run
+back. See decision 6 of [`document-editing.md`](document-editing.md) for why that had
+to change.
+
+**Undo is the editor's**, because cancelling every edit leaves the browser's own
+stack empty. Each step holds the operations it puts on the wire and the two
+halves of taking it back, so `canUndo` and the chord now agree and a host's undo
+button is live. One `beforeinput` is one step.
 
 **Known holes, both narrow.** A scripted `document.execCommand` can bypass the
 gate, because Chrome does not fire a cancelable `beforeinput` for every command;
-trusted input, which is all a reader has, is refused correctly. And a
-composition cannot be cancelled at all — `insertCompositionText` is allowed and
-reconciled afterwards, which is why the observer reports code 9 when text
-changes where no op can name it, rather than dropping it in silence. Android
-WebView's incomplete `beforeinput` (decision 8) is the reason that report
-exists; verify it on a device before trusting the gate there.
-
-**Two limits a reader meets, and phase 3 is where both go:**
-
-- **Undo belongs to the browser, not to us.** Every allowed edit is one the
-  browser applied, so its own stack is the one that replays — ctrl+Z works, and
-  `chordKey` leaves the key alone because no editor claims it (decision 9). But
-  we cannot read that stack's depth, so `canUndo` is honestly false and a host's
-  undo *button* stays grey. Phase 3 item 2 is what fixes it: once the editor
-  records an op with its inverse, it answers `undo()` and joins the shared log.
-  Until then the button and the chord disagree, which is worse than either.
-- **Backspace at the start of a run is refused.** Its target range reaches back
-  into the run before it, so the edit spans two and `range` refuses it —
-  merging two runs is not something `setText` can express. It did nothing under
-  the per-run hosts either; the difference is that it now says why. The op that
-  would fix it is `deleteRange` across runs, which needs the write-side adapter
-  work in phase 2, not a browser change.
+trusted input, which is all a reader has, goes through it. And a composition
+cannot be cancelled at all, so the editor lets it finish and reads the run back
+on `compositionend`; a composition that landed where no run can name it raises
+code 9 rather than being dropped. Android WebView's incomplete `beforeinput`
+(decision 8) is the reason that report exists, and the reason a delete whose
+range the browser did not state is extended by one character rather than
+refused; verify both on a device.
 
 ## Preliminary implementation plan (ODF / OOXML)
 
@@ -458,9 +445,10 @@ Sequence within Phase 2: (a) delete element, (b) toggle mark on a range,
 
 ### Phase 3 — Browser editor
 
-The frame is landed (decisions 9 to 12): the mode, the refusals, the callbacks
-and the keyboard classes are in `frontend/editing.js`, and `document.js`
-attaches the skeleton editor to it. What is left is the editor itself.
+**Landed**, over [`document-editing.md`](document-editing.md)'s schema. The mode, the
+refusals, the callbacks and the keyboard classes are in `frontend/editing.js`;
+`document.js` holds the editor, which owns every edit and carries its own
+undo.
 
 1. Model keyed by `data-odr-id`; op recorder; composition-aware reconciliation.
    `beforeinput` is already the gate (decision 13); what is left is owning the

--- a/src/odr/document.cpp
+++ b/src/odr/document.cpp
@@ -212,14 +212,27 @@ void Document::edit(const std::string_view operations,
     }
 
     if (name == "insertText") {
+      const auto text = operation.at("text").get<std::string>();
+      const std::int64_t address = reserve(operation);
+
+      // `parent` appends into an element rather than naming a run to sit
+      // beside
+      if (operation.contains("parent")) {
+        if (operation.contains("after") || operation.contains("before")) {
+          throw std::invalid_argument(
+              "insertText names `parent` or a run to sit beside, not both");
+        }
+        const Element parent = element_of(operation, "parent");
+        minted.emplace(address, append_text(parent, text).identifier());
+        continue;
+      }
+
       const bool after = operation.contains("after");
       if (after == operation.contains("before")) {
         throw std::invalid_argument(
-            "insertText names one of `after` and `before`");
+            "insertText names one of `after`, `before` and `parent`");
       }
-      const std::int64_t address = reserve(operation);
       const Text anchor = text_of(operation, after ? "after" : "before");
-      const auto text = operation.at("text").get<std::string>();
       const Text created = after ? insert_text_after(anchor, text)
                                  : insert_text_before(anchor, text);
       minted.emplace(address, created.identifier());
@@ -305,6 +318,14 @@ Text Document::insert_text_(const Text &anchor, const Placement where,
   }
   const ElementIdentifier identifier =
       runs->text_insert(anchor_id, where, text);
+  return {adapter, identifier, adapter->text_adapter(identifier)};
+}
+
+Text Document::append_text(const Element &parent,
+                           const std::string &text) const {
+  const internal::abstract::ElementAdapter *adapter = m_impl->element_adapter();
+  const ElementIdentifier identifier =
+      adapter->element_append_text(check_(parent), text);
   return {adapter, identifier, adapter->text_adapter(identifier)};
 }
 

--- a/src/odr/document.hpp
+++ b/src/odr/document.hpp
@@ -82,6 +82,11 @@ public:
   [[nodiscard]] Text insert_text_after(const Text &anchor,
                                        const std::string &text) const;
 
+  /// A run as the last child of @p parent. What a paragraph holding no run at
+  /// all is typed into.
+  [[nodiscard]] Text append_text(const Element &parent,
+                                 const std::string &text) const;
+
   /// Splits @p paragraph after @p after - one of its descendants, or an
   /// element that does not exist to move every child - into a new paragraph
   /// of the same style. Refuses where an element between the two is one it

--- a/src/odr/internal/abstract/document.hpp
+++ b/src/odr/internal/abstract/document.hpp
@@ -115,6 +115,15 @@ public:
     throw UnsupportedOperation();
   }
 
+  /// A run holding @p text as the last child of @p element_id. What a
+  /// paragraph holding no run at all is typed into.
+  /// @throws UnsupportedOperation where the engine cannot write.
+  virtual ElementIdentifier
+  element_append_text([[maybe_unused]] const ElementIdentifier element_id,
+                      [[maybe_unused]] const std::string &text) const {
+    throw UnsupportedOperation();
+  }
+
   [[nodiscard]] virtual const TextRootAdapter *
   text_root_adapter([[maybe_unused]] const ElementIdentifier element_id) const {
     return nullptr;

--- a/src/odr/internal/html/frontend/document.js
+++ b/src/odr/internal/html/frontend/document.js
@@ -1,6 +1,6 @@
-// The text editor, attached to `odr.editing`. The mode makes the whole view
-// editable and refuses what it cannot replay: `setText` is the only op the
-// file takes, so an edit has to land inside one addressed run.
+// The text editor, attached to `odr.editing`. It owns the edit: it cancels
+// what the browser was about to do and splices the page itself, so the markup
+// stays what the renderer wrote. See `docs/design/document-editing.md`.
 (function () {
   "use strict";
 
@@ -13,81 +13,736 @@
   }
 
   var root = document.body;
-  var modified = {};
 
-  function idOf(run) {
-    return Number(run.getAttribute("data-odr-id"));
+  // ---------------------------------------------------------------- address
+
+  // ids for the elements this session creates; the render wrote the positive
+  // ones, and replay tells the two apart by the sign
+  var lastMinted = 0;
+
+  function mint() {
+    return --lastMinted;
   }
 
-  function operations() {
-    var ops = [];
-    for (var id in modified) {
-      if (Object.prototype.hasOwnProperty.call(modified, id)) {
-        ops.push({
-          op: "setText",
-          id: Number(id),
-          // Not `innerText`: that is the rendered text, and it drops the
-          // trailing space a reader just typed.
-          text: modified[id].textContent,
-        });
-      }
-    }
-    return ops;
+  function idOf(element) {
+    return element === null ? null : Number(element.getAttribute("data-odr-id"));
   }
 
-  /// The run @p node sits in, or null where it sits outside every run.
+  /// The run @p node sits in, or null where it sits outside every run. A
+  /// paragraph carries an address too, so the tag is part of the question.
   function runOf(node) {
-    if (node === null) {
+    if (node === null || node === undefined) {
       return null;
     }
     var element = node.nodeType === 1 ? node : node.parentElement;
     return element === null ? null : element.closest("x-s[data-odr-id]");
   }
 
-  // The input types that only ever change the text of one run.
-  var textual = {
-    insertText: 1,
-    insertReplacementText: 1,
-    insertFromPaste: 1,
-    insertCompositionText: 1,
-    deleteContent: 1,
-    deleteContentBackward: 1,
-    deleteContentForward: 1,
-    deleteByCut: 1,
-    deleteWordBackward: 1,
-    deleteWordForward: 1,
-    deleteSoftLineBackward: 1,
-    deleteSoftLineForward: 1,
-    // Its stack holds the edits above and nothing else: the structural ones
-    // never happened.
-    historyUndo: 1,
-    historyRedo: 1,
-  };
+  function paragraphOf(node) {
+    if (node === null || node === undefined) {
+      return null;
+    }
+    var element = node.nodeType === 1 ? node : node.parentElement;
+    return element === null ? null : element.closest("x-p[data-odr-id]");
+  }
 
-  // A new line has nowhere to go in a run, and the reader knows the key.
-  var named = { insertParagraph: "newLine", insertLineBreak: "newLine" };
+  /// The runs of @p paragraph, in document order - one under a span or a link
+  /// counts as the paragraph's.
+  function runsOf(paragraph) {
+    return Array.prototype.slice.call(
+      paragraph.querySelectorAll("x-s[data-odr-id]")
+    );
+  }
 
-  /// Where an edit lands: `run` is the one run it is confined to, null where
-  /// it spans two or lands outside every run. `id` is where it starts.
-  function target(event) {
+  // ------------------------------------------------------------------- page
+
+  /// The renderer ends a paragraph with `<br>` where it holds nothing and
+  /// `<wbr>` where it holds something; keeping to that makes an edited page
+  /// look like a freshly rendered one.
+  function refreshLineBox(paragraph) {
+    var last = paragraph.lastChild;
+    while (last !== null && (last.nodeName === "BR" || last.nodeName === "WBR")) {
+      paragraph.removeChild(last);
+      last = paragraph.lastChild;
+    }
+    // a picture is content the same way text is, as the renderer has it
+    var holds =
+      paragraph.textContent !== "" || paragraph.firstElementChild !== null;
+    paragraph.appendChild(document.createElement(holds ? "wbr" : "br"));
+  }
+
+  /// A copy of @p element carrying what it looks like and none of what it
+  /// holds. @p id is null for a wrapper no operation names.
+  function shellCopy(element, id) {
+    var copy = element.cloneNode(false);
+    if (id === null) {
+      copy.removeAttribute("data-odr-id");
+    } else {
+      copy.setAttribute("data-odr-id", String(id));
+    }
+    return copy;
+  }
+
+  // -------------------------------------------------------------------- log
+
+  // a step holds the operations it puts on the wire and the two halves of
+  // taking it back; `done` is what a save reads, `undone` what redo replays
+  var done = [];
+  var undone = [];
+
+  function perform(step) {
+    if (step === null) {
+      return null;
+    }
+    step.apply();
+    done.push(step);
+    undone.length = 0;
+    odr.editing.changed();
+    return step;
+  }
+
+  /// A copy of @p op carrying @p text: folding must not write into the
+  /// operation its step hands over again after an undo and a redo.
+  function withText(op, text) {
+    var copy = {};
+    for (var field in op) {
+      if (Object.prototype.hasOwnProperty.call(op, field)) {
+        copy[field] = op[field];
+      }
+    }
+    copy.text = text;
+    return copy;
+  }
+
+  /// Folds what a save need not carry: several edits to one run are the text
+  /// it ends at, and a run created and typed into is one insert. Only adjacent
+  /// operations fold, so nothing between them can depend on it.
+  function coalesce(ops) {
+    var result = [];
+    for (var i = 0; i < ops.length; ++i) {
+      var op = ops[i];
+      var last = result.length === 0 ? null : result[result.length - 1];
+      if (
+        last !== null &&
+        op.op === "setText" &&
+        (last.op === "setText" || last.op === "insertText") &&
+        last.id === op.id
+      ) {
+        result[result.length - 1] = withText(last, op.text);
+        continue;
+      }
+      result.push(op);
+    }
+    return result;
+  }
+
+  function operations() {
+    var ops = [];
+    for (var i = 0; i < done.length; ++i) {
+      for (var j = 0; j < done[i].ops.length; ++j) {
+        ops.push(done[i].ops[j]);
+      }
+    }
+    return coalesce(ops);
+  }
+
+  // -------------------------------------------------------------- mutations
+
+  function setRunText(run, text) {
+    var before = run.textContent;
+    if (text === before) {
+      return null; // an edit that changes nothing is not an operation
+    }
+    return {
+      ops: [{ op: "setText", id: idOf(run), text: text }],
+      apply: function () {
+        run.textContent = text;
+      },
+      revert: function () {
+        run.textContent = before;
+      },
+    };
+  }
+
+  /// A run beside @p anchor, cloned from it so it lands in the same parent -
+  /// which is what gives it the same style on replay.
+  function insertRun(anchor, where, text) {
+    var id = mint();
+    var run = shellCopy(anchor, id);
+    run.textContent = text;
+    var op = { op: "insertText", text: text, id: id };
+    op[where] = idOf(anchor);
+    return {
+      run: run,
+      ops: [op],
+      apply: function () {
+        anchor.parentNode.insertBefore(
+          run,
+          where === "after" ? anchor.nextSibling : anchor
+        );
+      },
+      revert: function () {
+        run.parentNode.removeChild(run);
+      },
+    };
+  }
+
+  /// The first run of a paragraph that holds none: what a reader types into
+  /// after Enter.
+  function appendRun(paragraph, text) {
+    var id = mint();
+    var run = document.createElement("x-s");
+    run.setAttribute("data-odr-id", String(id));
+    run.textContent = text;
+    return {
+      run: run,
+      ops: [{ op: "insertText", parent: idOf(paragraph), text: text, id: id }],
+      apply: function () {
+        // ahead of the line box, which is the paragraph's last child
+        paragraph.insertBefore(run, paragraph.lastChild);
+        refreshLineBox(paragraph);
+      },
+      revert: function () {
+        paragraph.removeChild(run);
+        refreshLineBox(paragraph);
+      },
+    };
+  }
+
+  function removeElement(element) {
+    var parent = element.parentNode;
+    var at = element.nextSibling;
+    return {
+      ops: [{ op: "removeElement", id: idOf(element) }],
+      apply: function () {
+        parent.removeChild(element);
+      },
+      revert: function () {
+        parent.insertBefore(element, at);
+      },
+    };
+  }
+
+  /// Splits @p element after @p stays - one of its children, or null to move
+  /// all of them - into a copy of itself. The line box is the paragraph's own
+  /// and stays out of the move.
+  function splitLevel(element, stays, id, undoLog) {
+    var copy = shellCopy(element, id);
+    element.parentNode.insertBefore(copy, element.nextSibling);
+    undoLog.push(function () {
+      copy.parentNode.removeChild(copy);
+    });
+
+    var node = stays === null ? element.firstChild : stays.nextSibling;
+    while (node !== null) {
+      var next = node.nextSibling;
+      if (node.nodeName !== "BR" && node.nodeName !== "WBR") {
+        (function (moved, from, at) {
+          undoLog.push(function () {
+            from.insertBefore(moved, at);
+          });
+        })(node, element, next);
+        copy.appendChild(node);
+      }
+      node = next;
+    }
+    return copy;
+  }
+
+  /// Splits @p paragraph after @p after - one of its runs, or null to move
+  /// everything. Every span and link on the way up is split too.
+  /// No `after` splits before every child, stated as an absent key.
+  function splitOp(paragraph, after, id) {
+    var op = { op: "splitParagraph", paragraph: idOf(paragraph), id: id };
+    if (after !== null) {
+      op.after = idOf(after);
+    }
+    return op;
+  }
+
+  function splitParagraph(paragraph, after) {
+    var id = mint();
+    var undoLog = [];
+    var tail = null;
+
+    return {
+      get tail() {
+        return tail;
+      },
+      ops: [splitOp(paragraph, after, id)],
+      apply: function () {
+        undoLog = [];
+        var stays = after;
+        var level = after === null ? paragraph : after.parentNode;
+        while (level !== paragraph) {
+          splitLevel(level, stays, null, undoLog);
+          stays = level;
+          level = level.parentNode;
+        }
+        tail = splitLevel(paragraph, stays, id, undoLog);
+        refreshLineBox(paragraph);
+        refreshLineBox(tail);
+      },
+      revert: function () {
+        for (var i = undoLog.length - 1; i >= 0; --i) {
+          undoLog[i]();
+        }
+        undoLog = [];
+        refreshLineBox(paragraph);
+        tail = null;
+      },
+    };
+  }
+
+  /// @p paragraph takes the children of the paragraph after it, which goes.
+  function mergeParagraph(paragraph) {
+    var next = null;
+    var undoLog = [];
+    return {
+      ops: [{ op: "mergeParagraph", paragraph: idOf(paragraph) }],
+      apply: function () {
+        undoLog = [];
+        next = paragraph.nextElementSibling;
+        var parent = next.parentNode;
+        var at = next.nextSibling;
+        undoLog.push(function () {
+          parent.insertBefore(next, at);
+        });
+
+        var node = next.firstChild;
+        while (node !== null) {
+          var following = node.nextSibling;
+          if (node.nodeName !== "BR" && node.nodeName !== "WBR") {
+            (function (moved, from, back) {
+              undoLog.push(function () {
+                from.insertBefore(moved, back);
+              });
+            })(node, next, following);
+            paragraph.insertBefore(node, paragraph.lastChild);
+          }
+          node = following;
+        }
+        parent.removeChild(next);
+        refreshLineBox(paragraph);
+      },
+      revert: function () {
+        for (var i = undoLog.length - 1; i >= 0; --i) {
+          undoLog[i]();
+        }
+        undoLog = [];
+        refreshLineBox(paragraph);
+        refreshLineBox(next);
+      },
+    };
+  }
+
+  function insertParagraph(after) {
+    var id = mint();
+    var paragraph = shellCopy(after, id);
+    paragraph.appendChild(document.createElement("br"));
+    return {
+      paragraph: paragraph,
+      ops: [{ op: "insertParagraph", after: idOf(after), id: id }],
+      apply: function () {
+        after.parentNode.insertBefore(paragraph, after.nextSibling);
+      },
+      revert: function () {
+        paragraph.parentNode.removeChild(paragraph);
+      },
+    };
+  }
+
+  // ------------------------------------------------------------------ caret
+
+  function placeCaret(run, offset) {
+    var node = run.firstChild;
+    if (node === null || node.nodeType !== 3) {
+      node = run.insertBefore(document.createTextNode(""), run.firstChild);
+    }
+    var range = document.createRange();
+    range.setStart(node, Math.max(0, Math.min(offset, node.data.length)));
+    range.collapse(true);
+    var selection = window.getSelection();
+    selection.removeAllRanges();
+    selection.addRange(range);
+  }
+
+  /// The offset into @p run's text that (@p container, @p offset) names. The
+  /// browser counts characters inside a text node and children inside an
+  /// element, either of which may sit under a nested wrapper.
+  function offsetInRun(run, container, offset) {
+    var counted = 0;
+    if (container.nodeType === 1) {
+      var child = container.firstChild;
+      for (var i = 0; i < offset && child !== null; ++i) {
+        counted += child.textContent.length;
+        child = child.nextSibling;
+      }
+    } else {
+      counted = offset;
+    }
+    for (var node = container; node !== run; node = node.parentNode) {
+      for (
+        var previous = node.previousSibling;
+        previous !== null;
+        previous = previous.previousSibling
+      ) {
+        counted += previous.textContent.length;
+      }
+    }
+    return counted;
+  }
+
+  /// Where an edit lands, in the terms an operation is written in: a run and
+  /// an offset into its text. Null outside every run and every paragraph.
+  function placeOf(container, offset) {
+    var run = runOf(container);
+    if (run !== null) {
+      return {
+        run: run,
+        offset: offsetInRun(run, container, offset),
+        paragraph: paragraphOf(run),
+      };
+    }
+
+    var paragraph = paragraphOf(container);
+    if (paragraph === null) {
+      return null;
+    }
+    // beside the line box: the end of the last run is where a reader means,
+    // and a paragraph holding none is where the first run goes
+    var runs = runsOf(paragraph);
+    if (runs.length === 0) {
+      return { run: null, offset: 0, paragraph: paragraph };
+    }
+    var last = runs[runs.length - 1];
+    return {
+      run: last,
+      offset: last.textContent.length,
+      paragraph: paragraph,
+    };
+  }
+
+  /// The range an event states, or the selection where it states none - which
+  /// is what a browser lacking `getTargetRanges` leaves us.
+  function rangeOf(event) {
     var ranges =
       typeof event.getTargetRanges === "function" ? event.getTargetRanges() : [];
     var range = ranges.length === 1 ? ranges[0] : undefined;
-    if (ranges.length === 0) {
-      // No target range: a composition, and some browsers for a paste. The
-      // caret is what the edit will land on.
+    if (range === undefined) {
       var selection = window.getSelection();
-      if (selection !== null && selection.rangeCount > 0) {
-        range = selection.getRangeAt(0);
+      if (selection === null || selection.rangeCount === 0) {
+        return null;
+      }
+      range = selection.getRangeAt(0);
+    }
+    var start = placeOf(range.startContainer, range.startOffset);
+    var end = placeOf(range.endContainer, range.endOffset);
+    if (start === null || end === null) {
+      return null;
+    }
+    return { start: start, end: end };
+  }
+
+  // ------------------------------------------------------------------ edits
+
+  /// Replaces what @p at covers with @p text, and answers where the caret
+  /// then sits. One run, several runs, or several paragraphs - the last case
+  /// merges what is left of the two ends into one paragraph.
+  function replaceRange(at, text) {
+    var start = at.start;
+    var end = at.end;
+
+    // Everything the range covers has to be expressible before any of it is
+    // applied, or a refusal would leave half an edit on the page.
+    var between =
+      start.paragraph === end.paragraph
+        ? []
+        : paragraphsBetween(start.paragraph, end.paragraph);
+    if (between === null) {
+      return null;
+    }
+    if (start.run !== end.run) {
+      // the far end has to be a run, and what lies between has to be text
+      if (start.run === null || end.run === null) {
+        return null;
+      }
+      if (!coversOnlyText(start.run, end.run)) {
+        return null;
       }
     }
-    if (range === undefined) {
-      return { run: null, id: null };
+
+    if (start.run === null) {
+      if (text === "") {
+        return start;
+      }
+      // a paragraph holding no run at all: the text opens one
+      var opened = perform(appendRun(start.paragraph, text));
+      return {
+        run: opened.run,
+        offset: text.length,
+        paragraph: start.paragraph,
+      };
     }
-    var start = runOf(range.startContainer);
+
+    var head = start.run.textContent.slice(0, start.offset);
+    var caret = {
+      run: start.run,
+      offset: head.length + text.length,
+      paragraph: start.paragraph,
+    };
+
+    if (start.run === end.run) {
+      perform(
+        setRunText(start.run, head + text + end.run.textContent.slice(end.offset))
+      );
+      return caret;
+    }
+
+    var tail = end.run.textContent.slice(end.offset);
+    perform(setRunText(start.run, head + text));
+
+    if (start.paragraph === end.paragraph) {
+      removeRunsBetween(start.paragraph, start.run, end.run);
+      perform(setRunText(end.run, tail));
+      return caret;
+    }
+
+    // Several paragraphs: what is left of each end joins, and everything
+    // between goes whole.
+    removeRunsBetween(start.paragraph, start.run, null);
+    removeRunsBetween(end.paragraph, null, end.run);
+    perform(setRunText(end.run, tail));
+
+    for (var i = 0; i < between.length; ++i) {
+      perform(removeElement(between[i]));
+    }
+    perform(mergeParagraph(start.paragraph));
+
+    return caret;
+  }
+
+  /// Removes the runs of @p paragraph that lie strictly between @p after and
+  /// @p before; a null end means from the first run, or to the last.
+  function removeRunsBetween(paragraph, after, before) {
+    var runs = runsOf(paragraph);
+    var from = after === null ? 0 : runs.indexOf(after) + 1;
+    var to = before === null ? runs.length : runs.indexOf(before);
+    for (var i = from; i < to; ++i) {
+      perform(removeElement(runs[i]));
+    }
+  }
+
+  // What a range may reach over: a run, a wrapper around one, a paragraph of
+  // them, and the line box. A picture or a table is not, and no sequence of
+  // operations takes one away.
+  var reachable = { "X-S": 1, A: 1, "X-P": 1, BR: 1, WBR: 1 };
+
+  /// Whether everything between @p from and @p to is text.
+  function coversOnlyText(from, to) {
+    var probe = document.createRange();
+    probe.setStartAfter(from);
+    probe.setEndBefore(to);
+    var nodes = probe.cloneContents().querySelectorAll("*");
+    for (var i = 0; i < nodes.length; ++i) {
+      if (reachable[nodes[i].tagName] !== 1) {
+        return false;
+      }
+    }
+    return true;
+  }
+
+  /// The paragraphs strictly between @p first and @p last, or null where
+  /// something that is not a paragraph lies between them - a table, a picture
+  /// - which is a range no sequence of operations can express.
+  function paragraphsBetween(first, last) {
+    if (first.parentNode !== last.parentNode) {
+      return null;
+    }
+    var result = [];
+    for (
+      var at = first.nextElementSibling;
+      at !== null && at !== last;
+      at = at.nextElementSibling
+    ) {
+      if (at.tagName !== "X-P" || at.getAttribute("data-odr-id") === null) {
+        return null;
+      }
+      result.push(at);
+    }
+    return result;
+  }
+
+  /// Enter: what the caret covers goes, and the paragraph splits where it
+  /// then sits. Answers where the caret lands, which is the head of the new
+  /// paragraph.
+  function splitAt(at) {
+    var caret = replaceRange(at, "");
+    if (caret === null) {
+      return null;
+    }
+    var paragraph = caret.paragraph;
+
+    if (caret.run === null) {
+      var empty = perform(insertParagraph(paragraph));
+      return { paragraph: empty.paragraph, run: null, offset: 0 };
+    }
+
+    var after = caret.run;
+    if (caret.offset >= caret.run.textContent.length) {
+      // the caret is at the end of its run: nothing has to be cut
+    } else if (caret.offset === 0) {
+      var runs = runsOf(paragraph);
+      var before = runs.indexOf(caret.run) - 1;
+      after = before < 0 ? null : runs[before];
+    } else {
+      var whole = caret.run.textContent;
+      perform(setRunText(caret.run, whole.slice(0, caret.offset)));
+      perform(insertRun(caret.run, "after", whole.slice(caret.offset)));
+    }
+
+    var split = perform(splitParagraph(paragraph, after));
+    var tailRuns = runsOf(split.tail);
     return {
-      run: start !== null && start === runOf(range.endContainer) ? start : null,
-      id: start === null ? null : idOf(start),
+      paragraph: split.tail,
+      run: tailRuns.length === 0 ? null : tailRuns[0],
+      offset: 0,
+    };
+  }
+
+  /// Puts the caret where an edit left it; a paragraph holding no run has
+  /// nowhere but itself.
+  function restore(caret) {
+    if (caret.run !== null) {
+      placeCaret(caret.run, caret.offset);
+      return;
+    }
+    var range = document.createRange();
+    range.setStart(caret.paragraph, 0);
+    range.collapse(true);
+    var selection = window.getSelection();
+    selection.removeAllRanges();
+    selection.addRange(range);
+  }
+
+  // ------------------------------------------------------------------- gate
+
+  // Every edit is one of two shapes: a range replaced by some text, or a
+  // paragraph split where the caret sits. `text` reads what to put in.
+  var replacing = {
+    insertText: function (event) {
+      return event.data === null ? "" : event.data;
+    },
+    insertReplacementText: function (event) {
+      return event.data === null ? "" : event.data;
+    },
+    deleteContent: empty,
+    deleteContentBackward: empty,
+    deleteContentForward: empty,
+    deleteByCut: empty,
+    deleteWordBackward: empty,
+    deleteWordForward: empty,
+    deleteSoftLineBackward: empty,
+    deleteSoftLineForward: empty,
+    deleteHardLineBackward: empty,
+    deleteHardLineForward: empty,
+    deleteEntireSoftLine: empty,
+  };
+
+  function empty() {
+    return "";
+  }
+
+  // no operation carries a soft line break
+  var named = { insertLineBreak: "newLine" };
+
+  // A delete whose range the browser did not state is one character, in the
+  // direction the key names. The word and line deletes are not on this list:
+  // guessing where a word ends would take away text the reader did not name.
+  var extending = { deleteContentBackward: -1, deleteContentForward: 1 };
+
+  /// The run before @p run, reaching into the paragraph before where it is
+  /// the first - which is what Backspace at a paragraph start does.
+  function runBefore(run) {
+    var paragraph = paragraphOf(run);
+    var runs = runsOf(paragraph);
+    var at = runs.indexOf(run);
+    if (at > 0) {
+      return { run: runs[at - 1], paragraph: paragraph };
+    }
+    var previous = paragraph.previousElementSibling;
+    if (previous === null || previous.tagName !== "X-P") {
+      return null;
+    }
+    var before = runsOf(previous);
+    return before.length === 0
+      ? null
+      : { run: before[before.length - 1], paragraph: previous };
+  }
+
+  function runAfter(run) {
+    var paragraph = paragraphOf(run);
+    var runs = runsOf(paragraph);
+    var at = runs.indexOf(run);
+    if (at + 1 < runs.length) {
+      return { run: runs[at + 1], paragraph: paragraph };
+    }
+    var next = paragraph.nextElementSibling;
+    if (next === null || next.tagName !== "X-P") {
+      return null;
+    }
+    var after = runsOf(next);
+    return after.length === 0 ? null : { run: after[0], paragraph: next };
+  }
+
+  /// Grows a collapsed range by the one character a delete key takes, or by
+  /// the paragraph boundary it stands at - which merges and takes no
+  /// character. Null where there is nothing to take.
+  function extendForDelete(at, direction) {
+    if (at.start.run !== at.end.run || at.start.offset !== at.end.offset) {
+      return at;
+    }
+    var place = at.start;
+    if (place.run === null) {
+      return null;
+    }
+    if (direction < 0) {
+      if (place.offset > 0) {
+        return {
+          start: { run: place.run, offset: place.offset - 1, paragraph: place.paragraph },
+          end: place,
+        };
+      }
+      var before = runBefore(place.run);
+      if (before === null) {
+        return null;
+      }
+      // at the start of a paragraph the boundary itself is what goes, so the
+      // range takes no character with it
+      var back = before.paragraph === place.paragraph ? 1 : 0;
+      return {
+        start: {
+          run: before.run,
+          offset: before.run.textContent.length - back,
+          paragraph: before.paragraph,
+        },
+        end: place,
+      };
+    }
+    if (place.offset < place.run.textContent.length) {
+      return {
+        start: place,
+        end: { run: place.run, offset: place.offset + 1, paragraph: place.paragraph },
+      };
+    }
+    var after = runAfter(place.run);
+    if (after === null) {
+      return null;
+    }
+    var forward = after.paragraph === place.paragraph ? 1 : 0;
+    return {
+      start: place,
+      end: { run: after.run, offset: forward, paragraph: after.paragraph },
     };
   }
 
@@ -95,82 +750,148 @@
     if (event.cancelable) {
       event.preventDefault();
     }
-    // The id keeps two refusals apart, so Enter in one run and then in
-    // another is heard twice.
-    odr.editing.refuse(reason, { id: at.id });
+    // the id keeps two refusals apart, so the same key in one run and then in
+    // another is heard twice
+    odr.editing.refuse(reason, {
+      id: at === null || at.start.run === null ? null : idOf(at.start.run),
+    });
   }
 
-  // Where the edit the gate just allowed will land, for `input` to record.
-  var pending = null;
+  // a composition cannot be cancelled, so the browser writes and we read the
+  // run back afterwards; this is the run it started in
+  var composing = null;
+
+  root.addEventListener("compositionstart", function () {
+    var selection = window.getSelection();
+    composing =
+      selection === null || selection.rangeCount === 0
+        ? null
+        : runOf(selection.getRangeAt(0).startContainer);
+  });
+
+  root.addEventListener("compositionend", function () {
+    var run = composing;
+    composing = null;
+    if (!odr.editing.isEnabled()) {
+      return;
+    }
+    var selection = window.getSelection();
+    var landed =
+      selection === null || selection.rangeCount === 0
+        ? null
+        : runOf(selection.getRangeAt(0).startContainer);
+    var target = landed !== null ? landed : run;
+    if (target === null) {
+      odr.onError(9, "an edit landed where no operation can name it");
+      return;
+    }
+    // whatever the browser built inside the run, its text is the operation
+    perform(setRunText(target, target.textContent));
+  });
 
   root.addEventListener("beforeinput", function (event) {
-    pending = null;
-    var at = target(event);
+    var type = event.inputType;
+    var at = rangeOf(event);
+
     if (!odr.editing.isEnabled()) {
       refuse(event, "readOnly", at);
       return;
     }
-    if (!textual[event.inputType]) {
-      refuse(event, named[event.inputType] || "unsupportedEdit", at);
+
+    if (type === "historyUndo" || type === "historyRedo") {
+      event.preventDefault();
+      if (type === "historyUndo") {
+        odr.editing.undo();
+      } else {
+        odr.editing.redo();
+      }
       return;
     }
-    // Its own stack is what the browser replays; there is nothing to address.
-    if (event.inputType === "historyUndo" || event.inputType === "historyRedo") {
+
+    // mid-composition and unstoppable; `compositionend` reconciles it
+    if (type === "insertCompositionText" || composing !== null) {
       return;
     }
-    if (at.run === null) {
+
+    if (at === null) {
       refuse(event, "range", at);
       return;
     }
-    pending = at.run;
-    if (event.inputType === "insertFromPaste") {
-      // Whatever the clipboard holds, one run takes plain text on one line.
-      var text = event.dataTransfer
+
+    if (type === "insertParagraph") {
+      var split = splitAt(at);
+      if (split === null) {
+        refuse(event, "range", at);
+        return;
+      }
+      event.preventDefault();
+      restore(split);
+      return;
+    }
+
+    if (type === "insertFromPaste") {
+      var pasted = event.dataTransfer
         ? event.dataTransfer.getData("text/plain")
         : null;
-      if (text === null) {
+      if (pasted === null) {
         refuse(event, "unsupportedEdit", at);
-      } else if (/[\r\n]/.test(text)) {
-        refuse(event, "newLine", at);
-      } else {
-        event.preventDefault();
-        document.execCommand("insertText", false, text);
+        return;
+      }
+      if (!paste(at, pasted)) {
+        refuse(event, "range", at);
+        return;
+      }
+      event.preventDefault();
+      return;
+    }
+
+    var text = replacing[type];
+    if (text === undefined) {
+      refuse(event, named[type] || "unsupportedEdit", at);
+      return;
+    }
+
+    var covering = extending[type] === undefined
+        ? at
+        : extendForDelete(at, extending[type]);
+    if (covering === null) {
+      // nothing to take: the key does nothing rather than being refused
+      event.preventDefault();
+      return;
+    }
+
+    var caret = replaceRange(covering, text(event));
+    if (caret === null) {
+      refuse(event, "range", at);
+      return;
+    }
+    event.preventDefault();
+    restore(caret);
+  });
+
+  /// A paste is its lines: the first replaces the selection, each one after
+  /// it opens a paragraph.
+  function paste(at, pasted) {
+    var lines = pasted.split(/\r\n|\r|\n/);
+    var caret = replaceRange(at, lines[0]);
+    if (caret === null) {
+      return false;
+    }
+    for (var i = 1; i < lines.length; ++i) {
+      caret = splitAt({ start: caret, end: caret });
+      if (caret !== null && lines[i] !== "") {
+        caret = replaceRange({ start: caret, end: caret }, lines[i]);
+      }
+      if (caret === null) {
+        // the lines before this one stand; a host replays onto a fresh decode
+        return false;
       }
     }
-  });
-
-  /// The run the caret sits in, for an edit no `beforeinput` announced.
-  function selectedRun() {
-    var selection = window.getSelection();
-    return selection === null || selection.rangeCount === 0
-      ? null
-      : runOf(selection.getRangeAt(0).startContainer);
+    restore(caret);
+    return true;
   }
 
-  // `input` is the browser saying it applied an edit, which a script rewriting
-  // the page never raises - so a search highlighting nine matches leaves the
-  // log alone. A `MutationObserver` could not tell the two apart.
-  root.addEventListener("input", function () {
-    if (!odr.editing.isEnabled()) {
-      return;
-    }
-    // The caret first: the browser has just put it where the edit landed. A
-    // `beforeinput` whose edit changed nothing raises no `input`, so what it
-    // left in `pending` may be a run ago - it is the fallback, not the answer.
-    var run = selectedRun();
-    if (run === null) {
-      run = pending;
-    }
-    pending = null;
-    if (run === null) {
-      // The gate refuses an edit it cannot name, so this is a hole in it: a
-      // WebView that raised no `beforeinput`, or a composition it cannot stop.
-      odr.onError(9, "an edit landed where no operation can name it");
-      return;
-    }
-    modified[idOf(run)] = run;
-    odr.editing.changed();
-  });
+  // ------------------------------------------------------------------ mode
 
   odr.editing.attach({
     enable: function () {
@@ -180,8 +901,35 @@
       root.removeAttribute("contenteditable");
     },
     operations: operations,
+    canUndo: function () {
+      return done.length > 0;
+    },
+    canRedo: function () {
+      return undone.length > 0;
+    },
+    undo: function () {
+      if (done.length === 0) {
+        return false;
+      }
+      var step = done.pop();
+      step.revert();
+      undone.push(step);
+      odr.editing.changed();
+      return true;
+    },
+    redo: function () {
+      if (undone.length === 0) {
+        return false;
+      }
+      var step = undone.pop();
+      step.apply();
+      done.push(step);
+      odr.editing.changed();
+      return true;
+    },
     committed: function () {
-      modified = {};
+      done.length = 0;
+      undone.length = 0;
     },
   });
 })();

--- a/src/odr/internal/odf/odf_document.cpp
+++ b/src/odr/internal/odf/odf_document.cpp
@@ -663,6 +663,17 @@ public:
     return new_id;
   }
 
+  [[nodiscard]] ElementIdentifier
+  element_append_text(const ElementIdentifier element_id,
+                      const std::string &text) const override {
+    pugi::xml_node node = get_node(element_id);
+    const NodeSpan span = write_text_nodes(node, {}, text);
+    const auto &[new_id, unused_element, unused_text] =
+        m_registry->create_text_element(span.first, span.last);
+    m_registry->append_child(element_id, new_id);
+    return new_id;
+  }
+
   void element_remove(const ElementIdentifier element_id) const override {
     TreeEditor(*m_registry).remove(element_id);
   }

--- a/src/odr/internal/ooxml/text/ooxml_text_document.cpp
+++ b/src/odr/internal/ooxml/text/ooxml_text_document.cpp
@@ -276,6 +276,17 @@ public:
     return new_id;
   }
 
+  [[nodiscard]] ElementIdentifier
+  element_append_text(const ElementIdentifier element_id,
+                      const std::string &text) const override {
+    pugi::xml_node node = get_node(element_id);
+    const NodeSpan span = write_text_nodes(node, {}, text);
+    const auto &[new_id, unused_element, unused_text] =
+        m_registry->create_text_element(span.first, span.last);
+    m_registry->append_child(element_id, new_id);
+    return new_id;
+  }
+
   void element_remove(const ElementIdentifier element_id) const override {
     TreeEditor(*m_registry).remove(element_id);
   }

--- a/test/browser/text/README.md
+++ b/test/browser/text/README.md
@@ -1,6 +1,6 @@
 # text editing checks
 
-What the emitted text editor allows and what it refuses can only be seen in a
+What the emitted text editor does and what it refuses can only be seen in a
 browser, so these are run by hand rather than by `odr_test`.
 
 ```bash
@@ -13,35 +13,45 @@ open http://localhost:8734/tests.html
 what runs is the file the library embeds. `editing.js` goes first, as the
 library writes it.
 
-- **`tests.html`** — the mode makes the **whole view** editable, and the editor
-  refuses what it cannot replay. The fixture holds the shapes that decision
-  turns on: two runs beside each other, a run under a link, a run under a
-  style-only wrapper, and a paragraph holding a picture and no run at all. The
-  checks drive `beforeinput`, which is what a browser fires before it changes
-  anything, so a prevented one is an edit that never happened.
+- **`tests.html`** — the editor **owns the edit**: it cancels what the browser
+  was about to do and splices the page itself, so the markup stays what the
+  renderer wrote and every change has an operation behind it. The fixture holds
+  the shapes that turns on: two runs beside each other, a run under a link, a
+  run under a style-only wrapper, a paragraph holding a picture and no run at
+  all, and the `<wbr>` / `<br>` line box the renderer ends every paragraph
+  with. The checks drive `beforeinput`, which is what a browser fires before it
+  changes anything.
 
 Why the checks look the way they do:
 
+- **`defaultPrevented` no longer says whether an edit was taken.** The editor
+  cancels the event either way — once because it is doing the edit itself, once
+  because it is refusing. So `input()` answers `"taken"` or `"refused"` by
+  watching the refusal channel, and the cancelling is checked once on its own.
+- **The page is rebuilt between groups.** Every edit is a real edit, so a group
+  that ran before would decide what the next one starts from. `reset()` puts
+  the fixture back, clears the log and turns the mode on again.
 - **A synthetic `InputEvent` carries no target range.** `getTargetRanges()` is
   empty on an event the page constructs, so the editor falls back to the
-  selection — which is also what a browser lacking `getTargetRanges` gives it.
-  That is why each check sets the selection first.
+  selection — which is also what a browser lacking `getTargetRanges` gives it,
+  and what an Android WebView is reported to give it. That is why each check
+  sets the selection first, and it is the path `extendForDelete` exists for: a
+  Backspace whose range the browser did not state is one character, or the
+  paragraph boundary the caret stands at.
+- **The word and line deletes are not extended.** Where a browser states no
+  range for `deleteWordBackward`, guessing where the word ends would take away
+  text the reader did not name, so nothing happens.
 - **The repeat suppression is part of the contract.** Two identical refusals
   within two seconds are one event ([`editing.md`](../../docs/design/editing.md)
-  decision 9), and a refusal is keyed by its run — so the two `newLine` checks
-  sit in different runs, and the one outside every run asserts the prevented
-  edit rather than a second event.
-- **The gate and the collection are driven apart.** `beforeinput` is what
-  refuses; `input` is what collects, because a script rewriting the page raises
-  none — which is how a search highlighting nine matches leaves the log alone.
-  No script can raise the pair the way a key does, so a check drives one or the
-  other.
+  decision 9), and a refusal is keyed by its run.
+- **The log is checked, not only the page.** What a save hands to
+  `Document::edit` is the point of the editor, so each group asserts the
+  operations as well as the text: which ops, in which order, naming which ids.
+  `document_edit_test.cpp` replays the same shapes in C++, which is what keeps
+  the two sides from drifting apart.
 
 **Scripted editing is not the editing a reader does, which is why no check uses
-`execCommand`.** Chrome's scripted path differs from its trusted-input path
-twice over: it raises no cancelable `beforeinput`, so
-`execCommand("insertParagraph")` splits a paragraph the gate would have
-refused; and it dissolves a run whose whole text it replaces, leaving the new
-text outside every address. Trusted input does neither — a real Enter is
-refused, and typing over a whole run keeps the run, its address and its style.
-Both were checked by hand in a browser, and neither is reachable by a reader.
+`execCommand`.** Chrome's scripted path raises no cancelable `beforeinput`, so
+`execCommand("insertParagraph")` splits a paragraph without the editor ever
+seeing it. Trusted input does not; a real Enter goes through the gate. Checked
+by hand in a browser, and not reachable by a reader.

--- a/test/browser/text/tests.html
+++ b/test/browser/text/tests.html
@@ -12,28 +12,29 @@
   >
     <!-- A text document as `translate` writes one, cut down to the shapes the
          editor has to tell apart: runs beside each other, a run under a link,
-         a run under a style-only wrapper, and a paragraph holding a picture
-         and no run at all. -->
-    <div class="odr-text-flow">
+         a run under a style-only wrapper, a paragraph holding a picture and no
+         run at all, and the `<wbr>` / `<br>` line box the renderer ends every
+         paragraph with. The whole fixture is rebuilt before each group of
+         checks, because every edit is a real edit. -->
+    <div class="odr-text-flow" id="flow">
       <x-p data-odr-id="10" style="display:block"
         ><x-s data-odr-id="11">first run </x-s
         ><a href="https://x.example"
           ><x-s data-odr-id="12">a link</x-s></a
-        ><x-s data-odr-id="13"> and a tail</x-s></x-p
+        ><x-s data-odr-id="13"> and a tail</x-s><wbr></x-p
       >
       <x-p data-odr-id="20" style="display:block"
         ><x-s style="font-weight:bold"
           ><x-s data-odr-id="21">bold</x-s></x-s
-        ></x-p
+        ><wbr></x-p
       >
-      <x-p data-odr-id="30" style="display:block">
-        <img
+      <x-p data-odr-id="30" style="display:block"><x-s data-odr-id="31">third</x-s><wbr></x-p>
+      <x-p data-odr-id="40" style="display:block"><img
           alt=""
           width="16"
           height="16"
           src="data:image/gif;base64,R0lGODlhAQABAIAAAAAAAP///yH5BAEAAAAALAAAAAABAAEAAAIBRAA7"
-        />
-      </x-p>
+        /><wbr></x-p>
     </div>
 
     <!-- Not editable: the report is the harness, not the document. -->
@@ -45,19 +46,62 @@
     <script>
       var refusals = [];
       var errors = [];
+      var changes = [];
       odr.onEditRefused = function (event) {
         refusals.push(event.reason + " " + event.code);
       };
       odr.onError = function (code, message) {
         errors.push(code + " " + message);
       };
+      odr.onEditChange = function (event) {
+        changes.push(event);
+      };
+
+      var flow = document.getElementById("flow");
+      // The page as the renderer wrote it, kept so each group starts from it.
+      var source = flow.innerHTML;
+
+      /// Puts the fixture and the log back, so each group starts from the
+      /// page the renderer wrote.
+      function reset() {
+        odr.editing.disable();
+        flow.innerHTML = source;
+        odr.editing.committed();
+        odr.editing.enable();
+        refusals = [];
+        errors = [];
+        changes = [];
+      }
 
       function run(id) {
         return document.querySelector('x-s[data-odr-id="' + id + '"]');
       }
+      function paragraph(id) {
+        return document.querySelector('x-p[data-odr-id="' + id + '"]');
+      }
       function ops() {
         return JSON.parse(odr.editing.getOperations()).ops;
       }
+      /// The text of every paragraph in the flow.
+      function texts() {
+        return Array.prototype.map
+          .call(flow.querySelectorAll("x-p[data-odr-id]"), function (p) {
+            return p.textContent;
+          })
+          .join("|");
+      }
+      /// The line box each paragraph ends with: `br` where it holds nothing,
+      /// `wbr` where it holds something, as a fresh render would write it.
+      function boxes() {
+        return Array.prototype.map
+          .call(flow.querySelectorAll("x-p[data-odr-id]"), function (p) {
+            return p.lastChild === null
+              ? "-"
+              : p.lastChild.nodeName.toLowerCase();
+          })
+          .join(" ");
+      }
+
       /// Puts the caret or a selection where the next edit lands. A synthetic
       /// `InputEvent` carries no target range, so the editor reads the
       /// selection - which is what a browser with no `getTargetRanges` does.
@@ -72,10 +116,21 @@
         selection.removeAllRanges();
         selection.addRange(range);
       }
-      /// Whether the editor refused the edit. `beforeinput` is what the
-      /// browser fires before it changes anything, so a prevented one is an
-      /// edit that never happened.
+      /// Selects from an offset in one run's text to an offset in another's.
+      function selectRuns(fromId, fromOffset, toId, toOffset) {
+        select(
+          run(fromId).firstChild,
+          fromOffset,
+          run(toId).firstChild,
+          toOffset
+        );
+      }
+      /// `"taken"` where the editor did the edit itself, `"refused"` where it
+      /// said no. Both cancel the `beforeinput`, so the refusal channel is
+      /// what tells them apart, not `defaultPrevented`.
+      var prevented = null;
       function input(type, data) {
+        var before = refusals.length;
         var event = new InputEvent("beforeinput", {
           inputType: type,
           data: data === undefined ? null : data,
@@ -83,74 +138,235 @@
           cancelable: true,
         });
         document.body.dispatchEvent(event);
-        return event.defaultPrevented;
+        prevented = event.defaultPrevented;
+        return refusals.length > before ? "refused" : "taken";
+      }
+      /// Where the caret sits afterwards, as `<run id>:<offset>`.
+      function caret() {
+        var selection = window.getSelection();
+        if (selection === null || selection.rangeCount === 0) {
+          return "none";
+        }
+        var at = selection.getRangeAt(0);
+        var holder =
+          at.startContainer.nodeType === 1
+            ? at.startContainer
+            : at.startContainer.parentElement;
+        var run = holder.closest("x-s[data-odr-id]");
+        return run === null
+          ? "outside:" + at.startOffset
+          : run.getAttribute("data-odr-id") + ":" + at.startOffset;
       }
 
-      var first = run(11);
-      var tail = run(13);
+      // ---------------------------------------------------------- the mode
 
       check("the mode is off to start with", odr.editing.isEnabled() === false);
-      select(first.firstChild, 3);
-      check("and refuses an edit", input("insertText", "x") === true);
+      select(run(11).firstChild, 3);
+      check("and refuses an edit", input("insertText", "x") === "refused");
       check("saying the document is read-only", refusals.pop() === "readOnly 5");
+      check("with nothing changed", texts().indexOf("first run ") === 0);
+
+      check(
+        "and cancelled what the browser was going to do",
+        prevented === true
+      );
 
       check("the mode turns on", odr.editing.enable() === true);
       check(
         "and the whole view is editable, not a run of it",
         document.body.getAttribute("contenteditable") === "true" &&
-          first.getAttribute("contenteditable") === null
+          run(11).getAttribute("contenteditable") === null
       );
 
-      select(first.firstChild, 3);
-      check("typing inside a run is allowed", input("insertText", "x") === false);
-      select(first.firstChild, 0, first.firstChild, 5);
-      check("so is replacing a stretch of it", input("insertText", "x") === false);
-      select(first.firstChild, 3);
-      check("and so is a backspace", input("deleteContentBackward") === false);
+      // ------------------------------------------------- inside one run
 
-      refusals = [];
-      select(first.firstChild, 3);
-      check("a new line is refused", input("insertParagraph") === true);
-      check("by the name the reader knows", refusals.pop() === "newLine 1");
-      select(tail.firstChild, 3);
-      check("and so is a soft one", input("insertLineBreak") === true);
-      check("under the same reason", refusals.pop() === "newLine 1");
+      reset();
+      select(run(11).firstChild, 5);
+      check("typing inside a run is taken", input("insertText", "X") === "taken");
+      check("with the browser stopped from doing it too", prevented === true);
+      check("and the editor wrote it", run(11).textContent === "firstX run ");
+      check("leaving the caret after it", caret() === "11:6");
       check(
-        "a refusal says which run it was in",
-        input("insertParagraph") === true && refusals.length === 0
+        "as one setText naming the run",
+        ops().length === 1 &&
+          ops()[0].op === "setText" &&
+          ops()[0].id === 11 &&
+          ops()[0].text === "firstX run "
       );
 
-      check("a bold toggle is refused", input("formatBold") === true);
-      check("as an edit we cannot replay", refusals.pop() === "unsupportedEdit 7");
-      check("so is a list", input("insertOrderedList") === true);
-      refusals = [];
+      select(run(11).firstChild, 6);
+      input("insertText", "Y");
+      check("a second keystroke folds into the same op", ops().length === 1);
+      check("carrying the text the run ends at", ops()[0].text === "firstXY run ");
 
-      // The address is per run, so an edit has to land in one.
-      select(first.firstChild, 3, tail.firstChild, 4);
-      check("an edit across two runs is refused", input("insertText", "x") === true);
-      check("because no op could name it", refusals.pop() === "range 8");
+      selectRuns(11, 0, 11, 5);
+      check("replacing a stretch is taken", input("insertText", "F") === "taken");
+      check("and the run holds it", run(11).textContent === "FXY run ");
 
-      var picture = document.querySelectorAll("x-p")[2];
-      select(picture, 0, picture, picture.childNodes.length);
+      select(run(11).firstChild, 1);
+      check("so is a backspace", input("deleteContentBackward") === "taken");
+      check("which took the character", run(11).textContent === "XY run ");
+
+      // ------------------------------------------------- across two runs
+
+      reset();
+      selectRuns(11, 5, 13, 4);
       check(
-        "an edit where there is no run is refused too",
-        input("deleteContentBackward") === true
+        "an edit across two runs is taken",
+        input("insertText", "-") === "taken"
       );
       check(
-        "a paragraph's own address does not make it a run",
-        picture.getAttribute("data-odr-id") === "30" && refusals.pop() === "range 8"
+        "the two ends join and what lay between goes",
+        texts() === "first- a tail|bold|third|"
+      );
+      check("the caret sits where the text went in", caret() === "11:6");
+      var across = ops();
+      check(
+        "as setText on each end and a removeElement between",
+        across.length === 3 &&
+          across[0].op === "setText" &&
+          across[0].id === 11 &&
+          across[1].op === "removeElement" &&
+          across[1].id === 12 &&
+          across[2].op === "setText" &&
+          across[2].id === 13
       );
 
-      // A run under a link and one under a style-only wrapper are still runs.
-      var linked = run(12);
-      select(linked.firstChild, 2);
-      check("a run inside a link takes a write", input("insertText", "x") === false);
-      var bold = run(21);
-      select(bold.firstChild, 2);
-      check("and so does one under a style wrapper", input("insertText", "x") === false);
+      // ------------------------------------------- across two paragraphs
 
-      // The clipboard is plain text on one line or nothing.
+      reset();
+      selectRuns(11, 5, 31, 2);
+      check(
+        "an edit across two paragraphs is taken",
+        input("insertText", "=") === "taken"
+      );
+      check(
+        "the paragraphs between it go, and its ends become one",
+        texts() === "first=ird|"
+      );
+      var merged = ops();
+      check(
+        "ending in a mergeParagraph",
+        merged[merged.length - 1].op === "mergeParagraph" &&
+          merged[merged.length - 1].paragraph === 10
+      );
+      check(
+        "and the paragraph between it is removed whole",
+        merged.some(function (op) {
+          return op.op === "removeElement" && op.id === 20;
+        })
+      );
+
+      // --------------------------------------------------------- Enter
+
+      reset();
+      select(run(11).firstChild, 5);
+      check("Enter is taken, not refused", input("insertParagraph") === "taken");
+      check(
+        "the paragraph splits where the caret was",
+        texts() === "first| run a link and a tail|bold|third|"
+      );
+      check("and the caret opens the new paragraph", caret().indexOf(":0") > 0);
+      var split = ops();
+      check(
+        "as a setText, an insertText and a splitParagraph",
+        split.length === 3 &&
+          split[0].op === "setText" &&
+          split[1].op === "insertText" &&
+          split[1].after === 11 &&
+          split[2].op === "splitParagraph" &&
+          split[2].paragraph === 10 &&
+          split[2].after === 11
+      );
+      check(
+        "the created elements carrying ids of their own",
+        split[1].id < 0 && split[2].id < 0 && split[1].id !== split[2].id
+      );
+      check("and both paragraphs ending in a line box", boxes() === "wbr wbr wbr wbr wbr");
+
+      reset();
+      select(run(13).firstChild, run(13).textContent.length);
+      input("insertParagraph");
+      check(
+        "Enter at the end of a paragraph cuts no run",
+        ops().length === 1 && ops()[0].op === "splitParagraph"
+      );
+      check("and leaves an empty one after it", texts() === "first run a link and a tail||bold|third|");
+      check("whose line box says it holds nothing", boxes() === "wbr br wbr wbr wbr");
+
+      check("typing into it opens a run", input("insertText", "new") === "taken");
+      check("which the log states by its parent", ops()[1].op === "insertText" && ops()[1].parent < 0);
+      check("and the page holds the text", texts() === "first run a link and a tail|new|bold|third|");
+      check("with the line box back to holding something", boxes() === "wbr wbr wbr wbr wbr");
+
+      // ------------------------------------- Backspace at a paragraph start
+
+      reset();
+      select(run(21).firstChild, 0);
+      check(
+        "Backspace at the start of a paragraph is taken",
+        input("deleteContentBackward") === "taken"
+      );
+      check(
+        "and the paragraph joins the one before it",
+        texts() === "first run a link and a tailbold|third|"
+      );
+      check(
+        "as one mergeParagraph",
+        ops().length === 1 &&
+          ops()[0].op === "mergeParagraph" &&
+          ops()[0].paragraph === 10
+      );
+
+      // ------------------------------------------------------ undo / redo
+
+      reset();
+      check("nothing to take back to start with", odr.editing.undo() === false);
+      select(run(11).firstChild, 5);
+      input("insertText", "Z");
+      check("an edit can be taken back", odr.editing.undo() === true);
+      check("and the run is what it was", run(11).textContent === "first run ");
+      check("with the log empty", ops().length === 0);
+      check("redo puts it back", odr.editing.redo() === true);
+      check("text and all", run(11).textContent === "firstZ run " && ops().length === 1);
+
+      reset();
+      select(run(11).firstChild, 5);
+      input("insertParagraph");
+      check("a split can be taken back", odr.editing.undo() === true);
+      check(
+        "and the paragraph is one again",
+        texts() === "first run a link and a tail|bold|third|"
+      );
+      check("undo goes on to the run that was cut", odr.editing.undo() === true);
+      check("and to the run that was shortened", odr.editing.undo() === true);
+      check("until there is nothing left", odr.editing.undo() === false);
+      check("with the page as the renderer wrote it", texts() === "first run a link and a tail|bold|third|");
+      check("and the log empty", ops().length === 0);
+
+      reset();
+      select(run(21).firstChild, 0);
+      input("deleteContentBackward");
+      check("a merge can be taken back", odr.editing.undo() === true);
+      check(
+        "and both paragraphs are back",
+        texts() === "first run a link and a tail|bold|third|"
+      );
+      check("with their line boxes", boxes() === "wbr wbr wbr wbr");
+
+      reset();
+      select(run(11).firstChild, 5);
+      input("insertText", "Q");
+      odr.editing.undo();
+      check("a host is told undo is spent", changes.pop().canUndo === false);
+      select(run(11).firstChild, 5);
+      input("insertText", "R");
+      check("and a fresh edit drops what redo held", odr.editing.redo() === false);
+
+      // ----------------------------------------------------------- paste
+
       if (typeof DataTransfer === "function") {
+        reset();
         var clipboard = new DataTransfer();
         clipboard.setData("text/plain", "two\nlines");
         var pasted = new InputEvent("beforeinput", {
@@ -159,58 +375,91 @@
           bubbles: true,
           cancelable: true,
         });
-        select(tail.firstChild, 2);
+        select(run(11).firstChild, 5);
         document.body.dispatchEvent(pasted);
+        check("pasting two lines is taken", pasted.defaultPrevented === true);
         check(
-          "pasting two lines is refused",
-          pasted.defaultPrevented === true && refusals.pop() === "newLine 1"
+          "and the second opens a paragraph of its own",
+          texts() === "firsttwo|lines run a link and a tail|bold|third|"
         );
       }
 
-      // The collection half. Nothing scripted edits the way a key does -
-      // `execCommand` raises no `beforeinput` and dissolves a run whose whole
-      // text it replaces, neither of which trusted input does - so the two
-      // halves are driven apart: `beforeinput` above for the gate, and here
-      // the text change plus the `input` the browser raises after it.
-      check("nothing is collected yet", ops().length === 0);
-      select(first.firstChild, 3);
-      first.firstChild.data = "edited in the browser";
-      document.body.dispatchEvent(new Event("input", { bubbles: true }));
+      // ------------------------------------------------------- refusals
+
+      reset();
+      check("a bold toggle is refused", input("formatBold") === "refused");
+      check("as an edit we cannot replay", refusals.pop() === "unsupportedEdit 7");
+      check("so is a list", input("insertOrderedList") === "refused");
+      refusals = [];
+
+      select(run(11).firstChild, 3);
+      check("a soft line break is refused", input("insertLineBreak") === "refused");
+      check("by the name the reader knows", refusals.pop() === "newLine 1");
+
+      var picture = paragraph(40);
+      select(picture, 0, picture, picture.childNodes.length);
       check(
-        "an allowed edit reaches the log as one setText",
-        ops().length === 1 &&
-          ops()[0].op === "setText" &&
-          ops()[0].id === 11 &&
-          ops()[0].text === "edited in the browser"
+        "an edit over a paragraph holding no run is refused",
+        input("deleteContentBackward") === "refused"
+      );
+      check("because no operation could name it", refusals.pop() === "range 8");
+      check("and the picture is still there", picture.querySelector("img") !== null);
+
+      selectRuns(31, 0, 31, 2);
+      check(
+        "a range reaching over a picture is refused",
+        (function () {
+          select(run(31).firstChild, 0, picture, 0);
+          return input("insertText", "x") === "refused";
+        })()
+      );
+      check("under the same reason", refusals.pop() === "range 8");
+
+      // A run under a link and one under a style-only wrapper are still runs.
+      reset();
+      select(run(12).firstChild, 2);
+      check("a run inside a link takes a write", input("insertText", "x") === "taken");
+      check("and keeps its link", run(12).parentElement.tagName === "A");
+      select(run(21).firstChild, 2);
+      check("and so does one under a style wrapper", input("insertText", "x") === "taken");
+      check("keeping the wrapper", run(21).parentElement.getAttribute("style") === "font-weight:bold");
+
+      // A split inside a wrapper leaves the wrapper in both halves.
+      reset();
+      select(run(21).firstChild, 2);
+      input("insertParagraph");
+      check(
+        "a split inside a style wrapper cuts the wrapper too",
+        texts() === "first run a link and a tail|bo|ld|third|"
+      );
+      var tail = flow.querySelectorAll("x-p[data-odr-id]")[2];
+      check(
+        "so the tail keeps the style it had",
+        tail.querySelector("x-s[style]") !== null
       );
 
-      // A script rewriting the page raises no `input`, so the log stays as it
-      // was: nine highlights are not nine edits.
-      var hits = odr.search("edited");
-      check("a search finds its matches", hits > 0 && document.querySelectorAll("mark").length === hits);
+      // ---------------------------------------------- what is not an edit
+
+      // A script rewriting the page is not a reader typing, so the log stays
+      // as it was: nine highlights are not nine edits.
+      reset();
+      select(run(11).firstChild, 5);
+      input("insertText", "E");
+      var hits = odr.search("first");
+      check("a search finds its matches", hits > 0);
       check("and leaves the log alone", ops().length === 1);
       odr.resetSearch();
       check("as does clearing it", ops().length === 1);
 
-      // What a WebView raising `input` and no `beforeinput` looks like: the
-      // editor cannot name where it landed, and says so rather than dropping
-      // it.
-      var picture = document.querySelectorAll("x-p")[2];
-      select(picture, 0);
-      document.body.dispatchEvent(new Event("input", { bubbles: true }));
-      check(
-        "an edit the gate never saw is reported rather than lost",
-        errors.length === 1 && errors[0].indexOf("9 ") === 0
-      );
-      check("and it reaches no operation", ops().length === 1);
-
       odr.editing.committed();
       check("committing clears the log", ops().length === 0);
+      check("and undo with it", odr.editing.undo() === false);
       odr.editing.disable();
       check(
-        "and turning the mode off puts the view back",
+        "turning the mode off puts the view back",
         document.body.getAttribute("contenteditable") === null
       );
+      check("and nothing reported an error", errors.length === 0);
     </script>
   </body>
 </html>

--- a/test/src/document_edit_test.cpp
+++ b/test/src/document_edit_test.cpp
@@ -609,3 +609,27 @@ TEST(DocumentEdit, a_paragraph_edit_refuses_another_documents_element) {
   EXPECT_THROW((void)document.split_paragraph(paragraph, Element()),
                std::invalid_argument);
 }
+
+/// The paragraph Enter just made holds no run to sit beside, so the operation
+/// names the paragraph itself.
+TEST(DocumentEdit, a_run_is_appended_into_a_paragraph_that_holds_none) {
+  const Document document = two_paragraph_text();
+
+  document.edit(ops(R"({"op":"insertParagraph","after":)" +
+                    id_of(paragraph_at(document, 0)) + R"(,"id":-1},)" +
+                    R"({"op":"insertText","parent":-1,"text":"typed",)"
+                    R"("id":-2})"));
+
+  EXPECT_EQ(paragraph_texts(document),
+            (std::vector<std::string>{"one two three", "typed", "second"}));
+}
+
+TEST(DocumentEdit, an_insert_naming_a_parent_and_a_run_to_sit_beside_refuses) {
+  const Document document = two_paragraph_text();
+
+  EXPECT_THROW(document.edit(ops(
+                   R"({"op":"insertText","parent":)" +
+                   id_of(paragraph_at(document, 0)) + R"(,"after":)" +
+                   id_of(run_at(document, 0, 0)) + R"(,"text":"x","id":-1})")),
+               std::invalid_argument);
+}


### PR DESCRIPTION
🤖 Generated with [Claude Code](https://claude.com/claude-code)

Fourth of five; #874 is merged, so this now sits on main. See
`docs/design/document-editing.md` decisions 6 and 6b.

## What this one does

The editor **cancels what the browser was about to do and splices the page
itself**, so the markup stays what the renderer wrote and every change has an
operation behind it.

Reading the run back afterwards only worked while an edit stayed inside one
run. Contenteditable's answer to a selection spanning two paragraphs is
browser-specific — a `<div>` wrapper here, a merged `<b>` there — and maps onto
nothing in the element tree.

So a reader can now:

- type, replace and delete **across runs and across paragraphs**;
- press **Enter** to split a paragraph, keeping the formatting on both sides;
- press **Backspace at the start** of one to merge it into the paragraph before;
- **paste plain text** over as many lines as it holds.

## Undo and redo are the editor's

Cancelling every edit leaves the browser's own stack empty, so undo had to come
with this. Each step holds the operations it puts on the wire and the two
halves of taking it back, so `canUndo` and the chord agree at last and a host's
undo button is live. One `beforeinput` is one step.

## Two things the browser does not always state

- **A delete whose range it left out** is one character, in the direction the
  key names — or, at the start of a paragraph, the boundary itself, which
  merges and takes no character. A **word or line** delete is *not* guessed at:
  guessing where a word ends takes away text the reader did not name.
- **A composition cannot be cancelled**, so the editor lets it finish and reads
  the run back on `compositionend`. With the page as the model there is nothing
  to reconcile — the run's text is the operation.

`insertText` gains a `parent` form for the paragraph Enter just made, which
holds no run to sit beside; `Document::append_text` is the same in C++, on the
document rather than on a handle like the other structural edits.

## Checks

`test/browser/text/tests.html` — 48 checks, driving `beforeinput` and asserting
both the page and the log. `defaultPrevented` no longer says whether an edit
was taken, because the editor cancels either way, so the checks read the
refusal channel instead. Run headless:
`test/browser/text/serve` then Chrome `--headless --dump-dom`.
