### PR TITLE
feat(odf): a write takes the cached result of what reads it away

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,11 +16,13 @@ The release run heads these entries with the version and opens a fresh
 
 ## Unreleased
 
+- Writing a cell of an `.ods` takes the cached result of every formula reading
+  it away, keeping the formula itself, so the saved file states no number that
+  is now wrong. Such a cell renders empty until a reader computes it.
+
 - An editable sheet view states each formula cell's expression
-  (`data-odr-formula`, `odr.sheet.formulaAt`) and the cells it reads. A commit
-  marks the formula cells reading what it wrote with `odr-sheet-stale`, and
-  raises the new `odr.onCellsStale` callback, `{sheet, cells}`; an undo takes
-  the marks back. Nothing recomputes a formula yet.
+  (`data-odr-formula`, `odr.sheet.formulaAt`) and the cells it reads, and marks
+  the ones an edit left out of date (`odr-sheet-stale`, `odr.onCellsStale`).
 
 - `Document::dependents(position)` answers which cells' formulas read a
   position, directly or through another, and `unresolved_formulas()` those

--- a/docs/design/spreadsheet-editing.md
+++ b/docs/design/spreadsheet-editing.md
@@ -1,6 +1,6 @@
 # Spreadsheet editing design
 
-Status: **steps 0, 1 and 2 landed; step 3 is under way.** This
+Status: **steps 0 to 3 landed; step 4 — the evaluator — is next.** This
 records why spreadsheet editing is staged the way it is, what the code already
 gives us, and the order the steps go in. It is a plan, not a record — update it
 as steps land.
@@ -509,8 +509,22 @@ Each step ships on its own. "Both" means `.ods` and `.xlsx`.
    The page carries the graph rather than asking the host for it, because a
    mark has to keep up with typing. The engine's own graph (item 2) is what
    the file side uses.
-4. File: the `.ods` answer from the spike — drop the cached value of dirty
-   dependents, or whatever LibreOffice needs to recompute.
+4. **Landed.** File: an odf write takes the cached result of every formula
+   reading it away — the attributes stating a value, and the `text:p` showing
+   it, removed as an element so the registry keeps no dangling node. The
+   formula, the cell's style and a drawing anchored in it stay. An ooxml
+   write keeps them, because every save already sets `fullCalcOnLoad`.
+
+   **The spike says there is nothing to set.** ODF states no switch asking a
+   reader to recompute, and LibreOffice's `--convert-to` is no oracle for
+   what a reader shows, because it recomputes whatever the file cached. What
+   is left is the rule the file itself can carry: a cell stating a formula
+   and no result is one a reader has to compute, and none can show a wrong
+   number for.
+
+   The cost until step 4: such a cell renders empty here too. A formula the
+   graph could read no position out of (`unresolved_formulas`) keeps its
+   result — nothing links it to the write.
 
 ### Step 4 — Formulas, evaluate
 
@@ -565,8 +579,9 @@ Ordered by value over cost; all in step 0 or 1.
   cell's registry subtree points into `sharedStrings.xml` — it must be
   rebuilt, not patched. Verify with the oracle that a workbook mixing
   `inlineStr` and shared cells round-trips.
-- **Stale formula results in the file** for `.ods` (the spike). Until step 4
-  there is no way to write a correct value.
+- **Stale formula results in the file** for `.ods`: **answered** in step 3.4 —
+  the result is dropped rather than left wrong. Until step 4 there is no way to
+  write a correct one, so such a cell renders empty here.
 - **Row reflow after a commit**: the spill/clip geometry is computed at
   translate time from the neighbours; the browser has to redo it for the
   edited row. Without it an edit into a blank cell shows the left neighbour's

--- a/src/odr/document_element.hpp
+++ b/src/odr/document_element.hpp
@@ -373,6 +373,10 @@ public:
 
   /// Writes @p value into the cell. odf stores the number and its text both;
   /// ooxml keeps no text for a number and shows it through its format.
+  ///
+  /// An odf document then takes the cached result of every formula reading
+  /// the cell away, because it can ask no reader to recompute. An ooxml one
+  /// keeps them: every save sets `calcPr/@fullCalcOnLoad`.
   /// @throws UnsupportedOperation where the cell cannot be written, or where
   ///         @p value holds a formula - nothing here evaluates one.
   /// @throws ValueNotStated where @p value is typed a number and states none.

