### PR TITLE
feat(spreadsheet): read the formula of every cell of a shared group

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,10 @@ The release run heads these entries with the version and opens a fresh
 
 ## Unreleased
 
+- A shared formula in an `.xlsx` is read for every cell of its group, not only
+  the master that spells it: `SheetCell::value().formula()` answers a member
+  with the expression moved to it, and `#REF!` where it moved off the grid.
+
 - `TablePosition::try_to_column_num` / `try_to_row_num` read a column or row
   spelling as an optional instead of throwing, and without case. **Fix**:
   `to_column_num` wrapped silently past the index range instead of refusing.

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -188,7 +188,9 @@ set(ODR_SOURCE_FILES
         "src/odr/internal/csv/csv_file.cpp"
         "src/odr/internal/csv/csv_util.cpp"
 
+        "src/odr/internal/formula/formula_ast.cpp"
         "src/odr/internal/formula/formula_parser.cpp"
+        "src/odr/internal/formula/formula_writer.cpp"
 
         "src/odr/internal/html/common.cpp"
         "src/odr/internal/html/document.cpp"

--- a/docs/design/spreadsheet-editing.md
+++ b/docs/design/spreadsheet-editing.md
@@ -467,6 +467,12 @@ Each step ships on its own. "Both" means `.ods` and `.xlsx`.
    where the two part. A named expression, a reference over several sheets and
    a spelling past the grid (`A0`) stay opaque names; a formula that does not
    parse answers nothing.
+
+   A writer and a `shift` over the tree come with it, which is what makes an
+   ooxml shared formula readable: a group spells its expression on the master
+   alone ([ECMA-376] 18.3.1.40), so a member now reads it moved by the offset
+   between the two cells, `#REF!` where that leaves the grid. An array
+   formula's members carry no `<f>` at all and still report none.
 2. Reference extraction → dependency graph per document; `Document` answers
    "which cells depend on this position".
 3. View: a commit marks dependents stale (a class, the host is told); the

--- a/src/odr/internal/formula/formula_ast.cpp
+++ b/src/odr/internal/formula/formula_ast.cpp
@@ -1,0 +1,54 @@
+#include <odr/internal/formula/formula_ast.hpp>
+
+#include <limits>
+#include <variant>
+
+namespace odr::internal::formula {
+
+namespace {
+
+constexpr std::int64_t index_limit = std::numeric_limits<std::uint32_t>::max();
+
+[[nodiscard]] bool shift_coordinate(std::optional<Coordinate> &coordinate,
+                                    const std::int64_t by) {
+  if (!coordinate.has_value() || coordinate->absolute) {
+    return true;
+  }
+  const std::int64_t moved = static_cast<std::int64_t>(coordinate->index) + by;
+  if (moved < 0 || moved > index_limit) {
+    return false;
+  }
+  coordinate->index = static_cast<std::uint32_t>(moved);
+  return true;
+}
+
+[[nodiscard]] bool shift_cell(CellReference &cell, const std::int64_t columns,
+                              const std::int64_t rows) {
+  return shift_coordinate(cell.column, columns) &&
+         shift_coordinate(cell.row, rows);
+}
+
+} // namespace
+
+} // namespace odr::internal::formula
+
+namespace odr::internal {
+
+void formula::shift(Node &node, const std::int64_t columns,
+                    const std::int64_t rows) {
+  if (auto *cell = std::get_if<CellReference>(&node.content)) {
+    if (!shift_cell(*cell, columns, rows)) {
+      node.content = ErrorLiteral{ErrorType::reference};
+    }
+  } else if (auto *range = std::get_if<RangeReference>(&node.content)) {
+    if (!shift_cell(range->from, columns, rows) ||
+        !shift_cell(range->to, columns, rows)) {
+      node.content = ErrorLiteral{ErrorType::reference};
+    }
+  }
+  for (Node &child : node.children) {
+    shift(child, columns, rows);
+  }
+}
+
+} // namespace odr::internal

--- a/src/odr/internal/formula/formula_ast.hpp
+++ b/src/odr/internal/formula/formula_ast.hpp
@@ -168,4 +168,8 @@ struct Node final {
   }
 };
 
+/// Moves every relative reference in @p node by (@p columns, @p rows). An
+/// absolute (`$`) axis stays, and one moved off the grid becomes `#REF!`.
+void shift(Node &node, std::int64_t columns, std::int64_t rows);
+
 } // namespace odr::internal::formula

--- a/src/odr/internal/formula/formula_parser.cpp
+++ b/src/odr/internal/formula/formula_parser.cpp
@@ -7,6 +7,7 @@
 
 #include <algorithm>
 #include <array>
