### PR TITLE
fix(html): the envelope states the version the library takes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,10 @@ The release run heads these entries with the version and opens a fresh
 
 ## Unreleased
 
+- **Fix**: `odr.editing.getOperations()` and `odr.generateDiff()` stated
+  `"version": 1` while `Document::edit` takes 2, so every save the browser
+  produced was refused. A check page now asserts the version.
+
 - A `.pptx` can be edited and saved: every text operation a `.docx` takes, and
   a save that writes the slide parts back into the package. Its
   `FileTypeCapabilities` now states `edit` and `save`.

--- a/src/odr/internal/html/frontend/editing.js
+++ b/src/odr/internal/html/frontend/editing.js
@@ -162,9 +162,11 @@
       });
     },
 
-    /// The envelope a host hands to `Document::edit` before saving.
+    /// The envelope a host hands to `Document::edit` before saving. The
+    /// version is what the library takes; a check page asserts it, because
+    /// nothing else here would notice the two drifting apart.
     getOperations: function () {
-      return JSON.stringify({ version: 1, ops: operations() });
+      return JSON.stringify({ version: 2, ops: operations() });
     },
 
     /// False where no editor has an edit to take back.

--- a/test/browser/text/tests.html
+++ b/test/browser/text/tests.html
@@ -451,6 +451,11 @@
       odr.resetSearch();
       check("as does clearing it", ops().length === 1);
 
+      check(
+        "the envelope states the version the library takes",
+        JSON.parse(odr.editing.getOperations()).version === 2
+      );
+
       odr.editing.committed();
       check("committing clears the log", ops().length === 0);
       check("and undo with it", odr.editing.undo() === false);


### PR DESCRIPTION
🤖 Generated with [Claude Code](https://claude.com/claude-code)

**The browser-produced save has been broken since #872 merged.**

`odr.editing.getOperations()` — and `odr.generateDiff()`, which every app and
the wasm package call — stated `"version": 1`. `Document::edit` has taken 2
since #872. So every save a reader triggered from a rendered page threw
`std::invalid_argument("unsupported edit version")` before a single operation
was read.

One line. The rest is the guard.

## Why nothing caught it

- The browser check pages parse `getOperations()` and assert the **operations**
  — which ops, in which order, naming which ids — and never the envelope around
  them.
- `wasm/tests/edit.test.mjs` and `document_edit_test.cpp` both write their own
  envelope by hand, with `version: 2` spelled out.

So both sides were tested and the seam between them was not. That is exactly
the JS/C++ drift decision 7 of `editing.md` names as architecture A's main
risk.

A check on each page that produces an envelope now asserts the version, which
is the one thing neither side would notice drifting.