--- a/src/odr/internal/odf/AGENTS.md
+++ b/src/odr/internal/odf/AGENTS.md
@@ -213,6 +213,16 @@ The structural/foundational gaps, roughly by value:
    reachable. Their `pugi::xml_node` is dangling from then on, which is the
    cost `ooxml/spreadsheet` already pays for the same tombstoning.
 
+   A write also **takes the cached result of every formula reading it away**
+   (`drop_stale_results`, over `SheetDependencies`): the attributes stating a
+   value go, and the `text:p` showing it is removed as an element so the
+   registry keeps no dangling node. The formula, the cell's style and a
+   drawing anchored in it stay, and a formula the graph could read no
+   position out of (`SheetDependencies::unresolved`) keeps its result. ODF
+   has no `fullCalcOnLoad`, so a cell stating a formula and no result is the
+   only way the file avoids a wrong number; it renders empty until the
+   evaluator lands.
+
    A position the sheet stops before is reached by `grow_to_cell`, which
    appends the rows and the runs of empty cells it takes and declares the
    columns, so `dimensions` covers the new cell. A repeated row is cut before

--- a/src/odr/internal/odf/odf_document.cpp
+++ b/src/odr/internal/odf/odf_document.cpp
@@ -2,10 +2,12 @@
 
 #include <odr/document_element.hpp>
 #include <odr/exceptions.hpp>
+#include <odr/sheet_position.hpp>
 
 #include <odr/internal/abstract/filesystem.hpp>
 #include <odr/internal/common/element_adapter.hpp>
 #include <odr/internal/common/file.hpp>
+#include <odr/internal/common/sheet_dependencies.hpp>
 #include <odr/internal/common/table_cursor.hpp>
 #include <odr/internal/crypto/crypto_util.hpp>
 #include <odr/internal/odf/odf_chart.hpp>
@@ -171,6 +173,18 @@ std::optional<DrawingPath> connector_box(const pugi::xml_node node) {
     return {};
   }
   return read_path(node);
+}
+
+/// Every attribute a cell states its value with, so a cell left with its
+/// formula alone states no result. [ODF 1.2] 19.385 and around it.
+void remove_value_attributes(pugi::xml_node node) {
+  static constexpr std::array stated = {
+      "office:value-type", "office:value",      "office:boolean-value",
+      "office:date-value", "office:time-value", "office:string-value",
+      "office:currency",   "calcext:value-type"};
+  for (const char *attribute : stated) {
+    node.remove_attribute(attribute);
+  }
 }
 
 using TreeEditor = xml::TreeEditor<ElementRegistry>;
@@ -470,13 +484,7 @@ public:
     text_set_content(text_run_of(cell_id),
                      value.has_text() ? value.text() : "");
 