+#include <cmath>
 #include <cstddef>
 #include <cstdlib>
 #include <string>
@@ -410,7 +411,8 @@ private:
     const std::string text(rest().substr(0, length));
     char *end = nullptr;
     const double value = std::strtod(text.c_str(), &end);
-    if (end != text.c_str() + text.size()) {
+    // an overflow answers infinity, which no formula spells
+    if (end != text.c_str() + text.size() || !std::isfinite(value)) {
       return {};
     }
     advance(length);

--- a/src/odr/internal/formula/formula_writer.cpp
+++ b/src/odr/internal/formula/formula_writer.cpp
@@ -1,0 +1,359 @@
+#include <odr/internal/formula/formula_writer.hpp>
+
+#include <odr/table_position.hpp>
+
+#include <odr/internal/util/string_util.hpp>
+
+#include <algorithm>
+#include <cstddef>
+#include <cstdint>
+#include <optional>
+#include <string_view>
+#include <variant>
+
+#include <fmt/format.h>
+
+namespace odr::internal::formula {
+
+namespace str = util::string;
+
+namespace {
+
+/// How tightly an operator binds, lowest first. A child binding less tightly
+/// than its parent needs the parenthesis the tree no longer carries.
+enum Precedence : std::uint8_t {
+  comparison,
+  concatenation,
+  additive,
+  multiplicative,
+  exponentiation,
+  sign,
+  percent,
+  reference,
+  primary,
+};
+
+Precedence precedence_of(const BinaryOperator op) {
+  switch (op) {
+  case BinaryOperator::equal:
+  case BinaryOperator::not_equal:
+  case BinaryOperator::less:
+  case BinaryOperator::less_equal:
+  case BinaryOperator::greater:
+  case BinaryOperator::greater_equal:
+    return Precedence::comparison;
+  case BinaryOperator::concat:
+    return Precedence::concatenation;
+  case BinaryOperator::add:
+  case BinaryOperator::subtract:
+    return Precedence::additive;
+  case BinaryOperator::multiply:
+  case BinaryOperator::divide:
+    return Precedence::multiplicative;
+  case BinaryOperator::power:
+    return Precedence::exponentiation;
+  case BinaryOperator::range:
+  case BinaryOperator::intersect:
+  case BinaryOperator::unite:
+    return Precedence::reference;
+  }
+  return Precedence::primary;
+}
+
+Precedence precedence_of(const Node &node) {
+  if (node.holds<BinaryOperation>()) {
+    return precedence_of(node.get<BinaryOperation>().op);
+  }
+  if (node.holds<UnaryOperation>()) {
+    return node.get<UnaryOperation>().op == UnaryOperator::percent
+               ? Precedence::percent
+               : Precedence::sign;
+  }
+  return Precedence::primary;
+}
+
+std::string_view spelling_of(const BinaryOperator op) {
+  switch (op) {
+  case BinaryOperator::add:
+    return "+";
+  case BinaryOperator::subtract:
+    return "-";
+  case BinaryOperator::multiply:
+    return "*";
+  case BinaryOperator::divide:
+    return "/";
+  case BinaryOperator::power:
+    return "^";
+  case BinaryOperator::concat:
+    return "&";
+  case BinaryOperator::equal:
+    return "=";
+  case BinaryOperator::not_equal:
+    return "<>";
+  case BinaryOperator::less:
+    return "<";
+  case BinaryOperator::less_equal:
+    return "<=";
+  case BinaryOperator::greater:
+    return ">";
+  case BinaryOperator::greater_equal:
+    return ">=";
+  case BinaryOperator::range:
+    return ":";
+  case BinaryOperator::intersect:
+    return "!";
+  case BinaryOperator::unite:
+    return "~";
+  }
+  return "+";
+}
+
+std::string_view spelling_of(const ErrorType type) {
+  switch (type) {
+  case ErrorType::null:
+    return "#NULL!";
+  case ErrorType::division:
+    return "#DIV/0!";
+  case ErrorType::value:
+    return "#VALUE!";
+  case ErrorType::reference:
+    return "#REF!";
+  case ErrorType::name:
+    return "#NAME?";
+  case ErrorType::number:
+    return "#NUM!";
+  case ErrorType::not_available:
+    return "#N/A";
+  }
+  return "#NULL!";
+}
+
+/// A quote inside a quoted run is written twice, which is how both syntaxes
+/// escape one.
+std::string quote(const std::string_view text, const char mark) {
+  std::string result(1, mark);
+  for (const char c : text) {
+    if (c == mark) {
+      result += mark;
+    }
+    result += c;
+  }
+  result += mark;
+  return result;
+}
+
+/// A sheet name keeps its quotes only where it needs them: one holding
+/// anything but a letter, a digit or `_`, or opening with a digit, is quoted.
+bool needs_quotes(const std::string_view name) {
+  return name.empty() || str::is_ascii_digit(name.front()) ||
+         !std::ranges::all_of(name, [](const char c) {
+           return str::is_ascii_letter_or_digit(c) || c == '_';
+         });
+}
+
+std::string spell_coordinate(const std::optional<Coordinate> &coordinate,
+                             const bool column) {
+  if (!coordinate.has_value()) {
+    return "";
+  }
+  return (coordinate->absolute ? "$" : "") +
+         (column ? TablePosition::to_column_string(coordinate->index)
+                 : TablePosition::to_row_string(coordinate->index));
+}
+
+class Writer final {
+public:
+  explicit Writer(const Syntax syntax) : m_syntax{syntax} {}
+
+  [[nodiscard]] std::string write(const Node &node) const {
+    return std::visit(
+        [&](const auto &content) { return write_content(content, node); },
+        node.content);
+  }
+
+private:
+  Syntax m_syntax{Syntax::ooxml};
+
+  [[nodiscard]] char separator() const {
+    return m_syntax == Syntax::opendocument ? ';' : ',';
+  }
+
+  /// The child, parenthesised where its operator binds less tightly than the
+  /// one above — or equally, on the right: `1-(2-3)` is not `1-2-3`.
+  [[nodiscard]] std::string nested(const Node &child, const Precedence parent,
+                                   const bool right) const {
+    const Precedence own = precedence_of(child);
+    if (own < parent || (right && own == parent)) {
+      return "(" + write(child) + ")";
+    }
+    return write(child);
+  }
+
+  [[nodiscard]] std::string write_content(const NumberLiteral &content,
+                                          const Node &) const {
+    return fmt::format("{}", content.value);
+  }
+
+  [[nodiscard]] std::string write_content(const StringLiteral &content,
+                                          const Node &) const {
+    return quote(content.value, '"');
+  }
+
+  [[nodiscard]] std::string write_content(const BooleanLiteral &content,
+                                          const Node &) const {
+    if (m_syntax == Syntax::opendocument) {
+      return content.value ? "TRUE()" : "FALSE()";
+    }
+    return content.value ? "TRUE" : "FALSE";
+  }
+
+  [[nodiscard]] std::string write_content(const ErrorLiteral &content,
+                                          const Node &) const {
+    return std::string(spelling_of(content.type));
+  }
+
+  [[nodiscard]] std::string write_content(const Missing &, const Node &) const {
+    return "";
+  }
+
+  [[nodiscard]] std::string write_content(const CellReference &content,
+                                          const Node &) const {
+    if (m_syntax == Syntax::opendocument) {
+      return "[" + locator(content, true) + "]";
+    }
+    return locator(content, true);
+  }
+
+  [[nodiscard]] std::string write_content(const RangeReference &content,
+                                          const Node &) const {
+    if (m_syntax == Syntax::opendocument) {
+      return "[" + locator(content.from, true) + ":" +
+             locator(content.to, true) + "]";
+    }
+    return locator(content.from, true) + ":" + locator(content.to, false);
+  }
+
+  [[nodiscard]] std::string write_content(const NameReference &content,
+                                          const Node &) const {
+    if (m_syntax == Syntax::opendocument) {
+      return "$$" + (needs_quotes(content.name) ? quote(content.name, '\'')
+                                                : content.name);
+    }
+    return qualifier(content.document, content.sheet, false) + content.name;
+  }
+
+  [[nodiscard]] std::string write_content(const FunctionCall &content,
+                                          const Node &node) const {
+    std::string result = content.name + "(";
+    for (std::size_t i = 0; i < node.children.size(); ++i) {
+      if (i > 0) {
+        result += separator();
+      }
+      result += write(node.children[i]);
+    }
+    return result + ")";
+  }
+
+  [[nodiscard]] std::string write_content(const UnaryOperation &content,
+                                          const Node &node) const {
+    const Node &operand = node.children.front();
+    if (content.op == UnaryOperator::percent) {
+      return nested(operand, Precedence::percent, false) + "%";
+    }
+    return (content.op == UnaryOperator::minus ? "-" : "+") +
+           nested(operand, Precedence::sign, false);
+  }
+
+  [[nodiscard]] std::string write_content(const BinaryOperation &content,
+                                          const Node &node) const {
+    const Precedence own = precedence_of(content.op);
+    // ooxml spells a union with the comma it also separates arguments with,
+    // so the parenthesis is what tells the two apart
+    if (m_syntax == Syntax::ooxml && content.op == BinaryOperator::unite) {
+      return "(" + write(node.children.front()) + "," +
+             write(node.children.back()) + ")";
+    }
+    const std::string_view spelling =
+        m_syntax == Syntax::ooxml && content.op == BinaryOperator::intersect
+            ? " "
+            : spelling_of(content.op);
+    return nested(node.children.front(), own, false) + std::string(spelling) +
+           nested(node.children.back(), own, true);
+  }
+
+  [[nodiscard]] std::string write_content(const ArrayLiteral &content,
+                                          const Node &node) const {
+    const char row_separator = m_syntax == Syntax::opendocument ? '|' : ';';
+    std::string result = "{";
+    for (std::size_t i = 0; i < node.children.size(); ++i) {
+      if (i > 0) {
+        result += content.columns != 0 && i % content.columns == 0
+                      ? row_separator
+                      : separator();
+      }
+      result += write(node.children[i]);
+    }
+    return result + "}";
+  }
+
+  /// The document and the sheet in front of a reference or a name.
+  [[nodiscard]] std::string
+  qualifier(const std::optional<std::string> &document,
+            const std::optional<std::string> &sheet,
+            const bool sheet_absolute) const {
+    if (m_syntax == Syntax::opendocument) {
+      std::string result;
+      if (document.has_value()) {
+        result += quote(*document, '\'') + "#";
+      }
+      if (sheet_absolute) {
+        result += "$";
+      }
+      if (sheet.has_value()) {
+        result += needs_quotes(*sheet) ? quote(*sheet, '\'') : *sheet;
+      }
+      return result;
+    }
+    std::string result;
+    if (document.has_value()) {
+      result += "[" + *document + "]";
+    }
+    if (sheet.has_value()) {
+      result += (needs_quotes(*sheet) ? quote(*sheet, '\'') : *sheet) + "!";
+    } else if (document.has_value()) {
+      // `[1]!Total` names the other workbook itself, with no sheet between
+      result += "!";
+    }
+    return result;
+  }
+
+  /// One corner of a reference. The second corner of an ooxml range drops a
+  /// qualifier the first already states.
+  [[nodiscard]] std::string locator(const CellReference &cell,
+                                    const bool qualified) const {
+    std::string coordinates =
+        spell_coordinate(cell.column, true) + spell_coordinate(cell.row, false);
+    if (m_syntax == Syntax::opendocument) {
+      return qualifier(cell.document, cell.sheet, cell.sheet_absolute) + "." +
+             coordinates;
+    }
+    if (!qualified) {
+      return coordinates;
+    }
+    return qualifier(cell.document, cell.sheet, cell.sheet_absolute) +
+           coordinates;
+  }
+};
+
+} // namespace
+
+} // namespace odr::internal::formula
+
+namespace odr::internal {
+
+std::string formula::to_string(const formula::Node &node,
+                               const formula::Syntax syntax) {
+  return formula::Writer(syntax).write(node);
+}
+
+} // namespace odr::internal

--- a/src/odr/internal/formula/formula_writer.hpp
+++ b/src/odr/internal/formula/formula_writer.hpp
@@ -1,0 +1,14 @@
+#pragma once
+
+#include <odr/internal/formula/formula_ast.hpp>
+#include <odr/internal/formula/formula_parser.hpp>
+
+#include <string>
+
+namespace odr::internal::formula {
+
+/// Writes @p node back in @p syntax, without the `of:=` prefix or the leading
+/// `=`. A parenthesis the precedence already states is dropped.
+[[nodiscard]] std::string to_string(const Node &node, Syntax syntax);
+
+} // namespace odr::internal::formula

--- a/src/odr/internal/ooxml/spreadsheet/AGENTS.md
+++ b/src/odr/internal/ooxml/spreadsheet/AGENTS.md
@@ -34,9 +34,14 @@ never evaluated**. `sheet_cell_value_type` derives number-vs-string from
 `c/@t` (default "n" → `float_number` when a `<v>` exists; dates/booleans/errors
 report `string`). `sheet_cell_value` adds what that leaves out — `<v>` parsed
 as a number where the type is one, and `<f>` as its own string. A shared
-formula writes its expression on the group's master, so a member's formula is
-**set and empty** rather than absent. Merged ranges from `mergeCells` land in
-the `SheetCell` side map as anchor `span` + `is_covered` flags at parse time.
+formula (18.3.1.40) writes its expression on the group's master alone, so a
+member is read **through the master its `si` names** — the parser collects
+them per sheet, and `sheet_cell_value` moves the master's expression by the
+offset between the two cells (`internal/formula`), `#REF!` where that leaves
+the grid. A master that does not parse is handed out as it stands; a member
+whose `si` names none stays **set and empty**. Merged ranges from `mergeCells`
+land in the `SheetCell` side map as anchor `span` + `is_covered` flags at parse
+time.
 
 **Style resolution: styles.xml index vectors.** `StyleRegistry` loads positional
 `fonts`/`fills`/`borders`/`cellStyleXfs`/`cellXfs`. A cell's `s` attribute
@@ -87,7 +92,8 @@ reader is asked to.
 Coverage is in [`README.md`](README.md). Foundational gaps, roughly by value:
 
 1. **Formulas & rich value types.** `<f>` is never evaluated (the cached `<v>`
-   shows); dates, booleans, and errors are typed as plain strings.
+   shows); dates, booleans, and errors are typed as plain strings. An array
+   formula's members (`t="array"`) carry no `<f>` at all, so they report none.
 2. **Content-range detection.** `sheet_content` ignores the requested range and
    returns the full `<dimension>` — no trim to the populated range.
 3. **No named/master cell-style inheritance** (`cellStyleXfs` loaded but unused);

