### PR TITLE
feat(html): mark the formula cells an edit left out of date

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,12 @@ The release run heads these entries with the version and opens a fresh
 
 ## Unreleased
 
+- An editable sheet view states each formula cell's expression
+  (`data-odr-formula`, `odr.sheet.formulaAt`) and the cells it reads. A commit
+  marks the formula cells reading what it wrote with `odr-sheet-stale`, and
+  raises the new `odr.onCellsStale` callback, `{sheet, cells}`; an undo takes
+  the marks back. Nothing recomputes a formula yet.
+
 - `Document::dependents(position)` answers which cells' formulas read a
   position, directly or through another, and `unresolved_formulas()` those
   whose references could not all be read. A position is the new

--- a/docs/design/spreadsheet-editing.md
+++ b/docs/design/spreadsheet-editing.md
@@ -225,7 +225,12 @@ odr.onEditRefused = function (event) {};
 odr.onEditChange = function (event) {};
 // {editing, editable, reason, code, message}
 odr.onEditModeChange = function (event) {};
+// {sheet, cells} - the formula cells an edit left computing an old input
+odr.onCellsStale = function (event) {};
 ```
+
+`onCellsStale` carries no code, because it reports no refusal, and the page
+marks the cells itself, so a host that wires nothing still shows something.
 
 **The message is for the console; the code is for the host.** A mobile
 snackbar is written in the app's own string catalogue, and nothing in this
@@ -489,9 +494,21 @@ Each step ships on its own. "Both" means `.ods` and `.xlsx`.
    the cells the file *spells* rather than the positions they cover: a
    repeated ODS row of 1024 columns over 1048576 rows is a handful of nodes
    and a billion positions, and only the first is walked.
-3. View: a commit marks dependents stale (a class, the host is told); the
-   locked formula cell exposes its text (`data-odr-formula`, formula cells
-   only) so a formula bar or a tooltip can show it.
+3. **Landed.** View: a formula cell states its expression
+   (`data-odr-formula`, which `odr.sheet.formulaAt` hands a formula bar) and
+   the rectangles it reads (`data-odr-reads`: sheet, columns, rows, `*` for an
+   axis a reference leaves open). Both are editing scaffolding, so a read-only
+   render carries neither.
+
+   A commit then marks the cells reading what it wrote — and the cells reading
+   those — with `odr-sheet-stale`, and raises `odr.onCellsStale`. The marks
+   follow the **log**, not the last write: `repaintStale` recomputes them off
+   the coalesced log, so an undo takes back what it made stale and a save
+   clears them with the log. Nothing recomputes a value; step 4 is what does.
+
+   The page carries the graph rather than asking the host for it, because a
+   mark has to keep up with typing. The engine's own graph (item 2) is what
+   the file side uses.
 4. File: the `.ods` answer from the spike — drop the cached value of dirty
    dependents, or whatever LibreOffice needs to recompute.
 

--- a/src/odr/internal/common/sheet_dependencies.cpp
+++ b/src/odr/internal/common/sheet_dependencies.cpp
@@ -13,23 +13,6 @@
 
 namespace odr::internal {
 
-namespace {
-
-/// The syntax the engine behind @p file_type writes a formula in. Nothing
-/// where it states none at all.
-std::optional<formula::Syntax> syntax_of(const FileType file_type) {
-  switch (file_type) {
-  case FileType::opendocument_spreadsheet:
-    return formula::Syntax::opendocument;
-  case FileType::office_open_xml_workbook:
-    return formula::Syntax::ooxml;
-  default:
-    return {};
-  }
-}
-
-} // namespace
-
 bool SheetDependencies::Read::contains(const SheetPosition &position) const {
   return position.sheet == sheet && range.contains(position.cell);
 }
@@ -37,7 +20,8 @@ bool SheetDependencies::Read::contains(const SheetPosition &position) const {
 SheetDependencies SheetDependencies::of(const abstract::Document &document) {
   SheetDependencies result;
 
-  const std::optional<formula::Syntax> syntax = syntax_of(document.file_type());
+  const std::optional<formula::Syntax> syntax =
+      formula::syntax_of(document.file_type());
   const abstract::ElementAdapter *adapter = document.element_adapter();
   if (!syntax.has_value() || adapter == nullptr) {
     return result;

--- a/src/odr/internal/formula/formula_parser.cpp
+++ b/src/odr/internal/formula/formula_parser.cpp
@@ -684,6 +684,17 @@ std::string_view strip_prefix(std::string_view formula) {
 
 namespace odr::internal {
 
+std::optional<formula::Syntax> formula::syntax_of(const FileType file_type) {
+  switch (file_type) {
+  case FileType::opendocument_spreadsheet:
+    return formula::Syntax::opendocument;
+  case FileType::office_open_xml_workbook:
+    return formula::Syntax::ooxml;
+  default:
+    return {};
+  }
+}
+
 std::optional<formula::Node> formula::parse(const std::string_view formula,
                                             const formula::Syntax syntax) {
   return formula::Parser(formula::strip_prefix(formula), syntax).parse();

--- a/src/odr/internal/formula/formula_parser.hpp
+++ b/src/odr/internal/formula/formula_parser.hpp
@@ -1,5 +1,7 @@
 #pragma once
 
+#include <odr/file.hpp>
+
 #include <odr/internal/formula/formula_ast.hpp>
 
 #include <optional>
@@ -13,6 +15,10 @@ enum class Syntax {
   opendocument, ///< OpenFormula, as `table:formula` states it
   ooxml,        ///< the expression an `<f>` holds
 };
+
+/// The syntax the engine behind @p file_type writes a formula in. Nothing
+/// where it states none, or drops the expression at parse time (`.xls`).
+[[nodiscard]] std::optional<Syntax> syntax_of(FileType file_type);
 
 /// Parses @p formula, with or without the `of:=` prefix. Nothing where it does
 /// not parse, so a caller reads no reference out of a formula it cannot read.

--- a/src/odr/internal/html/common.hpp
+++ b/src/odr/internal/html/common.hpp
@@ -8,6 +8,7 @@
 
 #include <odr/html.hpp>
 #include <odr/internal/abstract/html_service.hpp>
+#include <odr/internal/formula/formula_parser.hpp>
 #include <odr/quantity.hpp>
 #include <odr/style.hpp>
 
@@ -58,6 +59,15 @@ struct WritingState {
     m_document_editable = editable;
   }
 
+  /// The syntax a formula of this document is written in, or nothing where
+  /// the engine states none.
+  [[nodiscard]] std::optional<formula::Syntax> formula_syntax() const {
+    return m_formula_syntax;
+  }
+  void set_formula_syntax(const std::optional<formula::Syntax> syntax) {
+    m_formula_syntax = syntax;
+  }
+
 private:
   HtmlWriter *m_out;
   const HtmlConfig *m_config;
@@ -67,6 +77,7 @@ private:
   TextDirection m_direction{TextDirection::left_to_right};
   bool m_editable_markup{true};
   bool m_document_editable{false};
+  std::optional<formula::Syntax> m_formula_syntax;
 };
 
 /// Writes the viewport meta tag. Precedence: `config.viewport_content` (raw,

--- a/src/odr/internal/html/document.cpp
+++ b/src/odr/internal/html/document.cpp
@@ -9,6 +9,7 @@
 
 #include <odr/internal/abstract/html_service.hpp>
 #include <odr/internal/common/null_stream.hpp>
+#include <odr/internal/formula/formula_parser.hpp>
 #include <odr/internal/html/common.hpp>
 #include <odr/internal/html/document_element.hpp>
 #include <odr/internal/html/document_style.hpp>
@@ -282,6 +283,7 @@ render(const Document &document, const HtmlConfig &config, const Logger &logger,
     WritingState state(out, config, resources, logger);
     state.set_direction(document_direction(document));
     state.set_document_editable(document.is_editable());
+    state.set_formula_syntax(formula::syntax_of(document.file_type()));
     write_head(document, state, name, content_pixels);
     body(state);
     out.write_end();
@@ -294,6 +296,7 @@ render(const Document &document, const HtmlConfig &config, const Logger &logger,
   WritingState head_state(out, config, resources, logger, &styles);
   head_state.set_direction(document_direction(document));
   head_state.set_document_editable(document.is_editable());
+  head_state.set_formula_syntax(formula::syntax_of(document.file_type()));
 
   util::stream::DeferredBuffer buffer(
       out.out(), static_cast<std::size_t>(config.spreadsheet_style_buffer),
@@ -307,6 +310,7 @@ render(const Document &document, const HtmlConfig &config, const Logger &logger,
     WritingState state(body_out, config, resources, logger, &styles);
     state.set_direction(head_state.direction());
     state.set_document_editable(head_state.document_editable());
+    state.set_formula_syntax(head_state.formula_syntax());
     body(state);
   }
   buffer.release();

--- a/src/odr/internal/html/document_element.cpp
+++ b/src/odr/internal/html/document_element.cpp
@@ -8,6 +8,8 @@
 
 #include <odr/internal/common/path.hpp>
 #include <odr/internal/common/table_cursor.hpp>
+#include <odr/internal/formula/formula_dependencies.hpp>
+#include <odr/internal/formula/formula_parser.hpp>
 #include <odr/internal/html/common.hpp>
 #include <odr/internal/html/document_style.hpp>
 #include <odr/internal/html/html_service.hpp>
@@ -15,9 +17,14 @@
 #include <odr/internal/html/image_file.hpp>
 #include <odr/internal/html/style_registry.hpp>
 #include <odr/internal/util/number_util.hpp>
+#include <odr/internal/util/string_util.hpp>
 #include <odr/internal/xml/xml_util.hpp>
 
 #include <algorithm>
+#include <limits>
+#include <optional>
+#include <string>
+#include <unordered_map>
 #include <vector>
 
 namespace odr::internal {
@@ -346,10 +353,78 @@ std::uint32_t sheet_ordinal(const Sheet &sheet) {
   return ordinal;
 }
 
+/// Every sheet by its name without case, as a formula names one, so a
+/// reference into another sheet resolves to the ordinal an op uses.
+std::unordered_map<std::string, std::uint32_t>
+sheet_ordinals_by_name(const Sheet &sheet) {
+  Element first = sheet;
+  for (Element previous = sheet.previous_sibling(); previous;
+       previous = previous.previous_sibling()) {
+    first = previous;
+  }
+
+  std::unordered_map<std::string, std::uint32_t> result;
+  std::uint32_t ordinal = 0;
+  for (Element current = first; current; current = current.next_sibling()) {
+    if (current.type() == ElementType::sheet) {
+      result.emplace(util::string::to_lower(current.as_sheet().name()),
+                     ordinal);
+    }
+    ++ordinal;
+  }
+  return result;
+}
+
+/// The open end of an axis a reference leaves out.
+std::string spell_bound(const std::uint32_t index) {
+  return index == std::numeric_limits<std::uint32_t>::max()
+             ? "*"
+             : std::to_string(index);
+}
+
+/// What @p formula reads, as the rectangles the page tests a written position
+/// against: `sheet,first column,last column,first row,last row`, space
+/// separated, with `*` for an axis the reference leaves open. Empty where the
+/// formula does not parse, or reads nothing this document holds.
+std::string
+cell_reads(const std::string &formula, const formula::Syntax syntax,
+           const std::uint32_t own_sheet,
+           const std::unordered_map<std::string, std::uint32_t> &by_name) {
+  const std::optional<formula::Node> node = formula::parse(formula, syntax);
+  if (!node.has_value()) {
+    return {};
+  }
+
+  std::string result;
+  for (const formula::Extent &extent : formula::references(*node).extents) {
+    if (extent.document.has_value()) {
+      continue; // another file, which no edit here reaches
+    }
+    std::uint32_t sheet = own_sheet;
+    if (extent.sheet.has_value()) {
+      const auto named = by_name.find(util::string::to_lower(*extent.sheet));
+      if (named == by_name.end()) {
+        continue;
+      }
+      sheet = named->second;
+    }
+    if (!result.empty()) {
+      result += " ";
+    }
+    result += std::to_string(sheet) + "," +
+              spell_bound(extent.range.from().column) + "," +
+              spell_bound(extent.range.to().column) + "," +
+              spell_bound(extent.range.from().row) + "," +
+              spell_bound(extent.range.to().row);
+  }
+  return result;
+}
+
 /// Why a cell cannot be edited, or null where it can be. The names the page
 /// reports to its host; `spreadsheet-editing.md` decision 3 lists them.
-const char *cell_lock(const SheetCell &cell, const bool anchors_shapes) {
-  if (cell.value().has_formula()) {
+const char *cell_lock(const CellValue &value, const SheetCell &cell,
+                      const bool anchors_shapes) {
+  if (value.has_formula()) {
     return "formula";
   }
   // its drawings are what the cell is, and an overlay would cover them
@@ -501,22 +576,30 @@ void html::translate_sheet(const Sheet &sheet, const WritingState &state) {
 
   const std::optional<double> print_fit = sheet_print_fit(sheet, end_column);
 
+  // scaffolding: a read-only render states neither a lock nor a dependency
+  const std::optional<formula::Syntax> syntax =
+      state.config().editable ? state.formula_syntax() : std::nullopt;
+  const std::uint32_t ordinal = sheet_ordinal(sheet);
+  const std::unordered_map<std::string, std::uint32_t> ordinals_by_name =
+      syntax.has_value() ? sheet_ordinals_by_name(sheet)
+                         : std::unordered_map<std::string, std::uint32_t>();
+
   state.out().write_element_begin(
-      "table",
-      HtmlElementOptions()
-          .set_class("odr-sheet")
-          .set_attributes([&](const HtmlAttributeWriterCallback &clb) {
-            // every op names its sheet, and a view holds only one
-            clb("data-odr-sheet", std::to_string(sheet_ordinal(sheet)));
-          })
-          .set_style([&]() -> std::optional<HtmlWritable> {
-            if (!print_fit.has_value()) {
-              return std::nullopt;
-            }
-            // `Measure` renders no exponent form
-            return "--odr-print-fit:" +
-                   Measure(*print_fit, DynamicUnit()).to_string() + ";";
-          }()));
+      "table", HtmlElementOptions()
+                   .set_class("odr-sheet")
+                   .set_attributes([&](const HtmlAttributeWriterCallback &clb) {
+                     // every op names its sheet, and a view holds only one
+                     clb("data-odr-sheet", std::to_string(ordinal));
+                   })
+                   .set_style([&]() -> std::optional<HtmlWritable> {
+                     if (!print_fit.has_value()) {
+                       return std::nullopt;
+                     }
+                     // `Measure` renders no exponent form
+                     return "--odr-print-fit:" +
+                            Measure(*print_fit, DynamicUnit()).to_string() +
+                            ";";
+                   }()));
 
   state.out().write_element_begin("col",
                                   HtmlElementOptions()
@@ -685,9 +768,18 @@ void html::translate_sheet(const Sheet &sheet, const WritingState &state) {
       const std::optional<FoldedCell> folded = fold_cell(
           cell, sheet_state, wraps, anchors_shapes, table_row_style.height);
 
-      // scaffolding: a read-only render states no lock
-      const char *lock =
-          state.config().editable ? cell_lock(cell, anchors_shapes) : nullptr;
+      const CellValue cell_value =
+          state.config().editable ? cell.value() : CellValue();
+      const char *lock = state.config().editable
+                             ? cell_lock(cell_value, cell, anchors_shapes)
+                             : nullptr;
+      // what a formula bar shows, and the rectangles the page marks against
+      const bool computes = cell_value.has_formula() &&
+                            !cell_value.formula().empty() && syntax.has_value();
+      const std::string reads = computes
+                                    ? cell_reads(cell_value.formula(), *syntax,
+                                                 ordinal, ordinals_by_name)
+                                    : std::string();
 
       state.out().write_element_begin(
           "td",
@@ -702,6 +794,13 @@ void html::translate_sheet(const Sheet &sheet, const WritingState &state) {
                 }
                 if (lock != nullptr) {
                   clb("data-odr-lock", lock);
+                }
+                if (computes) {
+                  clb("data-odr-formula",
+                      xml::escape_attribute(cell_value.formula()));
+                }
+                if (!reads.empty()) {
+                  clb("data-odr-reads", reads);
                 }
               })
               .set_style(

--- a/src/odr/internal/html/frontend/editing.js
+++ b/src/odr/internal/html/frontend/editing.js
@@ -49,6 +49,7 @@
     console.log("editing " + (event.editing ? "on" : "off"));
   };
   odr.onEditChange = function () {};
+  odr.onCellsStale = function () {};
 
   function fire(name, event) {
     if (typeof odr[name] === "function") {
@@ -160,6 +161,12 @@
         }
       }
       fire("onEditRefused", event);
+    },
+
+    /// The cells the edits so far left computing an old input. Raised
+    /// whenever the set changes, which an undo does too.
+    stale: function (detail) {
+      fire("onCellsStale", detail);
     },
 
     /// The log a host's save button reads; an editor calls it when its log

--- a/src/odr/internal/html/frontend/sheet-editing.js
+++ b/src/odr/internal/html/frontend/sheet-editing.js
@@ -97,6 +97,7 @@
       before: before,
     });
     undone = [];
+    repaintStale();
     odr.editing.changed();
     return true;
   }
@@ -106,7 +107,124 @@
   function replay(entry, value) {
     close();
     odr.sheet.showValue(entry.op.column, entry.op.row, value);
+    repaintStale();
     odr.editing.changed();
+  }
+
+  /// What each formula cell reads, off `data-odr-reads`. Only the rectangles
+  /// in this sheet, because an edit here names a position in it.
+  var readers = null;
+
+  function bound(text) {
+    return text === "*" ? Infinity : Number(text);
+  }
+
+  function readersOf() {
+    if (readers !== null) {
+      return readers;
+    }
+    readers = [];
+    var cells = table.querySelectorAll("td[data-odr-reads]");
+    for (var i = 0; i < cells.length; ++i) {
+      var at = odr.sheet.positionOf(cells[i]);
+      if (at === null) {
+        continue;
+      }
+      var boxes = [];
+      var groups = cells[i].getAttribute("data-odr-reads").split(" ");
+      for (var j = 0; j < groups.length; ++j) {
+        var parts = groups[j].split(",");
+        if (parts.length === 5 && Number(parts[0]) === sheet) {
+          boxes.push([
+            bound(parts[1]),
+            bound(parts[2]),
+            bound(parts[3]),
+            bound(parts[4]),
+          ]);
+        }
+      }
+      if (boxes.length > 0) {
+        readers.push({ cell: cells[i], at: at, reads: boxes });
+      }
+    }
+    return readers;
+  }
+
+  function readsAny(entry, positions) {
+    for (var i = 0; i < entry.reads.length; ++i) {
+      var box = entry.reads[i];
+      for (var j = 0; j < positions.length; ++j) {
+        var at = positions[j];
+        if (
+          at.column >= box[0] &&
+          at.column <= box[1] &&
+          at.row >= box[2] &&
+          at.row <= box[3]
+        ) {
+          return true;
+        }
+      }
+    }
+    return false;
+  }
+
+  /// Every cell reading one of @p positions, and every cell reading one of
+  /// those: a formula whose input went stale is stale itself.
+  function staleFrom(positions) {
+    var entries = readersOf();
+    var taken = [];
+    var frontier = positions;
+    var result = [];
+    while (frontier.length > 0) {
+      var next = [];
+      for (var i = 0; i < entries.length; ++i) {
+        if (taken[i] || !readsAny(entries[i], frontier)) {
+          continue;
+        }
+        taken[i] = true;
+        result.push(entries[i]);
+        next.push(entries[i].at);
+      }
+      frontier = next;
+    }
+    return result;
+  }
+
+  var stale = [];
+  var staleKey = "";
+
+  /// The marks follow the log, not the last write, so an undo takes back what
+  /// it made stale and a save clears them with the log.
+  function repaintStale() {
+    var written = [];
+    var ops = coalesced();
+    for (var i = 0; i < ops.length; ++i) {
+      written.push({ column: ops[i].column, row: ops[i].row });
+    }
+
+    for (var j = 0; j < stale.length; ++j) {
+      stale[j].classList.remove("odr-sheet-stale");
+    }
+    stale = [];
+
+    var cells = [];
+    var entries = staleFrom(written);
+    for (var k = 0; k < entries.length; ++k) {
+      entries[k].cell.classList.add("odr-sheet-stale");
+      stale.push(entries[k].cell);
+      cells.push({ column: entries[k].at.column, row: entries[k].at.row });
+    }
+
+    // A host hears when the set moved, not on every keystroke.
+    var key = cells
+      .map(function (at) {
+        return at.column + ":" + at.row;
+      })
+      .join(" ");
+    if (key !== staleKey) {
+      staleKey = key;
+      odr.editing.stale({ sheet: sheet, cells: cells });
+    }
   }
 
   // Offsets, not rects: blink scales a rect by the body zoom `viewport_js`
@@ -354,6 +472,7 @@
     committed: function () {
       history = [];
       undone = [];
+      repaintStale();
     },
   });
 })();

--- a/src/odr/internal/html/frontend/spreadsheet-dark.css
+++ b/src/odr/internal/html/frontend/spreadsheet-dark.css
@@ -9,6 +9,7 @@
 --odr-sheet-wash-ruler:rgba(255,255,255,.12);
 --odr-sheet-focus:#4c8dff;
 --odr-sheet-refused:#f0665b;
+--odr-sheet-stale:#e3b341;
 --odr-sheet-raised:#1c2128;
 }
 .odr-sheet{background-color:#161b22!important}

--- a/src/odr/internal/html/frontend/spreadsheet.css
+++ b/src/odr/internal/html/frontend/spreadsheet.css
@@ -9,6 +9,7 @@
 --odr-sheet-wash-ruler:rgba(0,0,0,.10);
 --odr-sheet-focus:#3c78dc;
 --odr-sheet-refused:#d1493f;
+--odr-sheet-stale:#b8860b;
 --odr-sheet-raised:#ffffff;
 --odr-sheet-font:-apple-system,BlinkMacSystemFont,"Segoe UI",Roboto,"Helvetica Neue",Arial,sans-serif;
 }
@@ -50,6 +51,10 @@ body{margin:0;background:var(--odr-sheet-canvas)}
 .odr-editing td{cursor:cell}
 .odr-editing td.odr-locked{cursor:not-allowed}
 .odr-sheet td.odr-sheet-refused{outline:2px solid var(--odr-sheet-refused);outline-offset:-2px}
+/* A formula whose input an edit changed; the cell still shows the cached
+   result. Underlined, so it layers over the pin and the hover wash and moves
+   no geometry. */
+.odr-sheet td.odr-sheet-stale{text-decoration:underline wavy var(--odr-sheet-stale);text-decoration-skip-ink:none}
 /* The header's `position:sticky` already makes it a containing block. */
 .odr-sheet-sort{position:absolute;top:1px;right:1px;bottom:1px;width:17px;display:flex;align-items:center;justify-content:center;border-radius:2px;opacity:0;cursor:pointer}
 .odr-sheet-column-header:hover .odr-sheet-sort,.odr-sheet-sort-asc,.odr-sheet-sort-desc{opacity:1}

--- a/src/odr/internal/html/frontend/spreadsheet.js
+++ b/src/odr/internal/html/frontend/spreadsheet.js
@@ -403,6 +403,13 @@
     return { type: "string", text: text };
   }
 
+  // The expression a formula cell computes, as the file spells it. Null for a
+  // cell holding none, and for a read-only render, which writes no scaffolding.
+  function formulaAt(column, row) {
+    var cell = cellAt(column, row);
+    return cell === null ? null : cell.getAttribute("data-odr-formula");
+  }
+
   // Shows @p value at a position, as a write leaves the cell, and reflows
   // the row around it.
   function showValue(column, row, value) {
@@ -430,6 +437,7 @@
     pin: pinAt,
     lower: lower,
     valueAt: valueAt,
+    formulaAt: formulaAt,
     showValue: showValue,
     reflow: reflow,
   };

--- a/test/browser/sheet/README.md
+++ b/test/browser/sheet/README.md
@@ -40,7 +40,8 @@ that is where `translate` writes it.
   way a host drives it, over the shapes a commit has to get right: a string cut
   where its neighbour shows something, a formula cell, a cell of several runs,
   and one whose single run carries a style a write must keep. Undo, redo and
-  the log a save resets follow.
+  the log a save resets follow, and last the marks a commit leaves on the
+  formula cells reading what it wrote.
 - **`keyboard.html`** — a page whose config took both key classes away. The
   arrows, Escape, a printable key and the undo chord are all the host's, while
   the commands (`editAt`, `undo`) and the open editor's own keys still work.

--- a/test/browser/sheet/editing.html
+++ b/test/browser/sheet/editing.html
@@ -9,8 +9,9 @@
   <body class="odr-body odr-gridlines-soft" data-odr-editable="true" data-odr-keyboard="navigation shortcuts">
     <!-- A sheet as `translate_sheet` writes one, with the styles it hoists into
          classes written inline: every column states a width, so a string is cut
-         where the next cell shows something. B3 holds a formula, C3 a run of
-         its own, D3 a link. -->
+         where the next cell shows something. B3 holds a formula over A1:A2,
+         C3 a run of its own, D3 a link. B5 holds a formula over B3, so an
+         edit into A1 reaches B5 through B3. -->
     <table class="odr-sheet" data-odr-sheet="2">
       <col class="odr-sheet-gutter" />
       <col style="width: 80px" />
@@ -44,7 +45,7 @@
         <tr>
           <th class="odr-sheet-row-header">3</th>
           <td style="max-width:0;white-space:nowrap"></td>
-          <td class="odr-value-type-float odr-locked" data-odr-lock="formula" style="max-width:0;white-space:nowrap">7</td>
+          <td class="odr-value-type-float odr-locked" data-odr-lock="formula" data-odr-formula="of:=SUM([.A1:.A2])" data-odr-reads="2,0,0,0,1" style="max-width:0;white-space:nowrap">7</td>
           <td style="max-width:0;white-space:nowrap"><x-p><x-s style="font-weight:bold">bold</x-s></x-p></td>
           <td class="odr-locked" data-odr-lock="rich" style="max-width:0;white-space:nowrap"><x-p><a href="https://x.example"><x-s>x</x-s></a></x-p></td>
         </tr>
@@ -58,7 +59,7 @@
         <tr>
           <th class="odr-sheet-row-header">5</th>
           <td style="max-width:0;white-space:nowrap"></td>
-          <td style="max-width:0;white-space:nowrap"></td>
+          <td class="odr-value-type-float odr-locked" data-odr-lock="formula" data-odr-formula="of:=[.B3]*2" data-odr-reads="2,1,1,2,2" style="max-width:0;white-space:nowrap">14</td>
           <td style="max-width:0;white-space:nowrap"></td>
           <td style="max-width:0;white-space:nowrap"></td>
         </tr>
@@ -78,6 +79,19 @@
       odr.onEditRefused = function (event) {
         refusals.push(event.reason + " " + event.code + " at " + event.column + "," + event.row);
       };
+      var staleEvents = [];
+      odr.onCellsStale = function (event) {
+        staleEvents.push(event);
+      };
+      function staleNow() {
+        return Array.prototype.slice
+          .call(document.querySelectorAll(".odr-sheet-stale"))
+          .map(function (td) {
+            var at = odr.sheet.positionOf(td);
+            return at.column + "," + at.row;
+          })
+          .join(" ");
+      }
 
       function editor() {
         return document.querySelector(".odr-sheet-editor");
@@ -312,6 +326,44 @@
       check("a chord in another input is that input's", cell(3, 0).textContent === "one");
       box.remove();
 
+      // What an edit leaves stale: the cells reading it, and those reading them.
+      odr.editing.committed();
+      staleEvents = [];
+      check("a formula cell hands out its expression", odr.sheet.formulaAt(1, 2) === "of:=SUM([.A1:.A2])");
+      check("and a cell holding none hands out nothing", odr.sheet.formulaAt(0, 0) === null);
+
+      odr.editing.editAt(0, 1);
+      editor().value = "99";
+      press(editor(), "Enter");
+      check("writing an input marks the formula reading it", staleNow() === "1,2 1,4");
+      check(
+        "and the host is told, once",
+        staleEvents.length === 1 &&
+          staleEvents[0].sheet === 2 &&
+          staleEvents[0].cells.length === 2 &&
+          staleEvents[0].cells[0].column === 1 &&
+          staleEvents[0].cells[0].row === 2
+      );
+
+      odr.editing.editAt(3, 4);
+      editor().value = "nothing reads this";
+      press(editor(), "Enter");
+      check("a write nothing reads leaves the set as it was", staleNow() === "1,2 1,4");
+      check("so the host hears nothing further", staleEvents.length === 1);
+
+      odr.editing.undo();
+      odr.editing.undo();
+      check("undoing the edits takes the marks back", staleNow() === "");
+      check("and the host is told that too", staleEvents.length === 2 && staleEvents[1].cells.length === 0);
+
+      odr.editing.redo();
+      check("a redo puts them back", staleNow() === "1,2 1,4");
+      odr.editing.committed();
+      check("and a save clears them with the log", staleNow() === "");
+
+      odr.editing.editAt(3, 0);
+      editor().value = "one";
+      press(editor(), "Enter");
       odr.editing.committed();
       check(
         "a save clears both stacks",

--- a/test/src/html_test.cpp
+++ b/test/src/html_test.cpp
@@ -616,10 +616,11 @@ DecodedFile csv_file(const std::uint32_t rows, const std::uint32_t columns) {
 }
 
 /// A flat ODF sheet holding @p rows, each a `table:table-row`, under the
-/// `table:table-column`s in @p columns. The one cell style, `ce1`, aligns a
-/// cell to the top, so every cell that names it writes the same style block.
-DecodedFile fods_file(const std::string &rows,
-                      const std::string &columns = "") {
+/// `table:table-column`s in @p columns, and the further `table:table`s in
+/// @p sheets. The one cell style, `ce1`, aligns a cell to the top, so every
+/// cell that names it writes the same style block.
+DecodedFile fods_file(const std::string &rows, const std::string &columns = "",
+                      const std::string &sheets = "") {
   const std::string fods =
       R"(<?xml version="1.0" encoding="UTF-8"?>)"
       R"(<office:document)"
@@ -642,8 +643,8 @@ DecodedFile fods_file(const std::string &rows,
       R"(</style:style>)"
       R"(</office:automatic-styles>)"
       R"(<office:body><office:spreadsheet><table:table table:name="Sheet1">)" +
-      columns + rows +
-      R"(</table:table></office:spreadsheet></office:body>)"
+      columns + rows + R"(</table:table>)" + sheets +
+      R"(</office:spreadsheet></office:body>)"
       R"(</office:document>)";
   return open(File::from_memory(fods),
               DecodeOptions::as(FileType::opendocument_spreadsheet));
@@ -947,6 +948,92 @@ TEST(html, a_formula_cell_is_locked_with_its_reason) {
 
   EXPECT_NE(page.find(R"(data-odr-lock="formula")"), std::string::npos);
   EXPECT_NE(page.find("odr-locked"), std::string::npos);
+}
+
+// A formula bar shows the expression, which is not what the cell shows.
+TEST(html, a_formula_cell_states_the_expression_it_computes) {
+  const std::string page = render_sheet(
+      fods_file(fods_row(
+          R"xml(<table:table-cell table:formula="of:=SUM([.B1:.C1])")xml"
+          R"( office:value-type="float" office:value="7">)"
+          R"(<text:p>7</text:p></table:table-cell>)")),
+      editing_config());
+
+  const std::string expected = R"xml(data-odr-formula="of:=SUM([.B1:.C1])")xml";
+  EXPECT_NE(page.find(expected), std::string::npos);
+}
+
+// The page marks against the rectangles, not against the expression.
+TEST(html, a_formula_cell_states_the_cells_it_reads) {
+  const std::string page = render_sheet(
+      fods_file(fods_row(
+          R"xml(<table:table-cell table:formula="of:=SUM([.B1:.C1])")xml"
+          R"( office:value-type="float" office:value="7">)"
+          R"(<text:p>7</text:p></table:table-cell>)")),
+      editing_config());
+
+  const std::string expected = R"xml(data-odr-reads="0,1,2,0,0")xml";
+  EXPECT_NE(page.find(expected), std::string::npos);
+}
+
+// A quote in an expression would close the attribute early.
+TEST(html, an_expression_is_escaped_into_its_attribute) {
+  const std::string page = render_sheet(
+      fods_file(fods_row(
+          R"xml(<table:table-cell table:formula="of:=IF([.B1];&quot;a&quot;;&quot;b&quot;)")xml"
+          R"( office:value-type="string">)"
+          R"(<text:p>a</text:p></table:table-cell>)")),
+      editing_config());
+
+  const std::string expected =
+      R"xml(data-odr-formula="of:=IF([.B1];&quot;a&quot;;&quot;b&quot;)")xml";
+  EXPECT_NE(page.find(expected), std::string::npos);
+}
+
+// A read-only render carries no dependency either: it is editing scaffolding.
+TEST(html, a_read_only_render_states_no_formula) {
+  const std::string page = render_sheet(
+      fods_file(fods_row(
+          R"xml(<table:table-cell table:formula="of:=SUM([.B1:.C1])")xml"
+          R"( office:value-type="float" office:value="7">)"
+          R"(<text:p>7</text:p></table:table-cell>)")),
+      HtmlConfig());
+
+  EXPECT_EQ(page.find(R"(data-odr-formula=")"), std::string::npos);
+  EXPECT_EQ(page.find(R"(data-odr-reads=")"), std::string::npos);
+}
+
+// A reference into another sheet resolves to the ordinal an op names it by,
+// and a sheet name is matched without case.
+TEST(html, a_formula_reading_another_sheet_states_its_ordinal) {
+  const std::string page = render_sheet(
+      fods_file(
+          fods_row(R"xml(<table:table-cell table:formula="of:=[$sheet2.B1]")xml"
+                   R"( office:value-type="float" office:value="7">)"
+                   R"(<text:p>7</text:p></table:table-cell>)"),
+          "",
+          R"(<table:table table:name="Sheet2"><table:table-row>)"
+          R"(<table:table-cell office:value-type="float" office:value="7">)"
+          R"(<text:p>7</text:p></table:table-cell></table:table-row>)"
+          R"(</table:table>)"),
+      editing_config());
+
+  const std::string expected = R"xml(data-odr-reads="1,1,1,0,0")xml";
+  EXPECT_NE(page.find(expected), std::string::npos);
+}
+
+// A formula naming no position states no rectangle, not an empty one.
+TEST(html, a_formula_reading_nothing_states_no_rectangle) {
+  const std::string page =
+      render_sheet(fods_file(fods_row(
+                       R"xml(<table:table-cell table:formula="of:=TODAY()")xml"
+                       R"( office:value-type="float" office:value="7">)"
+                       R"(<text:p>7</text:p></table:table-cell>)")),
+                   editing_config());
+
+  const std::string expected = R"xml(data-odr-formula="of:=TODAY()")xml";
+  EXPECT_NE(page.find(expected), std::string::npos);
+  EXPECT_EQ(page.find(R"(data-odr-reads=")"), std::string::npos);
 }
 
 // Several runs of one paragraph are one line, which a write replaces.

--- a/wasm/README.md
+++ b/wasm/README.md
@@ -85,6 +85,8 @@ page.editing.committed();
 
 `odr.editing` is on every document view, editable or not: `isEditable()` is what
 greys a host's edit button, and `onEditRefused` says why an edit was refused.
+On a sheet, `onCellsStale` names the formula cells an edit left computing an
+old input - the page marks them, and nothing recomputes one yet.
 `keyboardNavigation` and `keyboardShortcuts` in the config decide whether the
 page takes the arrow keys and the undo chord, for a host that has its own.
 `example/index.html` wires the whole surface.

--- a/wasm/example/index.html
+++ b/wasm/example/index.html
@@ -89,7 +89,7 @@
         return true;
       }
 
-      // The three callbacks a host assigns, which on droid/ios go in through
+      // The callbacks a host assigns, which on droid/ios go in through
       // `evaluateJavascript` once the WebView has finished loading.
       function wire() {
         const page = editing();
@@ -110,6 +110,12 @@
         frame.contentWindow.odr.onEditModeChange = (event) => {
           edit.textContent = event.editing ? 'editing' : 'edit';
           if (event.reason) status.textContent = event.message;
+        };
+        // The cells an edit left computing an old input; the page marks them.
+        frame.contentWindow.odr.onCellsStale = (event) => {
+          if (event.cells.length > 0) {
+            status.textContent = `${event.cells.length} formula cell(s) out of date`;
+          }
         };
       }
 


### PR DESCRIPTION
🤖 Generated with [Claude Code](https://claude.com/claude-code)

Rebased on `main`, now that #884, #885 and #886 have landed. One commit.

Step 3.3 of [`docs/design/spreadsheet-editing.md`](docs/design/spreadsheet-editing.md).

## What the markup gains

Per formula cell, in an editable render only:

```html
<td data-odr-lock="formula"
    data-odr-formula="of:=SUM([.A1:.A2])"
    data-odr-reads="2,0,0,0,1">7</td>