-    static constexpr std::array stated = {
-        "office:value-type", "office:value",      "office:boolean-value",
-        "office:date-value", "office:time-value", "office:string-value",
-        "office:currency",   "calcext:value-type"};
-    for (const char *attribute : stated) {
-      node.remove_attribute(attribute);
-    }
+    remove_value_attributes(node);
 
     switch (value.type()) {
     case ValueType::unknown:
@@ -489,6 +497,73 @@ public:
       node.append_attribute("office:value")
           .set_value(fmt::format("{}", value.number()).c_str());
       break;
+    }
+
+    drop_stale_results(element_id, column, row);
+  }
+
+  /// The sheets of the document in the order an operation names them by.
+  [[nodiscard]] std::vector<ElementIdentifier> sheets_() const {
+    std::vector<ElementIdentifier> result;
+    for (ElementIdentifier id = element_first_child(m_document->root_element());
+         id != null_element_id; id = element_next_sibling(id)) {
+      if (element_type(id) == ElementType::sheet) {
+        result.push_back(id);
+      }
+    }
+    return result;
+  }
+
+  /// A write leaves every formula reading it computing an old input, and ODF
+  /// states no switch asking a reader to recompute, so the cached result goes
+  /// instead. A formula the graph could read no position out of
+  /// (`SheetDependencies::unresolved`) keeps its result: nothing links it to
+  /// the write.
+  void drop_stale_results(const ElementIdentifier sheet_id,
+                          const std::uint32_t column,
+                          const std::uint32_t row) const {
+    const std::vector<ElementIdentifier> sheets = sheets_();
+    const auto written = std::ranges::find(sheets, sheet_id);
+    if (written == sheets.end()) {
+      return;
+    }
+
+    const SheetPosition position(
+        static_cast<std::uint32_t>(written - sheets.begin()),
+        TablePosition(column, row));
+    for (const SheetPosition &stale :
+         m_document->sheet_dependencies().dependents({position})) {
+      if (stale.sheet >= sheets.size()) {
+        continue;
+      }
+      if (const ElementRegistry::Sheet::Cell *cell =
+              m_registry->sheet_element_at(sheets[stale.sheet])
+                  .cell(stale.cell.column, stale.cell.row);
+          cell != nullptr) {
+        drop_cell_result(*cell);
+      }
+    }
+  }
+
+  /// Takes what the cell states about a result away, and nothing else: the
+  /// formula, the cell's style and a drawing anchored in it stay.
+  void drop_cell_result(const ElementRegistry::Sheet::Cell &cell) const {
+    pugi::xml_node node = cell.node;
+    remove_value_attributes(node);
+    if (cell.element_id == null_element_id) {
+      return;
+    }
+
+    // collected first, because removing one relinks the chain the walk is on
+    std::vector<ElementIdentifier> paragraphs;
+    for (ElementIdentifier child = element_first_child(cell.element_id);
+         child != null_element_id; child = element_next_sibling(child)) {
+      if (element_type(child) == ElementType::paragraph) {
+        paragraphs.push_back(child);
+      }
+    }
+    for (const ElementIdentifier paragraph : paragraphs) {
+      element_remove(paragraph);
     }
   }
 

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -87,6 +87,7 @@ add_executable(odr_test
         "src/internal/odf/odf_frame_test.cpp"
         "src/internal/odf/odf_geometry_test.cpp"
         "src/internal/odf/odf_sheet_repeat_test.cpp"
+        "src/internal/odf/odf_sheet_stale_test.cpp"
         "src/internal/odf/odf_sheet_value_test.cpp"
         "src/internal/odf/odf_sheet_write_test.cpp"
         "src/internal/odf/odf_table_test.cpp"

--- a/test/src/internal/odf/odf_sheet_stale_test.cpp
+++ b/test/src/internal/odf/odf_sheet_stale_test.cpp
@@ -1,0 +1,184 @@
+#include <odr/document.hpp>
+#include <odr/document_element.hpp>
+#include <odr/file.hpp>
+#include <odr/logger.hpp>
+
+#include <odr/internal/abstract/file.hpp>
+#include <odr/internal/common/file.hpp>
+#include <odr/internal/open_strategy.hpp>
+
+#include <gtest/gtest.h>
+
+#include <memory>
+#include <sstream>
+#include <string>
+
+using namespace odr;
+using namespace odr::internal;
+
+namespace {
+
+/// A flat spreadsheet of @p sheets, each written as a `table:table`.
+std::string flat_document(const std::string &sheets) {
+  return R"(<?xml version="1.0" encoding="UTF-8"?>)"
+         R"(<office:document office:mimetype=")"
+         R"(application/vnd.oasis.opendocument.spreadsheet">)"
+         R"(<office:body><office:spreadsheet>)" +
+         sheets + R"(</office:spreadsheet></office:body></office:document>)";
+}
+
+std::string sheet_of(const std::string &name, const std::string &cells) {
+  return R"(<table:table table:name=")" + name + R"("><table:table-row>)" +
+         cells + R"(</table:table-row></table:table>)";
+}
+
+std::string number_cell(const std::string &text) {
+  return R"(<table:table-cell office:value-type="float" office:value=")" +
+         text + R"("><text:p>)" + text + R"(</text:p></table:table-cell>)";
+}
+
+/// A cell computing @p formula, with the result its producer cached.
+std::string computed_cell(const std::string &formula,
+                          const std::string &cached) {
+  return R"(<table:table-cell table:formula=")" + formula +
+         R"(" office:value-type="float" office:value=")" + cached +
+         R"(" calcext:value-type="float"><text:p>)" + cached +
+         R"(</text:p></table:table-cell>)";
+}
+
+Document document_of(const std::string &source) {
+  return DecodedFile(
+             open_strategy::open_file(std::make_shared<MemoryFile>(source), {},
+                                      Logger::null()))
+      .as_document_file()
+      .document();
+}
+
+Sheet sheet_at(const Document &document, const std::uint32_t index) {
+  Element element = *document.root_element().children().begin();
+  for (std::uint32_t i = 0; i < index; ++i) {
+    element = element.next_sibling();
+  }
+  return element.as_sheet();
+}
+
+/// One row: A1 a number, B1 the sum of A1 and nothing else, C1 twice B1.
+std::string chain_sheet() {
+  return sheet_of("s", number_cell("1") +
+                           computed_cell("of:=SUM([.A1:.A1])", "1") +
+                           computed_cell("of:=[.B1]*2", "2"));
+}
+
+} // namespace
+
+/// ODF states no switch asking a reader to recompute, so the result goes: a
+/// cell stating a formula and no result is one a reader has to compute.
+TEST(OdfSheetStale, a_write_takes_the_result_of_what_reads_it_away) {
+  const Document document = document_of(flat_document(chain_sheet()));
+  const Sheet sheet = sheet_at(document, 0);
+
+  sheet.set_cell(0, 0, CellValue(10.0, "10"));
+
+  const CellValue stale = sheet.cell(1, 0).value();
+  EXPECT_FALSE(stale.has_number());
+  EXPECT_EQ(stale.text(), "");
+  ASSERT_TRUE(stale.has_formula());
+  EXPECT_EQ(stale.formula(), "of:=SUM([.A1:.A1])");
+}
+
+/// A formula reading a formula is wrong for the same reason.
+TEST(OdfSheetStale, the_whole_chain_loses_its_results) {
+  const Document document = document_of(flat_document(chain_sheet()));
+  const Sheet sheet = sheet_at(document, 0);
+
+  sheet.set_cell(0, 0, CellValue(10.0, "10"));
+
+  EXPECT_FALSE(sheet.cell(2, 0).value().has_number());
+  EXPECT_EQ(sheet.cell(2, 0).value().text(), "");
+}
+
+TEST(OdfSheetStale, a_formula_reading_something_else_keeps_its_result) {
+  const Document document = document_of(
+      flat_document(sheet_of("s", number_cell("1") + number_cell("2") +
+                                      computed_cell("of:=[.B1]", "2"))));
+  const Sheet sheet = sheet_at(document, 0);
+
+  sheet.set_cell(0, 0, CellValue(10.0, "10"));
+
+  EXPECT_DOUBLE_EQ(sheet.cell(2, 0).value().number(), 2);
+  EXPECT_EQ(sheet.cell(2, 0).value().text(), "2");
+}
+
+TEST(OdfSheetStale, a_formula_on_another_sheet_loses_its_result_too) {
+  const Document document = document_of(
+      flat_document(sheet_of("Data", number_cell("1")) +
+                    sheet_of("Report", computed_cell("of:=[Data.A1]*2", "2"))));
+
+  sheet_at(document, 0).set_cell(0, 0, CellValue(10.0, "10"));
+
+  EXPECT_FALSE(sheet_at(document, 1).cell(0, 0).value().has_number());
+}
+
+/// The cell keeps everything but the result, so a reader that computes one
+/// shows it the way the file states.
+TEST(OdfSheetStale, the_cell_keeps_its_style_and_its_formula) {
+  const Document document = document_of(flat_document(sheet_of(
+      "s", number_cell("1") +
+               R"(<table:table-cell table:style-name="ce1")"
+               R"( table:formula="of:=[.A1]" office:value-type="float")"
+               R"( office:value="1"><text:p>1</text:p></table:table-cell>)")));
+  const Sheet sheet = sheet_at(document, 0);
+
+  sheet.set_cell(0, 0, CellValue(10.0, "10"));
+
+  std::ostringstream saved;
+  document.save(saved);
+
+  EXPECT_NE(saved.str().find(R"(table:style-name="ce1")"), std::string::npos);
+  EXPECT_NE(saved.str().find(R"(table:formula="of:=[.A1]")"),
+            std::string::npos);
+  EXPECT_EQ(saved.str().find(R"(office:value="1")"), std::string::npos);
+}
+
+/// Only the paragraph showing the result goes: a drawing anchored in the cell
+/// is what the cell is.
+TEST(OdfSheetStale, a_drawing_anchored_in_a_stale_cell_stays) {
+  const Document document = document_of(flat_document(sheet_of(
+      "s", number_cell("1") +
+               R"(<table:table-cell table:formula="of:=[.A1]")"
+               R"( office:value-type="float" office:value="1">)"
+               R"(<text:p>1</text:p>)"
+               R"(<draw:frame><draw:image xlink:href="x.png"/></draw:frame>)"
+               R"(</table:table-cell>)")));
+
+  sheet_at(document, 0).set_cell(0, 0, CellValue(10.0, "10"));
+
+  std::ostringstream saved;
+  document.save(saved);
+
+  EXPECT_NE(saved.str().find("draw:frame"), std::string::npos);
+  EXPECT_EQ(saved.str().find(R"(<text:p>1</text:p>)"), std::string::npos);
+}
+
+TEST(OdfSheetStale, the_saved_file_states_no_result_either) {
+  const Document document = document_of(flat_document(chain_sheet()));
+  sheet_at(document, 0).set_cell(0, 0, CellValue(10.0, "10"));
+
+  std::ostringstream saved;
+  document.save(saved);
+
+  const Document reopened = document_of(saved.str());
+  EXPECT_FALSE(sheet_at(reopened, 0).cell(1, 0).value().has_number());
+  EXPECT_DOUBLE_EQ(sheet_at(reopened, 0).cell(0, 0).value().number(), 10);
+}
+
+/// Nothing reads the written cell, so no result is taken away.
+TEST(OdfSheetStale, a_write_nothing_reads_leaves_every_result_alone) {
+  const Document document = document_of(flat_document(
+      sheet_of("s", number_cell("1") + computed_cell("of:=[.A1]", "1"))));
+  const Sheet sheet = sheet_at(document, 0);
+
+  sheet.set_cell(2, 0, CellValue(10.0, "10"));
+
+  EXPECT_DOUBLE_EQ(sheet.cell(1, 0).value().number(), 1);
+}