--- a/src/odr/internal/ooxml/spreadsheet/ooxml_spreadsheet_document.cpp
+++ b/src/odr/internal/ooxml/spreadsheet/ooxml_spreadsheet_document.cpp
@@ -8,6 +8,9 @@
 #include <odr/internal/common/element_adapter.hpp>
 #include <odr/internal/common/file.hpp>
 #include <odr/internal/common/table_range.hpp>
+#include <odr/internal/formula/formula_ast.hpp>
+#include <odr/internal/formula/formula_parser.hpp>
+#include <odr/internal/formula/formula_writer.hpp>
 #include <odr/internal/ooxml/spreadsheet/ooxml_spreadsheet_parser.hpp>
 #include <odr/internal/util/number_util.hpp>
 #include <odr/internal/xml/xml_util.hpp>
@@ -15,6 +18,8 @@
 
 #include <algorithm>
 #include <array>
+#include <cstdint>
+#include <optional>
 #include <ostream>
 #include <sstream>
 #include <string_view>
@@ -363,9 +368,46 @@ public:
       }
     }
     if (const pugi::xml_node formula = node.child("f")) {
-      result = result.with_formula(formula.text().get());
+      result = result.with_formula(formula_expression(element_id, formula));
     }
     return result;
+  }
+
+  /// [ECMA-376] 18.3.1.40: a member of a shared group states its `si` alone,
+  /// and reads the master's expression moved by the offset between the two.
+  [[nodiscard]] std::string
+  formula_expression(const ElementIdentifier element_id,
+                     const pugi::xml_node formula) const {
+    std::string text = formula.text().get();
+    if (!text.empty() ||
+        std::string_view(formula.attribute("t").value()) != "shared") {
+      return text;
+    }
+    const ElementIdentifier sheet_id =
+        m_registry->element_at(element_id).parent_id;
+    if (sheet_id == null_element_id) {
+      return text;
+    }
+    const ElementRegistry::Sheet &sheet =
+        m_registry->sheet_element_at(sheet_id);
+    const auto master =
+        sheet.shared_formulas.find(formula.attribute("si").value());
+    if (master == sheet.shared_formulas.end()) {
+      return text;
+    }
+    std::optional<formula::Node> node =
+        formula::parse(master->second.expression, formula::Syntax::ooxml);
+    if (!node.has_value()) {
+      return master->second.expression;
+    }
+    const TablePosition position =
+        m_registry->sheet_cell_element_at(element_id).position;
+    formula::shift(*node,
+                   static_cast<std::int64_t>(position.column) -
+                       master->second.position.column,
+                   static_cast<std::int64_t>(position.row) -
+                       master->second.position.row);
+    return formula::to_string(*node, formula::Syntax::ooxml);
   }
 
   [[nodiscard]] TextStyle