```

`data-odr-reads` is `sheet,first column,last column,first row,last row` per
rectangle, space separated, with `*` for an axis a reference leaves open
(`A:A`). The renderer parses the cell's formula and resolves each sheet name to
the ordinal an op names it by.

## What the page does with it

A commit marks the cells reading what it wrote — and the cells reading those —
with `odr-sheet-stale`, and raises the new `odr.onCellsStale` callback
(`{sheet, cells}`). The cell still shows the result its producer cached;
**nothing here recomputes one**, that is step 4.

**The marks follow the log, not the last write.** `repaintStale` recomputes
them off the coalesced log after every commit, undo and redo, so an undo takes
back what it made stale and a save clears them with the log. The host hears
only when the set actually moves.

The style is a wavy underline in `--odr-sheet-stale`, which layers over the pin
and hover wash instead of fighting them and moves no geometry.

## Why the page carries the graph

A mark has to keep up with typing, so a host round trip is the wrong shape
here. The engine's own graph (#886) is what the file side will use in step 3.4.
`odr.sheet.formulaAt(column, row)` hands a formula bar the expression.

`formula::syntax_of(FileType)` is now the one mapping from a file type to a
formula syntax; the renderer and `SheetDependencies` both read it.

## Test

- `test/src/html_test.cpp`: six cases — the expression, the rectangles, a
  reference into another sheet resolving to its ordinal, the attribute
  escaping, a read-only render carrying neither, and a formula reading nothing
  stating no rectangle.
- `test/browser/sheet/editing.html`: 61 checks now (was 51), headless-green
  together with the other four sheet pages. The fixture gained a second formula
  cell reading the first, so the chain is checked.
- The wasm example wires `onCellsStale`, as the host-wiring reference.

**Reference output**: this changes the emitted html for every sheet holding a
formula, so `compare-html` stays red until the output repos get their commit
and the pins advance.

https://claude.ai/code/session_01VVmjmddv2Ui17Nptc1ggue