### PR DESCRIPTION
🤖 Generated with [Claude Code](https://claude.com/claude-code)

Rebased on `main`, now that the rest of the step-3 stack has landed. One commit.

Step 3.4 of [`docs/design/spreadsheet-editing.md`](docs/design/spreadsheet-editing.md).

## The problem

An edited input leaves every formula reading it computing an old number, and the saved `.ods` went on showing the result its producer cached. An `.xlsx` has a switch for exactly this — `calcPr/@fullCalcOnLoad`, which every save already sets. ODF has none.

## What it does

So the result goes instead. `drop_stale_results` asks `SheetDependencies` which cells read the written position — directly or through another formula — and takes the attributes stating a value off each. The `text:p` showing it goes as an **element** rather than as a node, so the registry keeps no dangling one.

```xml
<!-- before --><table:table-cell table:formula="of:=SUM([.A1:.A2])" office:value-type="float" office:value="3"><text:p>3</text:p></table:table-cell>
<!-- after  --><table:table-cell table:formula="of:=SUM([.A1:.A2])"/>
```

The formula, the cell's style and a drawing anchored in the cell all stay. A cell stating a formula and no result is one a reader has to compute, and none can show a wrong number for.

**A formula the graph could read no position out of keeps its result.** Nothing links it to the write. `Document::unresolved_formulas()` is what names them.

**The cost until step 4**: a cleared cell renders empty here too. That is the trade the design accepted — an empty cell says "not computed", a stale one says nothing.

## The spike, as far as a CLI can answer it

LibreOffice's `--convert-to` **recomputes whatever a file cached** — a file whose cached result I hand-edited to `999` converted back to `3` — so it cannot show what a reader that does not recompute would display, and setting `ODFRecalcMode` to "never" in a scratch profile changed nothing. ODF states no recalculation switch at all, so the rule the file itself can carry is what is left.

End-to-end check: a real LibreOffice-written `.ods`, edited through `Sheet::set_cell` and saved by us, opens as a valid package and LibreOffice computes the cell we cleared (`10 / 2 / 12`, where the file states no result for the third).

## Test

`test/src/internal/odf/odf_sheet_stale_test.cpp`, 8 cases from inline fixtures: the direct reader, the chain, a formula reading something else, a reader on another sheet, what the cell keeps, a drawing anchored in a cleared cell, the saved file, and a write nothing reads.

**Reference output**: this PR emits no different html — it changes the write path only. `compare-html` stays red until the output repos take the commit #887 still owes them.

https://claude.ai/code/session_01VVmjmddv2Ui17Nptc1ggue