--- a/src/odr/internal/ooxml/spreadsheet/ooxml_spreadsheet_element_registry.hpp
+++ b/src/odr/internal/ooxml/spreadsheet/ooxml_spreadsheet_element_registry.hpp
@@ -49,6 +49,12 @@ public:
       ElementIdentifier element_id{null_element_id};
     };
 
+    /// The master of a shared group, which every member of it reads.
+    struct SharedFormula final {
+      TablePosition position;
+      std::string expression;
+    };
+
     /// From the workbook's `<sheet name=…>`; the worksheet part carries none.
     std::string name;
 
@@ -57,6 +63,8 @@ public:
     std::map<std::uint32_t, Column> columns;
     std::unordered_map<std::uint32_t, Row> rows;
     std::unordered_map<TablePosition, Cell> cells;
+
+    std::unordered_map<std::string, SharedFormula> shared_formulas;
 
     ElementIdentifier first_shape_id{null_element_id};
     ElementIdentifier last_shape_id{null_element_id};

--- a/src/odr/internal/ooxml/spreadsheet/ooxml_spreadsheet_parser.cpp
+++ b/src/odr/internal/ooxml/spreadsheet/ooxml_spreadsheet_parser.cpp
@@ -135,6 +135,15 @@ parse_sheet_element(ElementRegistry &registry, const ParseContext &context,
       sheet.register_cell(position.column, position.row, cell_node, cell_id);
       parse_sheet_cell_children(registry, context, cell_id, cell_node);
 
+      // [ECMA-376] 18.3.1.40: only the master spells the expression
+      if (const pugi::xml_node formula_node = cell_node.child("f");
+          std::string_view(formula_node.attribute("t").value()) == "shared" &&
+          !std::string_view(formula_node.text().get()).empty()) {
+        sheet.shared_formulas.emplace(formula_node.attribute("si").value(),
+                                      ElementRegistry::Sheet::SharedFormula{
+                                          position, formula_node.text().get()});
+      }
+
       used.rows = std::max(used.rows, position.row + 1);
       used.columns = std::max(used.columns, position.column + 1);
     }

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -62,6 +62,7 @@ add_executable(odr_test
         "src/internal/csv/csv_file_test.cpp"
         "src/internal/encoding/text_encoding_test.cpp"
         "src/internal/formula/formula_parser_test.cpp"
+        "src/internal/formula/formula_writer_test.cpp"
         "src/internal/svg/svg_file_test.cpp"
         "src/internal/svg/svg_writer_test.cpp"
         "src/internal/xml/xml_file_test.cpp"

--- a/test/src/internal/formula/formula_parser_test.cpp
+++ b/test/src/internal/formula/formula_parser_test.cpp
@@ -288,6 +288,7 @@ TEST(FormulaParser, what_does_not_parse_is_nothing) {
   EXPECT_FALSE(ooxml("\"open").has_value());
   EXPECT_FALSE(ooxml("").has_value());
   EXPECT_FALSE(ooxml("A1 B1").has_value());
+  EXPECT_FALSE(ooxml("1e999").has_value());
 }
 
 /// Rows are 1-based, and both axes stop at what an index holds.

--- a/test/src/internal/formula/formula_writer_test.cpp
+++ b/test/src/internal/formula/formula_writer_test.cpp
@@ -1,0 +1,94 @@
+#include <odr/internal/formula/formula_ast.hpp>
+#include <odr/internal/formula/formula_parser.hpp>
+#include <odr/internal/formula/formula_writer.hpp>
+
+#include <gtest/gtest.h>
+
+#include <cstdint>
+#include <optional>
+#include <string>
+
+using namespace odr::internal::formula;
+
+namespace {
+
+std::string round_trip(const std::string &text, const Syntax syntax) {
+  const std::optional<Node> node = parse(text, syntax);
+  return node.has_value() ? to_string(*node, syntax) : "<no parse>";
+}
+
+std::string odf(const std::string &text) {
+  return round_trip(text, Syntax::opendocument);
+}
+
+std::string ooxml(const std::string &text) {
+  return round_trip(text, Syntax::ooxml);
+}
+
+std::string moved(const std::string &text, const std::int64_t columns,
+                  const std::int64_t rows) {
+  std::optional<Node> node = parse(text, Syntax::ooxml);
+  if (!node.has_value()) {
+    return "<no parse>";
+  }
+  shift(*node, columns, rows);
+  return to_string(*node, Syntax::ooxml);
+}
+
+} // namespace
+
+TEST(FormulaWriter, an_ooxml_expression_is_written_as_it_was_read) {
+  EXPECT_EQ(ooxml("SUM(A1:B2)"), "SUM(A1:B2)");
+  EXPECT_EQ(ooxml("IF(A1>0,\"a\",\"b\")"), "IF(A1>0,\"a\",\"b\")");
+  EXPECT_EQ(ooxml("$A$1+1"), "$A$1+1");
+  EXPECT_EQ(ooxml("'My Sheet'!A1:B2"), "'My Sheet'!A1:B2");
+  EXPECT_EQ(ooxml("[1]Sheet1!A1"), "[1]Sheet1!A1");
+  EXPECT_EQ(ooxml("A1&\"x\""), "A1&\"x\"");
+  EXPECT_EQ(ooxml("-3%"), "-3%");
+  EXPECT_EQ(ooxml("{1,2;3,4}"), "{1,2;3,4}");
+  EXPECT_EQ(ooxml("IF(A1,,B1)"), "IF(A1,,B1)");
+  EXPECT_EQ(ooxml("#DIV/0!"), "#DIV/0!");
+  EXPECT_EQ(ooxml("TRUE"), "TRUE");
+  EXPECT_EQ(ooxml("A:A"), "A:A");
+  EXPECT_EQ(ooxml("SUM((A1:A2,B1:B2))"), "SUM((A1:A2,B1:B2))");
+  EXPECT_EQ(ooxml("[1]!Total"), "[1]!Total");
+}
+
+TEST(FormulaWriter, an_opendocument_expression_is_written_as_it_was_read) {
+  EXPECT_EQ(odf("of:=SUM([.A1:.B2])"), "SUM([.A1:.B2])");
+  EXPECT_EQ(odf("of:=[$'My Sheet'.$A$1]"), "[$'My Sheet'.$A$1]");
+  EXPECT_EQ(odf("of:=IF([.A1]>0;1;2)"), "IF([.A1]>0;1;2)");
+  EXPECT_EQ(odf("of:={1;2|3;4}"), "{1;2|3;4}");
+  EXPECT_EQ(odf("of:=$$'Total Sales'"), "$$'Total Sales'");
+  EXPECT_EQ(odf("of:=[.A1:Sheet2.B2]"), "[.A1:Sheet2.B2]");
+  EXPECT_EQ(odf("of:=SUM([.A1:.A2]~[.B1:.B2])"), "SUM([.A1:.A2]~[.B1:.B2])");
+  EXPECT_EQ(odf("of:=['file:///x.ods'#$Sheet1.A1]"),
+            "['file:///x.ods'#$Sheet1.A1]");
+  EXPECT_EQ(odf("of:=TRUE"), "TRUE()");
+}
+
+TEST(FormulaWriter, a_parenthesis_is_written_only_where_it_is_needed) {
+  EXPECT_EQ(ooxml("(1+2)*3"), "(1+2)*3");
+  EXPECT_EQ(ooxml("1+(2*3)"), "1+2*3");
+  EXPECT_EQ(ooxml("1-(2-3)"), "1-(2-3)");
+  EXPECT_EQ(ooxml("(1-2)-3"), "1-2-3");
+  EXPECT_EQ(ooxml("-(1+2)"), "-(1+2)");
+}
+
+TEST(FormulaWriter, a_relative_reference_moves_and_an_absolute_one_does_not) {
+  EXPECT_EQ(moved("A1+B1", 0, 1), "A2+B2");
+  EXPECT_EQ(moved("$A$1+B1", 0, 1), "$A$1+B2");
+  EXPECT_EQ(moved("A$1+$A1", 1, 1), "B$1+$A2");
+  EXPECT_EQ(moved("SUM(A1:A5)", 2, 0), "SUM(C1:C5)");
+  EXPECT_EQ(moved("Sheet2!A1", 0, 3), "Sheet2!A4");
+}
+
+TEST(FormulaWriter, a_reference_moved_off_the_grid_is_lost) {
+  EXPECT_EQ(moved("A1+B2", 0, -1), "#REF!+B1");
+  EXPECT_EQ(moved("SUM(A1:B2)", -1, 0), "SUM(#REF!)");
+}
+
+TEST(FormulaWriter, what_a_shift_does_not_name_is_left_alone) {
+  EXPECT_EQ(moved("SUM(Total)+1", 3, 3), "SUM(Total)+1");
+  EXPECT_EQ(moved("\"A1\"", 3, 3), "\"A1\"");
+}

--- a/test/src/internal/ooxml/ooxml_spreadsheet_value_test.cpp
+++ b/test/src/internal/ooxml/ooxml_spreadsheet_value_test.cpp
@@ -5,6 +5,7 @@
 
 #include <gtest/gtest.h>
 
+#include <cstdint>
 #include <string>
 
 using namespace odr;
@@ -19,6 +20,12 @@ CellValue value_of(const std::string &sheet_data) {
 
 std::string text_of(const std::string &sheet_data) {
   return value_of(sheet_data).text();
+}
+
+std::string formula_at(const std::string &sheet_data,
+                       const std::uint32_t column, const std::uint32_t row) {
+  const Document document = decode(workbook(sheet_data));
+  return first_sheet(document).cell(column, row).value().formula();
 }
 
 } // namespace
@@ -70,12 +77,43 @@ TEST(OoxmlSpreadsheetValue, a_formula_cell_states_both_formula_and_result) {
 
 /// Set-and-empty says the member computes; unset would claim it does not.
 TEST(OoxmlSpreadsheetValue,
-     a_shared_formula_member_holds_a_formula_it_cannot_spell) {
+     a_shared_formula_member_without_its_master_spells_nothing) {
   const CellValue value = value_of(
       R"(<row r="1"><c r="A1"><f t="shared" si="0"/><v>8</v></c></row>)");
 
   ASSERT_TRUE(value.has_formula());
   EXPECT_TRUE(value.formula().empty());
+}
+
+/// ECMA-376 18.3.1.40: the master spells the expression for the whole group.
+TEST(OoxmlSpreadsheetValue, a_shared_formula_member_reads_its_master_moved) {
+  const std::string data =
+      R"(<row r="1"><c r="C1"><f t="shared" ref="C1:C3" si="0">A1+$B$1</f>)"
+      R"(<v>3</v></c></row>)"
+      R"(<row r="2"><c r="C2"><f t="shared" si="0"/><v>7</v></c></row>)"
+      R"(<row r="3"><c r="C3"><f t="shared" si="0"/><v>9</v></c></row>)";
+
+  EXPECT_EQ(formula_at(data, 2, 0), "A1+$B$1");
+  EXPECT_EQ(formula_at(data, 2, 1), "A2+$B$1");
+  EXPECT_EQ(formula_at(data, 2, 2), "A3+$B$1");
+}
+
+TEST(OoxmlSpreadsheetValue, a_shared_formula_member_can_lose_its_reference) {
+  const std::string data =
+      R"(<row r="2"><c r="C2"><f t="shared" ref="C1:C2" si="0">A1</f>)"
+      R"(<v>3</v></c></row>)"
+      R"(<row r="1"><c r="C1"><f t="shared" si="0"/><v>7</v></c></row>)";
+
+  EXPECT_EQ(formula_at(data, 2, 0), "#REF!");
+}
+
+TEST(OoxmlSpreadsheetValue, a_shared_formula_that_does_not_parse_is_kept) {
+  const std::string data =
+      R"(<row r="1"><c r="C1"><f t="shared" ref="C1:C2" si="0">A1 +</f>)"
+      R"(<v>3</v></c></row>)"
+      R"(<row r="2"><c r="C2"><f t="shared" si="0"/><v>7</v></c></row>)";
+
+  EXPECT_EQ(formula_at(data, 2, 1), "A1 +");
 }
 
 /// `<v>` holds `1`, not a quantity, and `c/@t="b"` types the cell a string.


### PR DESCRIPTION
🤖 Generated with [Claude Code](https://claude.com/claude-code)

Step 3.1 of [`docs/design/spreadsheet-editing.md`](docs/design/spreadsheet-editing.md), finishing what the parser was for.

## The problem

[ECMA-376] 18.3.1.40 spells a shared formula on the group's **master alone**:

```xml
<c r="C1"><f t="shared" ref="C1:C3" si="0">A1+$B$1</f><v>3</v></c>
<c r="C2"><f t="shared" si="0"/><v>7</v></c>
<c r="C3"><f t="shared" si="0"/><v>9</v></c>
```

Excel writes this whenever you fill a column down, so most formula cells in a real workbook are members. A member reported an empty formula, which leaves a formula bar with nothing to show and the dependency graph (next PR) with nothing to read.

## What it does

The parser collects the masters per sheet, and `sheet_cell_value` reads a member through the one its `si` names: parse the master's expression, move every relative reference by the offset between the two cells, write it again. So C2 above answers `A2+$B$1` and C3 `A3+$B$1` — the `$B$1` does not move, because a `$` axis never does.

That needs two pieces beside the parser, both in `internal/formula`:

- **`shift`** over the tree. A reference moved off the grid becomes `#REF!`, as a sheet makes it.
- **a writer**, `to_string(node, syntax)`, which spells a tree back in either syntax. It drops a parenthesis the precedence already states, so `1+(2*3)` comes back as `1+2*3` while `1-(2-3)` keeps its own.

One fix fell out of having a writer: the parser accepted `1e999` as infinity, which the writer would then spell `inf`. It refuses the number instead, so the master's own text is what a member gets.

## Two cells that keep what they had

- a master the parser cannot read is handed out **as it stands** rather than dropped;
- a member whose `si` names no master stays **set and empty** — it computes, and nothing here can spell what.

An array formula (`t="array"`) writes no `<f>` at all on its members, so those still report none. Noted in the module's `AGENTS.md`.

## Test

`test/src/internal/formula/formula_writer_test.cpp` round-trips both syntaxes and pins the shift; the shared-formula cases are in `ooxml_spreadsheet_value_test.cpp`, from inline fixtures. `test/data/input/odr-public/xlsx/sample.xlsx` is a real file of the shape — 32 members of one `RAND()` group.
